### PR TITLE
Update source strings for consistency and typos

### DIFF
--- a/mythtv/libs/libmythtv/Bluray/bdringbuffer.cpp
+++ b/mythtv/libs/libmythtv/Bluray/bdringbuffer.cpp
@@ -381,7 +381,7 @@ bool BDRingBuffer::OpenFile(const QString &lfilename, uint retry_ms)
         // no title, no point trying any longer
         bd_close(bdnav);
         bdnav = NULL;
-        lastError = tr("Can't find any Bluray-compatible title");
+        lastError = tr("Can't find any Blu-ray compatible titles");
         rwlock.unlock();
         mythfile_open_register_callback(filename.toLocal8Bit().data(), this, NULL);
         return false;
@@ -481,7 +481,7 @@ bool BDRingBuffer::OpenFile(const QString &lfilename, uint retry_ms)
             // no title, no point trying any longer
             bd_close(bdnav);
             bdnav = NULL;
-            lastError = tr("Can't find any usable Bluray title");
+            lastError = tr("Can't find any usable Blu-ray titles");
             rwlock.unlock();
             mythfile_open_register_callback(filename.toLocal8Bit().data(), this, NULL);
             return false;

--- a/mythtv/libs/libmythtv/channelsettings.cpp
+++ b/mythtv/libs/libmythtv/channelsettings.cpp
@@ -192,7 +192,7 @@ class Priority : public SpinBoxSetting, public ChannelDBStorage
             "Number of priority points to be added to any recording on this "
             "channel during scheduling. Use a positive number as the priority "
             "if you want this to be a preferred channel, a negative one to "
-            "deprecate this channel."));
+            "depreciate this channel."));
     }
 };
 
@@ -252,7 +252,7 @@ class XmltvID : public ComboBoxSetting, public ChannelDBStorage
         setLabel(QCoreApplication::translate("(Common)", "XMLTV ID"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)", 
-            "ID used by listing services to get an exact correspondance "
+            "ID used by listing services to get an exact correspondence "
             "between a channel in your line-up and a channel in their "
             "database. Normally this is set automatically when "
             "'mythfilldatabase' is run."));

--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -537,7 +537,7 @@ static GlobalSpinBox *RecordPreRoll()
                                         "scheduled start time. It does not "
                                         "affect the scheduler. It is ignored "
                                         "when two shows have been scheduled "
-                                        "without enough time in between."));
+                                        "without enough time inbetween."));
     bs->setValue(0);
 
     return bs;
@@ -556,7 +556,7 @@ static GlobalSpinBox *RecordOverTime()
                                         "scheduled end time. It does not "
                                         "affect the scheduler. It is ignored "
                                         "when two shows have been scheduled "
-                                        "without enough time in between."));
+                                        "without enough time inbetween."));
     return bs;
 }
 
@@ -604,7 +604,7 @@ static GlobalSpinBox *CategoryOverTime()
                                         "the recording by the specified "
                                         "number of minutes. It is ignored "
                                         "when two shows have been scheduled "
-                                        "without enough time in-between."));
+                                        "without enough time inbetween."));
     return bs;
 }
 


### PR DESCRIPTION
Suggested updates to some source strings I noticed whilst updating the translations for en_gb. There may be more! so I'm thinking of putting together a script to spot more of these.

There are several more in the the ThemeUI context, but these require updates to individual themes
