### PR TITLE
Updated getKeys() and getHosts() xml bindings to latest format

### DIFF
--- a/mythtv/bindings/python/MythTV/methodheap.py
+++ b/mythtv/bindings/python/MythTV/methodheap.py
@@ -1117,12 +1117,12 @@ class MythXML( XMLConnection ):
     def getHosts(self):
         """Returns a list of unique hostnames found in the settings table."""
         return self._request('Myth/GetHosts')\
-                                        .readJSON()['StringList']['Values']
+                                        .readJSON()['StringList']
 
     def getKeys(self):
         """Returns a list of unique keys found in the settings table."""
         return self._request('Myth/GetKeys')\
-                                        .readJSON()['StringList']['Values']
+                                        .readJSON()['StringList']
 
     def getSetting(self, key, hostname=None, default=None):
         """Retrieves a setting from the backend."""


### PR DESCRIPTION
Was playing around with python bindings and noticed that the getHosts() and getKeys() functions no longer worked due to 'Values' not being present in the resulting feed. This removes them to restore functionality