### PR TITLE
Add channel callsign to OSD

### DIFF
--- a/mythtv/themes/MythCenter-wide/osd.xml
+++ b/mythtv/themes/MythCenter-wide/osd.xml
@@ -219,6 +219,11 @@
             <align>hcenter,vcenter</align>
             <value>%CHANNUM%</value>
         </textarea>
+        <textarea name="callsign">
+            <area>925,10,300,80</area>
+            <font>large</font>
+            <align>allcenter</align>
+        </textarea>
         <imagetype name="iconpath">
             <area>1015,10,125,80</area>
         </imagetype>


### PR DESCRIPTION
After adding a HDHR Prime to my system it became apparent that the OSD did not display the channel callsign which made browsing channels very difficult. This seemed to work well for me. The SD theme could probably use this too but the widget placement would need to be tweaked.
