### PR TITLE
Increase the maximum linux firewire buffer size

### DIFF
--- a/mythtv/libs/libmythtv/linuxfirewiredevice.cpp
+++ b/mythtv/libs/libmythtv/linuxfirewiredevice.cpp
@@ -116,7 +116,7 @@ static void remove_handle(raw1394handle_t handle)
 const uint LinuxFirewireDevice::kBroadcastChannel    = 63;
 const uint LinuxFirewireDevice::kConnectionP2P       = 0;
 const uint LinuxFirewireDevice::kConnectionBroadcast = 1;
-const uint LinuxFirewireDevice::kMaxBufferedPackets  = 2000;
+const uint LinuxFirewireDevice::kMaxBufferedPackets  = 20000;
 
 // callback function for libiec61883
 int linux_firewire_device_tspacket_handler(


### PR DESCRIPTION
Some JMicron firewire cards will enter into an unrecoverable state if
they run out of buffer space when receiving data. This can cause the
firewire-ohci module to deadlock, leaving a reboot as the only method of
recovery.

Since the consequences are so severe, allow setting the maximum linux
firewire buffer up to 20,000 packets (~3.7 MiB). This should be enough
to buffer up to a second of most HD streams.

Note that the actual buffer size is determined from the HDRingbufferSize
setting. Increasing the value will increase the linux firewire buffer
size linearly.
