### PR TITLE
Have mythtranscode report aac_latm

### DIFF
--- a/mythtv/programs/mythtranscode/transcode.cpp
+++ b/mythtv/programs/mythtranscode/transcode.cpp
@@ -1527,6 +1527,12 @@ int Transcode::TranscodeFile(const QString &inputname,
             case CODEC_ID_MP2:
                 audio_codec_name = "mp2";
                 break;
+            case CODEC_ID_AAC:
+                audio_codec_name = "aac";
+                break;
+            case CODEC_ID_AAC_LATM:
+                audio_codec_name = "aac_latm";
+                break;
             default:
                 audio_codec_name = "unknown";
         }


### PR DESCRIPTION
This extends mythtranscode's reporting of audio formats to include aac and acc_latm.
Scripts can use these reports when using mythtranscode in fifodir mode to determine what will be sent to the fifos.
