### PR TITLE
Allow rotating an image.

### DIFF
--- a/mythtv/libs/libmythui/mythimage.cpp
+++ b/mythtv/libs/libmythui/mythimage.cpp
@@ -41,6 +41,7 @@ MythImage::MythImage(MythPainter *parent, const char *name) :
     m_gradAlpha = 255;
     m_gradDirection = FillTopToBottom;
 
+    m_isRotated = false;
     m_isReflected = false;
     m_isYUV = false;
 
@@ -110,6 +111,24 @@ void MythImage::Assign(const QImage &img)
 void MythImage::Assign(const QPixmap &pix)
 {
     Assign(pix.toImage());
+}
+
+void MythImage::Rotate(int rotationAngle, QSize size)
+{
+    if (m_isRotated)
+        return;
+
+    QMatrix matrix;
+    matrix.rotate(rotationAngle);
+    Assign(transformed(matrix, Qt::SmoothTransformation));
+
+    // TODO: The rotated image is higher than the parent area
+    // the image needs to be resized to be with the areas dimensions
+    if (!size.isNull())
+    {
+        Resize(size, true);
+    }
+    m_isRotated = true;
 }
 
 void MythImage::Resize(const QSize &newSize, bool preserveAspect)

--- a/mythtv/libs/libmythui/mythimage.h
+++ b/mythtv/libs/libmythui/mythimage.h
@@ -45,6 +45,7 @@ class MUI_PUBLIC MythImage : public QImage, public ReferenceCounter
 
     bool IsGradient() const { return m_isGradient; }
     bool IsReflected() const { return m_isReflected; }
+    bool IsRotated() const { return m_isRotated; }
 
     void SetToYUV(void) { m_isYUV = true; }
     void ConvertToYUV(void);
@@ -55,6 +56,7 @@ class MUI_PUBLIC MythImage : public QImage, public ReferenceCounter
     bool Load(MythImageReader *reader);
     bool Load(const QString &filename, bool scale = true);
 
+    void Rotate(int rotationAngle, QSize size);
     void Resize(const QSize &newSize, bool preserveAspect = false);
     void Reflect(ReflectAxis axis, int shear, int scale, int length,
                  int spacing = 0);
@@ -79,6 +81,7 @@ class MUI_PUBLIC MythImage : public QImage, public ReferenceCounter
     QString GetFileName(void) const { return m_FileName; }
 
     void setIsReflected(bool reflected) { m_isReflected = reflected; }
+    void setIsRotated(bool rotated) { m_isRotated = rotated; }
 
     void SetIsInCache(bool bCached);
 
@@ -103,6 +106,7 @@ class MUI_PUBLIC MythImage : public QImage, public ReferenceCounter
     int m_gradAlpha;
     FillDirection m_gradDirection;
 
+    bool m_isRotated;
     bool m_isReflected;
     bool m_isYUV;
 

--- a/mythtv/libs/libmythui/mythuiimage.h
+++ b/mythtv/libs/libmythui/mythuiimage.h
@@ -56,12 +56,14 @@ class ImageProperties
     bool isGreyscale;
     bool isReflected;
     bool isMasked;
+    bool isRotated;
 
     ReflectAxis reflectAxis;
     int reflectScale;
     int reflectLength;
     int reflectShear;
     int reflectSpacing;
+    int rotationAngle;
 
   private:
     void Init(void);
@@ -118,6 +120,8 @@ class MUI_PUBLIC MythUIImage : public MythUIType
     virtual void Pulse(void);
 
     virtual void LoadNow(void);
+
+    void SetRotation(int rotationAngle);
 
   protected:
     virtual void DrawSelf(MythPainter *p, int xoffset, int yoffset,


### PR DESCRIPTION
This can be done either by either calling Rotate(angle) or by the rotate
tag and its attribute angle in the theme. The angle value should be
multiple of 90 degrees.
