### PR TITLE
Add Season/Episode/InetRefNum support to mythlink.pl

### DIFF
--- a/mythtv/bindings/perl/MythTV/Program.pm
+++ b/mythtv/bindings/perl/MythTV/Program.pm
@@ -319,6 +319,14 @@ package MythTV::Program;
             $omonth = '00';
             $oday   = '00';
         }
+    # Season/Episode/InetRef
+        my ($season, $episode, $inetref);
+        $season = ($self->{'season'} or '');
+        $season = "0$season" if ($season && $season < 10);
+        $episode = ($self->{'episode'} or '');
+        $episode = "0$episode" if ($episode && $episode < 10);
+        $inetref = ($self->{'intetref'} or '');
+
     # Build a list of name format options
         my %fields;
         ($fields{'T'} = ($self->{'title'}       or '')) =~ s/%/%%/g;
@@ -400,6 +408,11 @@ package MythTV::Program;
         $fields{'om'} = $omonth;            # month, leading zero
         $fields{'oj'} = int($oday);         # day of month
         $fields{'od'} = $oday;              # day of month, leading zero
+    # Season/Episode/Inetref
+        $fields{'ss'} = $season;
+        $fields{'ep'} = $episode;
+        $fields{'in'} = $inetref;
+
     # Literals
         $fields{'%'}   = '%';
         ($fields{'-'}  = $separator) =~ s/%/%%/g;

--- a/mythtv/contrib/user_jobs/mythlink.pl
+++ b/mythtv/contrib/user_jobs/mythlink.pl
@@ -110,6 +110,9 @@ options:
     \%T   = Title (show name)
     \%S   = Subtitle (episode name)
     \%R   = Description
+    \%ss  = Season (leading zero)
+    \%ep  = Episode (leading zero)
+    \%in  = Internet reference number
     \%C   = Category
     \%U   = RecGroup
     \%hn  = Hostname of the machine where the file resides


### PR DESCRIPTION
Allow mythlink to use episode and season number (left padded with 0's to two digits) and Internet reference number when formatting the symlink. Works well with Plex Media Server (format: '%T/Season %ss/%T%-s%sse%ep').
