### PR TITLE
fix issue #10222: mythcommflag segfaulting

### DIFF
--- a/mythtv/libs/libmythtv/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/avformatdecoder.cpp
@@ -1380,8 +1380,6 @@ void AvFormatDecoder::InitVideoCodec(AVStream *stream, AVCodecContext *enc,
         FlagIsSet(kDecodeFewBlocks) || FlagIsSet(kDecodeNoLoopFilter)   ||
         FlagIsSet(kDecodeNoDecode))
     {
-        enc->flags2 |= CODEC_FLAG2_FAST;
-
         if ((AV_CODEC_ID_MPEG2VIDEO == codec->id) ||
             (AV_CODEC_ID_MPEG1VIDEO == codec->id))
         {


### PR DESCRIPTION
The problem in issue #10222 is that it is adding the CODEC_FLAG2_FAST flag.  This causes unsafe functions to be used, causing a segfault. The proper way to fix this would probably be to figure out how to test for the "experimental speedups" flag, however I don't know the codebase well enough for this.

I tested how this would affect the speed of mythcommflag on one of my recordings.  The results:

Before removing flag:
real 2m13.123s
user 2m16.713s
sys 0m3.502s

After removing flag:
real 2m13.021s
user 2m15.446s
sys 0m3.758s
