### PR TITLE
Fix bug in mythtranscodes clean-cutting mechanism

### DIFF
--- a/mythtv/programs/mythtranscode/transcode.cpp
+++ b/mythtv/programs/mythtranscode/transcode.cpp
@@ -578,7 +578,18 @@ class Cutter
             // amount to drop is sufficient then we can drop less
             // audio rather than drop a frame
             audioFramesToCut -= (int64_t)(audioFramesPerVideoFrame + 0.5);
-            return true;
+
+            // But if it's a frame we are supposed to drop anyway, still do so,
+            // and record that we have
+            if (videoFramesToCut > 0)
+            {
+                videoFramesToCut-- ;
+                return false;
+            }
+            else
+            {
+                return true;
+            }
         }
         else
         {


### PR DESCRIPTION
One of the clean-cut methods interacted badly with mythtranscodes
synchronisation algorithm and would sometimes cause frames from
cut segments to be kept. This commit fixes that bug
