### PR TITLE
Update logging.py

### DIFF
--- a/mythtv/bindings/python/MythTV/logging.py
+++ b/mythtv/bindings/python/MythTV/logging.py
@@ -413,7 +413,7 @@ class MythLog( LOGLEVEL, LOGMASK, LOGFACILITY ):
                                     (host, application, pid, thread,
                                      msgtime, level, message)
                                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                    (self.db.gethostname(), argv[0].rsplit('/', 1)[1],
+                    (self.db.gethostname(), argv[0],
                      os.getpid(), self.module, self.time(), level,
                      message + (' -- {0}'.format(detail) if detail else '')))
 


### PR DESCRIPTION
line 416 - argv[0].rsplit('/', 1)[1] , the split would cause job crashes that did not provide a splittable input. Not sure why you would want to split argument 0 here anyway. Offending script was mythvidexport.py. I know it is not a perfect solution, but making a check for the possibility of an out of index error in a cursor call seemed a little more extensive than I cared to contribute just for a log entry
