### PR TITLE
Include glu.h for gluErrorString

### DIFF
--- a/mythtv/libs/libmythui/mythrender_opengl.cpp
+++ b/mythtv/libs/libmythui/mythrender_opengl.cpp
@@ -7,6 +7,7 @@
 
 #if defined(Q_WS_X11)
 #include <QX11Info>
+#include <GL/glu.h>
 #include <GL/glx.h>
 #endif
 


### PR DESCRIPTION
This file uses a C function gluErrorString which is defined in GL/glu.h which is not included in this file. For some reason this did not affect builds on Fedora 14 and 15 but caused a fatal error on Fedora 16.
