### PR TITLE
Issue #12046: Fix random SBE PlaybackSock timeout in MBE.

### DIFF
--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -443,8 +443,24 @@ void MainServer::ProcessRequest(MythSocket *sock)
 
 void MainServer::ProcessRequestWork(MythSocket *sock)
 {
+    sockListLock.lockForRead();
+    PlaybackSock *pbs = GetPlaybackBySock(sock);
+    if (pbs)
+        pbs->IncrRef();
+    sockListLock.unlock();
+
     QStringList listline;
-    if (!sock->ReadStringList(listline) || listline.empty())
+    if (pbs)
+    {
+        if (!pbs->ReadStringList(listline) || listline.empty())
+        {
+            pbs->DecrRef();
+            LOG(VB_GENERAL, LOG_INFO, "No data in ProcessRequestWork()");
+            return;
+        }
+        pbs->DecrRef();
+    }
+    else if (!sock->ReadStringList(listline) || listline.empty())
     {
         LOG(VB_GENERAL, LOG_INFO, "No data in ProcessRequestWork()");
         return;
@@ -475,7 +491,7 @@ void MainServer::ProcessRequestWork(MythSocket *sock)
     }
 
     sockListLock.lockForRead();
-    PlaybackSock *pbs = GetPlaybackBySock(sock);
+    pbs = GetPlaybackBySock(sock);
     if (!pbs)
     {
         sockListLock.unlock();

--- a/mythtv/programs/mythbackend/playbacksock.cpp
+++ b/mythtv/programs/mythbackend/playbacksock.cpp
@@ -10,6 +10,7 @@ using namespace std;
 #include "mythcorecontext.h"
 #include "mythdate.h"
 #include "inputinfo.h"
+#include "referencecounter.h"
 
 #define LOC QString("PlaybackSock: ")
 #define LOC_ERR QString("PlaybackSock, Error: ")
@@ -69,6 +70,20 @@ bool PlaybackSock::wantsOnlySystemEvents(void) const
 PlaybackSockEventsMode PlaybackSock::eventsMode(void) const
 {
     return m_eventsMode;
+}
+
+bool PlaybackSock::ReadStringList(QStringList &list)
+{
+    sock->IncrRef();
+    ReferenceLocker rlocker(sock);
+    QMutexLocker locker(&sockLock);
+    if (!sock->IsDataAvailable())
+    {
+        LOG(VB_GENERAL, LOG_DEBUG,
+            "PlaybackSock::ReadStringList(): Data vanished !!!");
+        return false;
+    }
+    return sock->ReadStringList(list);
 }
 
 bool PlaybackSock::SendReceiveStringList(

--- a/mythtv/programs/mythbackend/playbacksock.h
+++ b/mythtv/programs/mythbackend/playbacksock.h
@@ -101,6 +101,8 @@ class PlaybackSock : public ReferenceCounter
 
     QStringList ForwardRequest(const QStringList&);
 
+    bool ReadStringList(QStringList &list);
+
   private:
     bool SendReceiveStringList(QStringList &strlist, uint min_reply_length = 0);
 


### PR DESCRIPTION
SBE PlaybackSocks in the master suffer from random disconnection, occuring
after a 7000 ms timeout. It often happens when a frontend ask for the
thumbnail of a program currently being recorded on a slave backend.

I could identify two problems causing this:

First, there is a race between MainServer::ProcessRequestWork and
PlaybackSock::SendReceiveStringList. Even if callbacks are disabled during
SendReceiveStringList execution, a ProcessRequestWork may already be running
and can swallow the reply, leading to the timeout in SendReceiveStringList.

The second problem is that an invocation of ProcessRequestWork is fired for
each block of data arriving in the socket (for example when a reply is long
enough to be fragmented, ie. GENERATED_PIXMAP) but this data is consumed all at
once by one worker, leaving the other workers without food. This also leads to
the timeout in ReadStringList.

This patch fixes the first problem by assuring that no worker reads from the
socket while a SendReceiveStringList is running and the second one by aborting
a worker if there is no more data to read, but only once the lock has been
acquired.
