### PR TITLE
Allow mythlink to specify season & episodes.

### DIFF
--- a/mythtv/bindings/perl/MythTV/Program.pm
+++ b/mythtv/bindings/perl/MythTV/Program.pm
@@ -123,6 +123,8 @@ package MythTV::Program;
         $self->{'title'}       = 'Untitled'       unless ($self->{'title'} =~ /\S/);
         $self->{'subtitle'}    = 'Untitled'       unless ($self->{'subtitle'} =~ /\S/);
         $self->{'description'} = 'No Description' unless ($self->{'description'} =~ /\S/);
+        $self->{'season'}      = '00' unless $self->{'season'};
+        $self->{'episode'}     = '00' unless $self->{'episode'};
 
     # Credits
         $self->load_credits();
@@ -394,6 +396,9 @@ package MythTV::Program;
         $fields{'om'} = $omonth;            # month, leading zero
         $fields{'oj'} = int($oday);         # day of month
         $fields{'od'} = $oday;              # day of month, leading zero
+    # Season & Episode
+        $fields{'sea'} = $self->{'season'};
+        $fields{'ep'}  = $self->{'episode'};
     # Literals
         $fields{'%'}   = '%';
         ($fields{'-'}  = $separator) =~ s/%/%%/g;

--- a/mythtv/contrib/user_jobs/mythlink.pl
+++ b/mythtv/contrib/user_jobs/mythlink.pl
@@ -179,6 +179,8 @@ options:
     \%om  = Original Airdate:  month, leading zero
     \%oj  = Original Airdate:  day of month
     \%od  = Original Airdate:  day of month, leading zero
+    \%sea = Season number
+    \%ep  = Episode number
     \%%   = a literal % character
 
     * The program start time is the time from the listings data and is not


### PR DESCRIPTION
Subject says it all.
I use this so I can have mythlink create links in a format Plex can understand.
Plex is very inflexible in this regard.

Pull request against fixes/0.26 instead of master.

Fixes: http://code.mythtv.org/trac/ticket/11919
Supercedes #56
