### PR TITLE
Ticket #10447 - SQL Optimization for Program Listing

### DIFF
--- a/mythtv/programs/mythbackend/services/guide.cpp
+++ b/mythtv/programs/mythbackend/services/guide.cpp
@@ -91,14 +91,16 @@ DTC::ProgramGuide *Guide::GetProgramGuide( const QDateTime &dtStartTime ,
                          "AND program.chanid <= :EndChanId "
                          "AND program.endtime >= :StartDate "
                          "AND program.starttime <= :EndDate "
+                         "AND program.starttime >= :StartDateLimit "
                         "GROUP BY program.starttime, channel.channum, "
                          "channel.callsign, program.title "
                         "ORDER BY program.chanid ";
 
-    bindings[":StartChanId"] = nStartChanId;
-    bindings[":EndChanId"  ] = nEndChanId;
-    bindings[":StartDate"  ] = dtStartTime;
-    bindings[":EndDate"    ] = dtEndTime;
+    bindings[":StartChanId"   ] = nStartChanId;
+    bindings[":EndChanId"     ] = nEndChanId;
+    bindings[":StartDate"     ] = dtStartTime;
+    bindings[":StartDateLimit"] = dtStartTime.addDays(-1);
+    bindings[":EndDate"       ] = dtEndTime;
 
     // ----------------------------------------------------------------------
     // Get all Pending Scheduled Programs

--- a/mythtv/programs/mythfrontend/guidegrid.cpp
+++ b/mythtv/programs/mythfrontend/guidegrid.cpp
@@ -695,14 +695,15 @@ ProgramList GuideGrid::GetProgramList(uint chanid) const
     ProgramList proglist;
     MSqlBindings bindings;
     QString querystr =
-        "WHERE program.chanid     = :CHANID  AND "
-        "      program.endtime   >= :STARTTS AND "
-        "      program.starttime <= :ENDTS   AND "
+        "WHERE program.chanid     = :CHANID       AND "
+        "      program.endtime   >= :STARTTS      AND "
+        "      program.starttime <= :ENDTS        AND "
+        "      program.starttime >= :STARTLIMITTS AND "
         "      program.manualid   = 0 ";
-    bindings[":STARTTS"] =
-        m_currentStartTime.addSecs(0 - m_currentStartTime.time().second());
-    bindings[":ENDTS"] =
-        m_currentEndTime.addSecs(0 - m_currentEndTime.time().second());
+    QDateTime starttime = m_currentStartTime.addSecs(0 - m_currentStartTime.time().second());
+    bindings[":STARTTS"] = starttime;
+    bindings[":STARTLIMITTS"] = starttime.addDays(-1);
+    bindings[":ENDTS"] = m_currentEndTime.addSecs(0 - m_currentEndTime.time().second());
     bindings[":CHANID"]  = chanid;
 
     ProgramList dummy;
@@ -1075,12 +1076,13 @@ ProgramList *GuideGrid::getProgramListFromProgram(int chanNum)
         QString querystr = "WHERE program.chanid = :CHANID "
                            "  AND program.endtime >= :STARTTS "
                            "  AND program.starttime <= :ENDTS "
+                           "  AND program.starttime >= :STARTLIMITTS "
                            "  AND program.manualid = 0 ";
+        QDateTime starttime = m_currentStartTime.addSecs(0 - m_currentStartTime.time().second());
         bindings[":CHANID"]  = GetChannelInfo(chanNum)->chanid;
-        bindings[":STARTTS"] =
-            m_currentStartTime.addSecs(0 - m_currentStartTime.time().second());
-        bindings[":ENDTS"] =
-            m_currentEndTime.addSecs(0 - m_currentEndTime.time().second());
+        bindings[":STARTTS"] = starttime;
+        bindings[":STARTLIMITTS"] = starttime.addDays(-1);
+        bindings[":ENDTS"] = m_currentEndTime.addSecs(0 - m_currentEndTime.time().second());
 
         LoadFromProgram(*proglist, querystr, bindings, m_recList, false);
     }


### PR DESCRIPTION
This adds a 24 hour cap on the starttime of program listings returned from mythfrontend/guidegrid.cpp and mythbackend/guide.cpp, which gives a performance boost of anywhere from 2x to 3x depending on the where clause of some of the queries. By putting this cap, large number of disk seeks and table lookups are avoided to filter out programs with invalid end times for the query
