### PR TITLE
DevTools: Allow unit test suites to be run individually

### DIFF
--- a/mythtv/programs/scripts/unittests.sh
+++ b/mythtv/programs/scripts/unittests.sh
@@ -9,8 +9,15 @@ GCOV=`which gcov`
 GREP=`which grep`
 TEST_FAILED=0
 
+SEARCH=""
+if [ $1 != "" ]; then
+    SEARCH="test_"$1".pro"
+else
+    SEARCH="test_*.pro"
+fi
 
-TESTS=`find . -name "test_*.pro"`
+TESTS=`find . -name $SEARCH`
+
 
 for TEST in $TESTS
 do


### PR DESCRIPTION
This is to allow the use of the current unittests.sh scripts for running individual unit test suites, instead of just running the all every time.
