### PR TITLE
Safely escape shell arguments

### DIFF
--- a/mythplugins/mythgallery/dcrawplugin/dcrawhandler.cpp
+++ b/mythplugins/mythgallery/dcrawplugin/dcrawhandler.cpp
@@ -14,6 +14,7 @@
 #include "exitcodes.h"
 #include "../mythgallery/galleryutil.h"
 #include "mythlogging.h"
+#include "mythmiscutil.h"
 
 namespace
 {
@@ -40,7 +41,7 @@ bool DcrawHandler::canRead() const
         // MythGallery anyway. So for simplicity we give up.
         return false;
 
-    QString command = "dcraw -i " + path;
+    QString command = QString("dcraw -i %1").arg(ShellEscape(path));
     return (myth_system(command) == GENERIC_EXIT_OK);
 }
 
@@ -55,13 +56,12 @@ bool DcrawHandler::read(QImage *image)
         // MythGallery anyway. So for simplicity we give up.
         return false;
 
-    path = "'" + path + "'";
     QStringList arguments;
     arguments << "-c" << "-w" << "-W";
 #ifdef ICC_PROFILE
-    arguments << "-p" << ICC_PROFILE;
+    arguments << "-p" << ShellEscape(ICC_PROFILE);
 #endif // ICC_PROFILE
-    arguments << path;
+    arguments << ShellEscape(path);
 
     uint flags = kMSRunShell | kMSStdOut | kMSBuffered;
     MythSystem ms("dcraw", arguments, flags);
@@ -81,7 +81,7 @@ int DcrawHandler::loadThumbnail(QImage *image, QString fileName)
 {
     QStringList arguments;
     arguments << "-e" << "-c";
-    arguments << "'" + fileName + "'";
+    arguments << ShellEscape(fileName);
 
     uint flags = kMSRunShell | kMSStdOut | kMSBuffered;
     MythSystem ms("dcraw", arguments, flags);

--- a/mythtv/libs/libmyth/netgrabbermanager.cpp
+++ b/mythtv/libs/libmyth/netgrabbermanager.cpp
@@ -281,8 +281,7 @@ void Search::executeSearch(const QString &script, const QString &query, uint pag
     }
 
     args.append("-S");
-    QString term = query;
-    args.append(ShellEscape(term));
+    args.append(ShellEscape(query));
 
     LOG(VB_GENERAL, LOG_DEBUG, LOC +
         QString("Internet Search Query: %1 %2") .arg(cmd).arg(args.join(" ")));

--- a/mythtv/libs/libmythbase/mythmiscutil.cpp
+++ b/mythtv/libs/libmythbase/mythmiscutil.cpp
@@ -1412,21 +1412,9 @@ bool MythRemoveDirectory(QDir &aDir)
     return(has_err);
 }
 
-QString &ShellEscape(QString &string)
+QString ShellEscape(const QString &string)
 {
-    if (string.contains("\""))
-        string = string.replace("\"", "\\\"");
-
-    if (string.contains("\'"))
-        string = string.replace("\'", "\\\'");
-
-    if (string.contains(" "))
-    {
-        string.prepend("\"");
-        string.append("\"");
-    }
-
-    return string;
+    return QString("'%1'").arg(QString(string).replace("'", "'\\''"));
 }
 
 /**

--- a/mythtv/libs/libmythbase/mythmiscutil.h
+++ b/mythtv/libs/libmythbase/mythmiscutil.h
@@ -110,7 +110,7 @@ MBASE_PUBLIC QString xml_indent(uint level);
  MBASE_PUBLIC  bool myth_ioprio(int val); // range -1..8, smaller is higher priority
 
  MBASE_PUBLIC  bool MythRemoveDirectory(QDir &aDir);
- MBASE_PUBLIC  QString &ShellEscape(QString &string);
+ MBASE_PUBLIC  QString ShellEscape(const QString &string);
 
  MBASE_PUBLIC  void setHttpProxy(void);
 

--- a/mythtv/programs/mythfrontend/videoplayercommand.cpp
+++ b/mythtv/programs/mythfrontend/videoplayercommand.cpp
@@ -15,14 +15,6 @@
 
 namespace
 {
-    QString ShellEscape(const QString &src)
-    {
-        return QString(src)
-                .replace(QRegExp("\""), "\\\"")
-                .replace(QRegExp("`"), "\\`")
-                .replace(QRegExp("\\$"), "\\$");
-    }
-
     QString ExpandPlayCommand(const QString &command, const QString &filename)
     {
         // If handler contains %d, substitute default player command
@@ -44,7 +36,7 @@ namespace
             tmp.replace(QRegExp("%d"), default_handler);
         }
 
-        QString arg = QString("\"%1\"").arg(ShellEscape(filename));
+        QString arg = ShellEscape(filename);
 
         if (tmp.contains("%s"))
             return tmp.replace(QRegExp("%s"), arg);


### PR DESCRIPTION
The existing ShellEscape method(s) are not consistent and not thorough. This implementation will handle spaces, single quotes, double quotes, newlines, and all other shell metacharacters.
