### PR TITLE
Added 3 new commands to Frontend Control Socket

### DIFF
--- a/mythtv/programs/mythfrontend/networkcontrol.cpp
+++ b/mythtv/programs/mythfrontend/networkcontrol.cpp
@@ -992,8 +992,10 @@ QString NetworkControl::processQuery(NetworkCommand *nc)
              (nc->getArg(3).contains(QRegExp(
                          "^\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d$"))))
         return listRecordings(nc->getArg(2), nc->getArg(3).toUpper());
-    else if (is_abbrev("recordings", nc->getArg(1)))
+    else if ((nc->getArgCount() == 2) && is_abbrev("recordings", nc->getArg(1)))
         return listRecordings();
+    else if ((nc->getArgCount() == 3) && is_abbrev("recordings", nc->getArg(1)))
+        return listRecordings("", "", nc->getArg(2));
     else if (is_abbrev("channels", nc->getArg(1)))
     {
         if (nc->getArgCount() == 2)
@@ -1158,6 +1160,8 @@ QString NetworkControl::processHelp(NetworkCommand *nc)
             "query location        - Query current screen or location\r\n"
             "query volume          - Query the current playback volume\r\n"
             "query recordings      - List currently available recordings\r\n"
+            "query recordings STORAGEGROUP\r\n"
+            "                      - List currently available recordings for the specified storage group\r\n"
             "query recording CHANID STARTTIME\r\n"
             "                      - List info about the specified program\r\n"
             "query liveTV          - List current TV schedule\r\n"
@@ -1404,7 +1408,7 @@ QString NetworkControl::listSchedule(const QString& chanID) const
     return result;
 }
 
-QString NetworkControl::listRecordings(QString chanid, QString starttime)
+QString NetworkControl::listRecordings(QString chanid, QString starttime, QString storageGroup)
 {
     QString result;
     MSqlQuery query(MSqlQuery::InitCon());
@@ -1419,6 +1423,10 @@ QString NetworkControl::listRecordings(QString chanid, QString starttime)
         queryStr += "AND chanid = " + chanid + " "
                     "AND starttime = '" + starttime + "' ";
         appendCRLF = false;
+    }
+
+    if (!storageGroup.isEmpty()) {
+        queryStr += "AND storageGroup = '" + storageGroup + "' ";
     }
 
     queryStr += "ORDER BY starttime, title;";

--- a/mythtv/programs/mythfrontend/networkcontrol.h
+++ b/mythtv/programs/mythfrontend/networkcontrol.h
@@ -121,7 +121,7 @@ class NetworkControl : public QTcpServer, public QRunnable
     void sendReplyToClient(NetworkControlClient *ncc, QString &reply);
     void customEvent(QEvent *e);
 
-    QString listRecordings(QString chanid = "", QString starttime = "");
+    QString listRecordings(QString chanid = "", QString starttime = "", QString storageGroup = "");
     QString listSchedule(const QString& chanID = "") const;
     QString listVideos();
     QString listChannels(const uint start, const uint limit) const;


### PR DESCRIPTION
These new commands allow additional functionality for the MythMote Android remote control app (and any other apps that wish to allow users to select videos and recordings from a list).

Commands are as follows:
- query recordings STORAGEGROUP - List currently available recordings for the specified storage group
- query storagegroups - Query storage group directories
- query videos - Query available videos
