### PR TITLE
MythUI - make focusorder -1 make m_CanHaveFocus = false

### DIFF
--- a/mythtv/libs/libmythui/mythuitype.cpp
+++ b/mythtv/libs/libmythui/mythuitype.cpp
@@ -1216,7 +1216,7 @@ bool MythUIType::ParseElement(
     {
         int order = getFirstText(element).toInt();
         SetFocusOrder(order);
-        if(order < 1)
+        if(order < 0)
             SetCanTakeFocus(false)            
     }
     else if (element.tagName() == "loadondemand")


### PR DESCRIPTION
I'd like this so I can add a webbrowser control to the menu displaying the weather/news etc and it never steals the focus from the menu
