### PR TITLE
Fix issue #11306: Master backend crashes when a slave backend disconnects

### DIFF
--- a/mythtv/programs/mythbackend/encoderlink.h
+++ b/mythtv/programs/mythbackend/encoderlink.h
@@ -3,6 +3,7 @@
 
 #include <QString>
 #include <QMap>
+#include <QMutex>
 
 #include "tv.h"
 #include "programinfo.h"
@@ -82,7 +83,7 @@ class EncoderLink
     bool IsBusyRecording(void);
 
     TVState GetState();
-    uint GetFlags(void) const;
+    uint GetFlags(void);
     bool IsRecording(const ProgramInfo *rec); // scheduler call only.
 
     bool MatchesRecording(const ProgramInfo *rec);
@@ -109,7 +110,7 @@ class EncoderLink
     void PauseRecorder(void);
     void SetLiveRecording(int);
     void SetNextLiveTVDir(QString dir);
-    vector<InputInfo> GetFreeInputs(const vector<uint> &excluded_cards) const;
+    vector<InputInfo> GetFreeInputs(const vector<uint> &excluded_cards);
     QString GetInput(void) const;
     QString SetInput(QString);
     void ToggleChannelFavorite(QString);
@@ -137,9 +138,13 @@ class EncoderLink
                         QString channame, QString xmltv);
 
   private:
+    bool HasSockAndIncrRef();
+    bool HasSockAndDecrRef();
+
     int m_capturecardnum;
 
     PlaybackSock *sock;
+    QMutex sockLock;
     QString hostname;
 
     TVRec *tv;


### PR DESCRIPTION
Protect pbs with proper (aka locked) refcounting.

The PlaybackSock must not be immediatly deleted on connectionClosed() if some other requests are still using it. This leads to segfaults in the MBE when a SBE disconnects.
