### PR TITLE
Improve UPNP sort order for TV recordings

### DIFF
--- a/mythtv/programs/mythbackend/upnpcdstv.cpp
+++ b/mythtv/programs/mythbackend/upnpcdstv.cpp
@@ -71,7 +71,7 @@ UPnpCDSRootInfo UPnpCDSTv::g_RootNodes[] =
             "ORDER BY title",
         "WHERE title=:KEY", "starttime" },
         
-    {   "By Title",
+    {   "By Title (ordered by subtitle)",
         "title",
         "SELECT title as id, "
           "title as name, "
@@ -80,7 +80,7 @@ UPnpCDSRootInfo UPnpCDSTv::g_RootNodes[] =
             "%1 "
             "GROUP BY title "
             "ORDER BY title",
-        "WHERE title=:KEY", "title" },
+        "WHERE title=:KEY", "subtitle" },
 
     {   "By Genre",
         "category",


### PR DESCRIPTION
It can be very hard to use the current sort order for the content items over UPNP especially if you have large numbers of a title and don't know the exact date of the recording.

This patch adds logical folders for date sorted versions of the listings by title and it also applies a subtitle sort to the non-date sorted title list to help where you know the particular episode that you want.

I have tested these changes on Ubuntu Precise but have not built from the Git source.  I think that this is a very low risk change.

I understand if the design choices you make do not want to offer all these choices but as a heavy UPNP user I would strongly request that you do make a user obvious sort apply to the title grouped content (and I suggest by date).  I also understand if you need to change the names, especially if internationalisation is required but I wanted to offer this upstream anyway.
