### PR TITLE
If transcoding, don't discard frames during a seek operation

### DIFF
--- a/mythtv/libs/libmythtv/decoderbase.cpp
+++ b/mythtv/libs/libmythtv/decoderbase.cpp
@@ -742,7 +742,7 @@ bool DecoderBase::DoFastForward(long long desiredFrame, bool discardFrames)
     normalframes = max(normalframes, 0);
     SeekReset(lastKey, normalframes, needflush, discardFrames);
 
-    if (discardFrames)
+    if (discardFrames || transcoding)
         m_parent->SetFramesPlayed(framesPlayed+1);
 
     // Re-enable rawframe state if it was enabled before FF

--- a/mythtv/libs/libmythtv/mythplayer.cpp
+++ b/mythtv/libs/libmythtv/mythplayer.cpp
@@ -3125,7 +3125,7 @@ void MythPlayer::DecoderLoop(bool pause)
                 if (((uint64_t)decoderSeek < framesPlayed) && decoder)
                     decoder->DoRewind(decoderSeek);
                 else if (decoder)
-                    decoder->DoFastForward(decoderSeek);
+                    decoder->DoFastForward(decoderSeek, !transcoding);
                 decoderSeek = -1;
                 decoderSeekLock.unlock();
             }


### PR DESCRIPTION
This is necessary because trancoding uses a queue of frames, and frames
held in the queue can be reused and overwritten if DiscardFrames is
called.

See Ticket #11759
