### PR TITLE
Fix creation of rows with autoincrement fields in Python bindings

### DIFF
--- a/mythtv/bindings/python/MythTV/database.py
+++ b/mythtv/bindings/python/MythTV/database.py
@@ -261,7 +261,6 @@ class DBDataWrite( DBData ):
                         db.tablefields[cls._table][cls._key[0]].extra:
                     create = cls._create_autoincrement
                     cls._defaults[cls._key[0]] = None
-                    return
         if not hasattr(cls, 'create'):
             cls.create = create
 


### PR DESCRIPTION
I was trying to create a new Job using the Python bindings, and I found that the Job object did not have a 'create' method. Looking at the code, it seems that the method returns before setting the create attribute. Skipping the return statement allows me to create new jobs.
