### PR TITLE
Observed behavior: exit playback, black screen you could not interact wi...

### DIFF
--- a/mythtv/libs/libmythtv/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/avformatdecoder.cpp
@@ -4665,7 +4665,10 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype)
             if (!ic || ((retval = ReadPacket(ic, pkt, storevideoframes)) < 0))
             {
                 if (retval == -EAGAIN)
+                {
+                    avcodeclock->unlock();
                     continue;
+                }
 
                 SetEof(true);
                 delete pkt;


### PR DESCRIPTION
...th, only recourse was to restart mythfrontend.

Fix the mutex lock count. It would get off by one for every EAGAIN preventing the player teardown form completing (lock in AvFormatDecoder::CloseCodecs that could never be obtained).
