### PR TITLE
VAAPI: Don't try to crop frames, they have no real buffer attached.

### DIFF
--- a/mythtv/libs/libmythtv/videoout_opengl.cpp
+++ b/mythtv/libs/libmythtv/videoout_opengl.cpp
@@ -477,7 +477,10 @@ void VideoOutputOpenGL::ProcessFrame(VideoFrame *frame, OSD *osd,
         pauseframe = true;
     }
 
-    CropToDisplay(frame);
+    if (sw_frame)
+    {
+        CropToDisplay(frame);
+    }
 
     bool dummy = frame->dummy;
     if (filterList && sw_frame && !dummy)


### PR DESCRIPTION
The VAAPI playback is crippled with random segfaults occurring either after some time of playing or at the very first frame.
This is due to VideoOutput::CropToDisplay being applied on the fake frame buffers (VAAPI doesn't give direct access to the decoded frame buffer), ending up in heap space corruption.
It was introduced in commit 0a4e3e423d6604252aeb31f849085a00f9f4b2e9 to fix #11358.

This patch fixes it.
