### PR TITLE
Services API - Get cut list and comm break for recorded

### DIFF
--- a/mythtv/libs/libmyth/programinfo.h
+++ b/mythtv/libs/libmyth/programinfo.h
@@ -613,6 +613,10 @@ class MPUBLIC ProgramInfo
                          int64_t min_frm = -1, int64_t max_frm = -1) const;
     void SavePositionMapDelta(frm_pos_map_t &, MarkTypes type) const;
 
+    // Get position/duration for keyframe
+    bool QueryKeyFramePosition(uint64_t *, uint64_t keyframe, bool backwards) const;
+    bool QueryKeyFrameDuration(uint64_t *, uint64_t keyframe, bool backwards) const;
+
     // Get/set all markup
     struct MarkupEntry
     {

--- a/mythtv/libs/libmythservicecontracts/datacontracts/cutList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/cutList.h
@@ -1,0 +1,89 @@
+//////////////////////////////////////////////////////////////////////////////
+// Program Name: cutList.h
+// Created     : Mar. 09, 2014
+//
+// Copyright (c) 2014 team MythTV
+//
+// Licensed under the GPL v2 or later, see COPYING for details
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CUTLIST_H_
+#define CUTLIST_H_
+
+#include <QString>
+#include <QVariantList>
+
+#include "serviceexp.h"
+#include "datacontracthelper.h"
+
+#include "cutting.h"
+
+namespace DTC
+{
+
+class SERVICE_PUBLIC CutList : public QObject
+{
+    Q_OBJECT
+    Q_CLASSINFO( "version", "1.0" );
+
+    // Q_CLASSINFO Used to augment Metadata for properties.
+    // See datacontracthelper.h for details
+
+    Q_CLASSINFO( "Cuttings", "type=DTC::Cutting");
+
+    Q_PROPERTY( QVariantList Cuttings READ Cuttings DESIGNABLE true )
+
+    PROPERTYIMP_RO_REF( QVariantList, Cuttings )
+
+    public:
+
+        static inline void InitializeCustomTypes();
+
+    public:
+
+        CutList(QObject *parent = 0)
+            : QObject         ( parent )
+        {
+        }
+
+        CutList( const CutList &src )
+        {
+            Copy( src );
+        }
+
+        void Copy( const CutList &src )
+        {
+            CopyListContents< Cutting >( this, m_Cuttings, src.m_Cuttings );
+        }
+
+        Cutting *AddNewCutting()
+        {
+            // We must make sure the object added to the QVariantList has
+            // a parent of 'this'
+
+            Cutting *pObject = new Cutting( this );
+            m_Cuttings.append( QVariant::fromValue<QObject *>( pObject ));
+
+            return pObject;
+        }
+
+};
+
+} // namespace DTC
+
+Q_DECLARE_METATYPE( DTC::CutList  )
+Q_DECLARE_METATYPE( DTC::CutList* )
+
+namespace DTC
+{
+inline void CutList::InitializeCustomTypes()
+{
+    qRegisterMetaType< CutList  >();
+    qRegisterMetaType< CutList* >();
+
+    Cutting::InitializeCustomTypes();
+}
+}
+
+#endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/cutting.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/cutting.h
@@ -1,0 +1,71 @@
+//////////////////////////////////////////////////////////////////////////////
+// Program Name: cutting.h
+// Created     : Mar. 09, 2014
+//
+// Copyright (c) 2014 team MythTV
+//
+// Licensed under the GPL v2 or later, see COPYING for details
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CUTTING_H_
+#define CUTTING_H_
+
+#include <QString>
+#include <QVariantList>
+
+#include "serviceexp.h"
+#include "datacontracthelper.h"
+
+namespace DTC
+{
+
+class SERVICE_PUBLIC Cutting : public QObject
+{
+    Q_OBJECT
+    Q_CLASSINFO( "version"    , "1.0" );
+
+    Q_PROPERTY( int Mark          READ Mark         WRITE setMark   )
+    Q_PROPERTY( qlonglong Offset  READ Offset       WRITE setOffset )
+
+    PROPERTYIMP    ( int        , Mark   )
+    PROPERTYIMP    ( qlonglong  , Offset )
+
+    public:
+
+        static inline void InitializeCustomTypes();
+
+    public:
+
+        Cutting(QObject *parent = 0)
+            : QObject         ( parent )
+        {
+        }
+
+        Cutting( const Cutting &src )
+        {
+            Copy( src );
+        }
+
+        void Copy( const Cutting &src )
+        {
+            m_Mark          = src.m_Mark   ;
+            m_Offset        = src.m_Offset ;
+        }
+};
+
+} // namespace DTC
+
+Q_DECLARE_METATYPE( DTC::Cutting  )
+Q_DECLARE_METATYPE( DTC::Cutting* )
+
+namespace DTC
+{
+inline void Cutting::InitializeCustomTypes()
+{
+    qRegisterMetaType< Cutting  >();
+    qRegisterMetaType< Cutting* >();
+}
+}
+
+#endif

--- a/mythtv/libs/libmythservicecontracts/libmythservicecontracts.pro
+++ b/mythtv/libs/libmythservicecontracts/libmythservicecontracts.pro
@@ -53,6 +53,7 @@ HEADERS += datacontracts/inputList.h
 HEADERS += datacontracts/recRuleFilter.h         datacontracts/recRuleFilterList.h
 HEADERS += datacontracts/castMember.h            datacontracts/castMemberList.h
 HEADERS += datacontracts/frontend.h              datacontracts/frontendList.h
+HEADERS += datacontracts/cutting.h               datacontracts/cutList.h
 
 SOURCES += service.cpp
 
@@ -101,6 +102,7 @@ incDatacontracts.files += datacontracts/inputList.h
 incDatacontracts.files += datacontracts/recRuleFilter.h       datacontracts/recRuleFilterList.h
 incDatacontracts.files += datacontracts/castMember.h          datacontracts/castMemberList.h
 incDatacontracts.files += datacontracts/enum.h                datacontracts/enumItem.h
+incDatacontracts.files += datacontracts/cutting.h             datacontracts/cutList.h
 
 INSTALLS += inc incServices incDatacontracts
 

--- a/mythtv/libs/libmythservicecontracts/services/dvrServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/dvrServices.h
@@ -24,6 +24,7 @@
 #include "datacontracts/titleInfoList.h"
 #include "datacontracts/input.h"
 #include "datacontracts/inputList.h"
+#include "datacontracts/cutList.h"
 
 /////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////
@@ -70,6 +71,7 @@ class SERVICE_PUBLIC DvrServices : public Service  //, public QScriptable ???
             DTC::RecRuleList::InitializeCustomTypes();
             DTC::TitleInfoList::InitializeCustomTypes();
             DTC::RecRuleFilterList::InitializeCustomTypes();
+            DTC::CutList::InitializeCustomTypes();
         }
 
     public slots:
@@ -108,6 +110,16 @@ class SERVICE_PUBLIC DvrServices : public Service  //, public QScriptable ???
                                                                  int   ChanId,
                                                                  const QDateTime &StartTime,
                                                                  bool  Watched) = 0;
+
+        virtual DTC::CutList*      GetRecordedCutList    ( int              RecordedId,
+                                                           int              ChanId,
+                                                           const QDateTime &StartTime,
+                                                           const QString   &OffsetType ) = 0;
+
+        virtual DTC::CutList*      GetRecordedCommBreak  ( int              RecordedId,
+                                                           int              ChanId,
+                                                           const QDateTime &StartTime,
+                                                           const QString   &OffsetType ) = 0;
 
         virtual DTC::ProgramList*  GetConflictList       ( int              StartIndex,
                                                            int              Count,

--- a/mythtv/programs/mythbackend/services/dvr.cpp
+++ b/mythtv/programs/mythbackend/services/dvr.cpp
@@ -276,11 +276,11 @@ DTC::CutList* Dvr::GetRecordedCutList ( int RecordedId,
         (chanid <= 0 || !recstarttsRaw.isValid()))
         throw QString("Recorded ID or Channel ID and StartTime appears invalid.");
 
-    ProgramInfo pi;
+    RecordingInfo ri;
     if (RecordedId > 0)
-        pi = ProgramInfo(RecordedId);
+        ri = RecordingInfo(RecordedId);
     else
-        pi = ProgramInfo(chanid, recstarttsRaw.toUTC());
+        ri = RecordingInfo(chanid, recstarttsRaw.toUTC());
 
     DTC::CutList* pCutList = new DTC::CutList();
     if (offsettype == "Position")
@@ -290,7 +290,7 @@ DTC::CutList* Dvr::GetRecordedCutList ( int RecordedId,
     else
         marktype = 0;
 
-    FillCutList(pCutList, &pi, marktype);
+    FillCutList(pCutList, &ri, marktype);
 
     return pCutList;
 }
@@ -309,11 +309,11 @@ DTC::CutList* Dvr::GetRecordedCommBreak ( int RecordedId,
         (chanid <= 0 || !recstarttsRaw.isValid()))
         throw QString("Recorded ID or Channel ID and StartTime appears invalid.");
 
-    ProgramInfo pi;
+    RecordingInfo ri;
     if (RecordedId > 0)
-        pi = ProgramInfo(RecordedId);
+        ri = RecordingInfo(RecordedId);
     else
-        pi = ProgramInfo(chanid, recstarttsRaw.toUTC());
+        ri = RecordingInfo(chanid, recstarttsRaw.toUTC());
 
     DTC::CutList* pCutList = new DTC::CutList();
     if (offsettype == "Position")
@@ -323,7 +323,7 @@ DTC::CutList* Dvr::GetRecordedCommBreak ( int RecordedId,
     else
         marktype = 0;
 
-    FillCommBreak(pCutList, &pi, marktype);
+    FillCommBreak(pCutList, &ri, marktype);
 
     return pCutList;
 }

--- a/mythtv/programs/mythbackend/services/dvr.cpp
+++ b/mythtv/programs/mythbackend/services/dvr.cpp
@@ -266,7 +266,73 @@ bool Dvr::UpdateRecordedWatchedStatus ( int RecordedId,
 //
 /////////////////////////////////////////////////////////////////////////////
 
-DTC::ProgramList* Dvr::GetExpiringList( int nStartIndex, 
+DTC::CutList* Dvr::GetRecordedCutList ( int RecordedId,
+                                        int chanid,
+                                        const QDateTime &recstarttsRaw,
+                                        const QString &offsettype )
+{
+    int marktype;
+    if ((RecordedId <= 0) &&
+        (chanid <= 0 || !recstarttsRaw.isValid()))
+        throw QString("Recorded ID or Channel ID and StartTime appears invalid.");
+
+    ProgramInfo pi;
+    if (RecordedId > 0)
+        pi = ProgramInfo(RecordedId);
+    else
+        pi = ProgramInfo(chanid, recstarttsRaw.toUTC());
+
+    DTC::CutList* pCutList = new DTC::CutList();
+    if (offsettype == "Position")
+        marktype = 1;
+    else if (offsettype == "Duration")
+        marktype = 2;
+    else
+        marktype = 0;
+
+    FillCutList(pCutList, &pi, marktype);
+
+    return pCutList;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+/////////////////////////////////////////////////////////////////////////////
+
+DTC::CutList* Dvr::GetRecordedCommBreak ( int RecordedId,
+                                          int chanid,
+                                          const QDateTime &recstarttsRaw,
+                                          const QString &offsettype )
+{
+    int marktype;
+    if ((RecordedId <= 0) &&
+        (chanid <= 0 || !recstarttsRaw.isValid()))
+        throw QString("Recorded ID or Channel ID and StartTime appears invalid.");
+
+    ProgramInfo pi;
+    if (RecordedId > 0)
+        pi = ProgramInfo(RecordedId);
+    else
+        pi = ProgramInfo(chanid, recstarttsRaw.toUTC());
+
+    DTC::CutList* pCutList = new DTC::CutList();
+    if (offsettype == "Position")
+        marktype = 1;
+    else if (offsettype == "Duration")
+        marktype = 2;
+    else
+        marktype = 0;
+
+    FillCommBreak(pCutList, &pi, marktype);
+
+    return pCutList;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+/////////////////////////////////////////////////////////////////////////////
+
+DTC::ProgramList* Dvr::GetExpiringList( int nStartIndex,
                                         int nCount      )
 {
     pginfolist_t  infoList;

--- a/mythtv/programs/mythbackend/services/dvr.h
+++ b/mythtv/programs/mythbackend/services/dvr.h
@@ -75,6 +75,16 @@ class Dvr : public DvrServices
                                                         const QDateTime &StartTime,
                                                         bool  Watched);
 
+        DTC::CutList*     GetRecordedCutList  ( int              RecordedId,
+                                                int              ChanId,
+                                                const QDateTime &StartTime,
+                                                const QString   &OffsetType );
+
+        DTC::CutList*     GetRecordedCommBreak ( int              RecordedId,
+                                                 int              ChanId,
+                                                 const QDateTime &StartTime,
+                                                 const QString   &OffsetType );
+
         DTC::ProgramList* GetConflictList     ( int              StartIndex,
                                                 int              Count,
                                                 int              RecordId );

--- a/mythtv/programs/mythbackend/services/serviceUtil.cpp
+++ b/mythtv/programs/mythbackend/services/serviceUtil.cpp
@@ -35,6 +35,7 @@
 #include "videoutils.h"
 #include "metadataimagehelper.h"
 #include "cardutil.h"
+#include "datacontracts/cutList.h"
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -516,4 +517,96 @@ void FillCastMemberList(DTC::CastMemberList* pCastMemberList,
 
     //pCastMemberList->setCount(query.size());
     //pCastMemberList->setTotalAvailable(query.size());
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+/////////////////////////////////////////////////////////////////////////////
+
+void FillCutList(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
+{
+    frm_dir_map_t markMap;
+    frm_dir_map_t::const_iterator it;
+
+    if (pInfo && pInfo->GetChanID())
+    {
+        pInfo->QueryCutList(markMap);
+
+        for (it = markMap.begin(); it != markMap.end(); ++it)
+        {
+            bool isend = ((*it) == MARK_CUT_END || (*it) == MARK_COMM_END) ? true : false;
+            if (marktype == 0)
+            {
+                DTC::Cutting *pCutting = pCutList->AddNewCutting();
+                pCutting->setMark(*it);
+                pCutting->setOffset(it.key());
+            }
+            else if (marktype == 1)
+            {
+                uint64_t offset;
+                if (pInfo->QueryKeyFramePosition(&offset, it.key(), isend))
+                {
+                  DTC::Cutting *pCutting = pCutList->AddNewCutting();
+                  pCutting->setMark(*it);
+                  pCutting->setOffset(offset);
+                }
+            }
+            else if (marktype == 2)
+            {
+                uint64_t offset;
+                if (pInfo->QueryKeyFrameDuration(&offset, it.key(), isend))
+                {
+                  DTC::Cutting *pCutting = pCutList->AddNewCutting();
+                  pCutting->setMark(*it);
+                  pCutting->setOffset(offset);
+                }
+            }
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+/////////////////////////////////////////////////////////////////////////////
+
+void FillCommBreak(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
+{
+    frm_dir_map_t markMap;
+    frm_dir_map_t::const_iterator it;
+
+    if (pInfo && pInfo->GetChanID())
+    {
+        pInfo->QueryCommBreakList(markMap);
+
+        for (it = markMap.begin(); it != markMap.end(); ++it)
+        {
+            bool isend = ((*it) == MARK_CUT_END || (*it) == MARK_COMM_END) ? true : false;
+            if (marktype == 0)
+            {
+                DTC::Cutting *pCutting = pCutList->AddNewCutting();
+                pCutting->setMark(*it);
+                pCutting->setOffset(it.key());
+            }
+            else if (marktype == 1)
+            {
+                uint64_t offset;
+                if (pInfo->QueryKeyFramePosition(&offset, it.key(), isend))
+                {
+                  DTC::Cutting *pCutting = pCutList->AddNewCutting();
+                  pCutting->setMark(*it);
+                  pCutting->setOffset(offset);
+                }
+            }
+            else if (marktype == 2)
+            {
+                uint64_t offset;
+                if (pInfo->QueryKeyFrameDuration(&offset, it.key(), isend))
+                {
+                  DTC::Cutting *pCutting = pCutList->AddNewCutting();
+                  pCutting->setMark(*it);
+                  pCutting->setOffset(offset);
+                }
+            }
+        }
+    }
 }

--- a/mythtv/programs/mythbackend/services/serviceUtil.cpp
+++ b/mythtv/programs/mythbackend/services/serviceUtil.cpp
@@ -523,14 +523,14 @@ void FillCastMemberList(DTC::CastMemberList* pCastMemberList,
 //
 /////////////////////////////////////////////////////////////////////////////
 
-void FillCutList(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
+void FillCutList(DTC::CutList* pCutList, RecordingInfo* rInfo, int marktype)
 {
     frm_dir_map_t markMap;
     frm_dir_map_t::const_iterator it;
 
-    if (pInfo && pInfo->GetChanID())
+    if (rInfo && rInfo->GetChanID())
     {
-        pInfo->QueryCutList(markMap);
+        rInfo->QueryCutList(markMap);
 
         for (it = markMap.begin(); it != markMap.end(); ++it)
         {
@@ -544,7 +544,7 @@ void FillCutList(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
             else if (marktype == 1)
             {
                 uint64_t offset;
-                if (pInfo->QueryKeyFramePosition(&offset, it.key(), isend))
+                if (rInfo->QueryKeyFramePosition(&offset, it.key(), isend))
                 {
                   DTC::Cutting *pCutting = pCutList->AddNewCutting();
                   pCutting->setMark(*it);
@@ -554,7 +554,7 @@ void FillCutList(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
             else if (marktype == 2)
             {
                 uint64_t offset;
-                if (pInfo->QueryKeyFrameDuration(&offset, it.key(), isend))
+                if (rInfo->QueryKeyFrameDuration(&offset, it.key(), isend))
                 {
                   DTC::Cutting *pCutting = pCutList->AddNewCutting();
                   pCutting->setMark(*it);
@@ -569,14 +569,14 @@ void FillCutList(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
 //
 /////////////////////////////////////////////////////////////////////////////
 
-void FillCommBreak(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
+void FillCommBreak(DTC::CutList* pCutList, RecordingInfo* rInfo, int marktype)
 {
     frm_dir_map_t markMap;
     frm_dir_map_t::const_iterator it;
 
-    if (pInfo && pInfo->GetChanID())
+    if (rInfo && rInfo->GetChanID())
     {
-        pInfo->QueryCommBreakList(markMap);
+        rInfo->QueryCommBreakList(markMap);
 
         for (it = markMap.begin(); it != markMap.end(); ++it)
         {
@@ -590,7 +590,7 @@ void FillCommBreak(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
             else if (marktype == 1)
             {
                 uint64_t offset;
-                if (pInfo->QueryKeyFramePosition(&offset, it.key(), isend))
+                if (rInfo->QueryKeyFramePosition(&offset, it.key(), isend))
                 {
                   DTC::Cutting *pCutting = pCutList->AddNewCutting();
                   pCutting->setMark(*it);
@@ -600,7 +600,7 @@ void FillCommBreak(DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype)
             else if (marktype == 2)
             {
                 uint64_t offset;
-                if (pInfo->QueryKeyFrameDuration(&offset, it.key(), isend))
+                if (rInfo->QueryKeyFrameDuration(&offset, it.key(), isend))
                 {
                   DTC::Cutting *pCutting = pCutList->AddNewCutting();
                   pCutting->setMark(*it);

--- a/mythtv/programs/mythbackend/services/serviceUtil.h
+++ b/mythtv/programs/mythbackend/services/serviceUtil.h
@@ -41,6 +41,7 @@
 #include "channelgroup.h"
 #include "inputinfo.h"
 #include "channelinfo.h"
+#include "recordinginfo.h"
 
 void FillProgramInfo( DTC::Program *pProgram,
                       ProgramInfo  *pInfo,
@@ -75,8 +76,8 @@ void FillInputInfo( DTC::Input *input, InputInfo inputInfo);
 void FillCastMemberList( DTC::CastMemberList *pCastMemberList,
                          ProgramInfo  *pInfo);
 
-void FillCutList( DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype);
+void FillCutList( DTC::CutList* pCutList, RecordingInfo* rInfo, int marktype);
 
-void FillCommBreak( DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype);
+void FillCommBreak( DTC::CutList* pCutList, RecordingInfo* rInfo, int marktype);
 
 #endif

--- a/mythtv/programs/mythbackend/services/serviceUtil.h
+++ b/mythtv/programs/mythbackend/services/serviceUtil.h
@@ -33,6 +33,7 @@
 #include "datacontracts/channelGroup.h"
 #include "datacontracts/input.h"
 #include "datacontracts/castMemberList.h"
+#include "datacontracts/cutList.h"
 
 #include "programinfo.h"
 #include "recordingrule.h"
@@ -73,4 +74,9 @@ void FillInputInfo( DTC::Input *input, InputInfo inputInfo);
 
 void FillCastMemberList( DTC::CastMemberList *pCastMemberList,
                          ProgramInfo  *pInfo);
+
+void FillCutList( DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype);
+
+void FillCommBreak( DTC::CutList* pCutList, ProgramInfo* pInfo, int marktype);
+
 #endif


### PR DESCRIPTION
This is a patch adding the ability to get cut list and comm break for recordings.
Also new servives are able to return offset by keyframe, position or duration
depending of request parameter "OffsetType" { nil , "Position", "Duration" }