### PR TITLE
Use a separate thread for recursive directory scans

### DIFF
--- a/mythplugins/mythgallery/mythgallery/glsingleview.h
+++ b/mythplugins/mythgallery/mythgallery/glsingleview.h
@@ -161,13 +161,10 @@ class GLSingleView : public QGLWidget, public ImageView
 class KenBurnsImageLoader : public MThread
 {
 public:
-    KenBurnsImageLoader(GLSingleView *singleView, ThumbList &itemList, QSize m_texSize, QSize m_screenSize);
-    void Initialize(int pos);
+    KenBurnsImageLoader(GLSingleView *singleView, QSize m_texSize, QSize m_screenSize);
     void run();
 private:
     GLSingleView *m_singleView;
-    ThumbList     m_itemList;
-    int           m_pos;
     bool          m_tex1First;
     QSize         m_screenSize;
     QSize         m_texSize;

--- a/mythplugins/mythgallery/mythgallery/imageview.cpp
+++ b/mythplugins/mythgallery/mythgallery/imageview.cpp
@@ -18,18 +18,46 @@
  * 
  * ============================================================ */
 
+// STL headers
+#include <algorithm>
+
 // Qt headers
 #include <QDir>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QRunnable>
+#include <QWaitCondition>
 
 // MythTV plugin headers
 #include <mythcontext.h>
 #include <lcddevice.h>
+#include <mthread.h>
 #include <mythuihelper.h>
 
 // MythGallery headers
 #include "imageview.h"
 #include "galleryutil.h"
 #include "thumbgenerator.h"
+
+class ImageView::LoadAlbumRunnable : public QRunnable {
+    ImageView *m_parent;
+    ThumbList m_dirList;
+    int m_sortorder;
+    int m_slideshow_sequencing;
+    QMutex m_isAliveLock;
+    bool m_isAlive;
+
+public:
+    LoadAlbumRunnable(ImageView *parent, const ThumbList &roots, int sortorder,
+            int slideshow_sequencing);
+
+    void abort();
+    virtual void run();
+
+    /** Separate the input into files and directories */
+    static void filterDirectories(const ThumbList &input,
+            ThumbList &fileList, ThumbList &dirList);
+};
 
 ImageView::ImageView(const ThumbList &itemList,
                      int *pos, int slideShow, int sortorder)
@@ -38,7 +66,6 @@ ImageView::ImageView(const ThumbList &itemList,
       m_hmult(1.0f),
       m_pos(*pos),
       m_savedPos(pos),
-      m_itemList(itemList),
       m_movieState(0),
       m_zoom(1.0f),
 
@@ -50,7 +77,6 @@ ImageView::ImageView(const ThumbList &itemList,
       m_slideshow_running(false),
       m_slideshow_sequencing(slideShow),
       m_slideshow_sequencing_inc_order(sortorder),
-      m_slideshow_sequence(NULL),
       m_slideshow_frame_delay(2),
       m_slideshow_frame_delay_state(m_slideshow_frame_delay * 1000),
       m_slideshow_timer(NULL),
@@ -59,7 +85,13 @@ ImageView::ImageView(const ThumbList &itemList,
       m_effect_running(false),
       m_effect_current_frame(0),
       m_effect_method(QString::null),
-      m_effect_random(false)
+      m_effect_random(false),
+
+      m_loaderRunnable(NULL),
+      m_listener(this),
+      m_loaderThread(NULL),
+      m_itemList(itemList),
+      m_slideshow_sequence(NULL)
 {
 
     int xbase, ybase, screenwidth, screenheight;
@@ -72,27 +104,26 @@ ImageView::ImageView(const ThumbList &itemList,
     bool recurse = gCoreContext->GetNumSetting("GalleryRecursiveSlideshow", 0);
 
     ThumbItem *origItem = NULL;
-    if (m_pos < m_itemList.size())
-        origItem = m_itemList.at(m_pos);
+    if (m_pos < itemList.size())
+        origItem = itemList.at(m_pos);
 
-    // Load pictures from all directories if requested
-    for (int x = 0; recurse && x < m_itemList.size(); ++x)
-    {
-        ThumbItem *item = m_itemList.at(x);
-        if (item->IsDir())
-                GalleryUtil::LoadDirectory(m_itemList, item->GetPath(),
-                                           sortorder, recurse, NULL, NULL);
-    }
+    ThumbList fileList, dirList;
+    LoadAlbumRunnable::filterDirectories(itemList, fileList, dirList);
+    AddItems(fileList);
 
-    //remove all dirs from m_itemList;
-    for (int x = 0; x < m_itemList.size(); ++x)
+    if (recurse)
     {
-        ThumbItem *item = m_itemList.at(x);
-        if (item->IsDir())
-        {
-            m_itemList.takeAt(x);
-            --x;
-        }
+        // Load pictures from all directories on a different thread.
+        m_loaderRunnable = new LoadAlbumRunnable(this, dirList, sortorder,
+                                                 m_slideshow_sequencing);
+        m_loaderThread = new MThread("LoadAlbum", m_loaderRunnable);
+        QObject::connect(m_loaderThread->qthread(), SIGNAL(finished()),
+                &m_listener, SLOT(finishLoading()));
+        m_loaderThread->start();
+
+        // Wait for at least one image to be loaded.
+        QMutexLocker guard(&m_itemListLock);
+        m_imagesLoaded.wait(&m_itemListLock);
     }
 
     // --------------------------------------------------------------------
@@ -102,6 +133,7 @@ ImageView::ImageView(const ThumbList &itemList,
         m_pos = m_itemList.indexOf(origItem);
 
     m_pos = (!origItem || (m_pos == -1)) ? 0 : m_pos;
+    m_pos = m_slideshow_sequence->index(m_pos);
 
     // --------------------------------------------------------------------
 
@@ -114,27 +146,37 @@ ImageView::ImageView(const ThumbList &itemList,
 
     if (slideShow > 1)
     {
-        m_slideshow_sequence = new SequenceShuffle(m_itemList.size());
         m_slideshow_mode = QT_TR_NOOP("Random Slideshow");
-        m_pos = 0;
     }
     else
     {
-        m_slideshow_sequence = new SequenceInc(m_itemList.size());
         m_slideshow_mode = QT_TR_NOOP("Slideshow");
     }
-
-    m_pos = m_slideshow_sequence->index(m_pos);
 }
 
 ImageView::~ImageView()
 {
     UpdateLCD(NULL);
+    if (m_loaderRunnable && m_loaderThread)
+    {
+        m_loaderRunnable->abort();
+        m_loaderThread->wait();
+    }
 
     if (m_slideshow_sequence)
     {
         delete m_slideshow_sequence;
         m_slideshow_sequence = NULL;
+    }
+
+    if (m_loaderRunnable) {
+        delete m_loaderRunnable;
+        m_loaderRunnable = NULL;
+    }
+
+    if (m_loaderThread) {
+        delete m_loaderThread;
+        m_loaderThread = NULL;
     }
 
     *m_savedPos = m_pos;
@@ -205,4 +247,131 @@ void ImageView::GetScreenShot(QImage& image, const ThumbItem *item)
             image = *img;
         }
     }
+}
+
+void ImageView::AddItems(const ThumbList &itemList)
+{
+    QMutexLocker guard(&m_itemListLock);
+
+    m_itemList.append(itemList);
+
+    if (m_slideshow_sequence)
+    {
+        delete m_slideshow_sequence;
+        m_slideshow_sequence = NULL;
+    }
+
+    if (m_slideshow_sequencing > 1)
+    {
+        m_slideshow_sequence = new SequenceShuffle(m_itemList.size());
+    }
+    else
+    {
+        m_slideshow_sequence = new SequenceInc(m_itemList.size());
+    }
+
+    if (!m_itemList.empty()) {
+        m_imagesLoaded.wakeAll();
+    }
+}
+
+ThumbItem *ImageView::getCurrentItem() const
+{
+    QMutexLocker guard(&m_itemListLock);
+    return m_itemList.at(m_pos);
+}
+
+ThumbItem *ImageView::advanceItem()
+{
+    QMutexLocker guard(&m_itemListLock);
+    m_pos = m_slideshow_sequence->next();
+    return m_itemList.at(m_pos);
+}
+
+ThumbItem *ImageView::retreatItem()
+{
+    QMutexLocker guard(&m_itemListLock);
+    m_pos = m_slideshow_sequence->prev();
+    return m_itemList.at(m_pos);
+}
+
+void ImageView::finishLoading()
+{
+    QMutexLocker guard(&m_itemListLock);
+    m_imagesLoaded.wakeAll();
+}
+
+ImageView::LoadAlbumRunnable::LoadAlbumRunnable(
+        ImageView *parent, const ThumbList &roots, int sortorder,
+        int slideshow_sequencing)
+    : m_parent(parent),
+      m_dirList(roots),
+      m_sortorder(sortorder),
+      m_slideshow_sequencing(slideshow_sequencing),
+      m_isAlive(true)
+{
+}
+
+/** Request that all processing stop */
+void ImageView::LoadAlbumRunnable::abort() {
+    QMutexLocker guard(&m_isAliveLock);
+    m_isAlive = false;
+}
+
+void ImageView::LoadAlbumRunnable::run()
+{
+    while (!m_dirList.empty())
+    {
+        ThumbItem *dir = m_dirList.takeFirst();
+        ThumbList children;
+        GalleryUtil::LoadDirectory(children, dir->GetPath(),
+                                   m_sortorder, false, NULL, NULL);
+
+        {
+            QMutexLocker guard(&m_isAliveLock);
+            if (!m_isAlive)
+            {
+                break;
+            }
+        }
+
+        // The first images should not always come from the first directory.
+        if (m_slideshow_sequencing > 1)
+        {
+            std::random_shuffle(children.begin(), children.end());
+        }
+
+        ThumbList fileList;
+        filterDirectories(children, fileList, m_dirList);
+        if (!fileList.empty())
+        {
+            m_parent->AddItems(fileList);
+        }
+    }
+}
+
+/** Separate the input into files and directories */
+void ImageView::LoadAlbumRunnable::filterDirectories(const ThumbList &input,
+        ThumbList &fileList, ThumbList &dirList)
+{
+    for (int i = 0; i < input.size(); ++i)
+    {
+        ThumbItem *item = input.at(i);
+        ThumbList &targetList = item->IsDir() ? dirList : fileList;
+        targetList.append(item);
+    }
+}
+
+LoadAlbumListener::LoadAlbumListener(ImageView *parent)
+    : m_parent(parent)
+{
+}
+
+LoadAlbumListener::~LoadAlbumListener()
+{
+}
+
+void LoadAlbumListener::finishLoading() const
+{
+    m_parent->finishLoading();
 }

--- a/mythplugins/mythgallery/mythgallery/imageview.h
+++ b/mythplugins/mythgallery/mythgallery/imageview.h
@@ -124,6 +124,7 @@ private:
     mutable QMutex         m_itemListLock;
     ThumbList              m_itemList;
     SequenceBase          *m_slideshow_sequence;
+    bool                   m_finishedLoading;
 };
 
 #endif /* IMAGEVIEW_H */

--- a/mythplugins/mythgallery/mythgallery/singleview.cpp
+++ b/mythplugins/mythgallery/mythgallery/singleview.cpp
@@ -187,7 +187,7 @@ void SingleView::paintEvent(QPaintEvent *)
     {
         m_movieState = 2;
 
-        ThumbItem *item = m_itemList.at(m_pos);
+        ThumbItem *item = getCurrentItem();
 
         if (item)
             GalleryUtil::PlayVideo(item->GetPath());
@@ -248,7 +248,7 @@ void SingleView::paintEvent(QPaintEvent *)
             }
             else if (m_caption_show && !m_caption_timer->isActive())
             {
-                ThumbItem *item = m_itemList.at(m_pos);
+                ThumbItem *item = getCurrentItem();
                 if (!item->HasCaption())
                     item->InitCaption(true);
 
@@ -307,7 +307,7 @@ void SingleView::paintEvent(QPaintEvent *)
 
                 QPainter p(&pix);
                 p.initFrom(this);
-                ThumbItem *item = m_itemList.at(m_pos);
+                ThumbItem *item = getCurrentItem();
                 QString info = QString::null;
                 if (item)
                 {
@@ -489,7 +489,7 @@ void SingleView::keyPressEvent(QKeyEvent *e)
         }
         else if (action == "DELETE")
         {
-            ThumbItem *item = m_itemList.at(m_pos);
+            ThumbItem *item = getCurrentItem();
             if (item && GalleryUtil::Delete(item->GetPath()))
             {
                 item->SetPixmap(NULL);
@@ -566,8 +566,7 @@ void SingleView::DisplayNext(bool reset, bool loadImage)
     int oldpos = m_pos;
     while (true)
     {
-        m_pos = m_slideshow_sequence->next();
-        item = m_itemList.at(m_pos);
+        item = advanceItem();
         if (item)
         {
             if (QFile::exists(item->GetPath()))
@@ -600,9 +599,7 @@ void SingleView::DisplayPrev(bool reset, bool loadImage)
     int oldpos = m_pos;
     while (true)
     {
-        m_pos = m_slideshow_sequence->prev();
-
-        ThumbItem *item = m_itemList.at(m_pos);
+        ThumbItem *item = retreatItem();
         if (item && QFile::exists(item->GetPath()))
             break;
 
@@ -623,7 +620,7 @@ void SingleView::Load(void)
 
     SetPixmap(NULL);
 
-    ThumbItem *item = m_itemList.at(m_pos);
+    ThumbItem *item = getCurrentItem();
     if (!item)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + QString("No item at %1").arg(m_pos));
@@ -660,7 +657,7 @@ void SingleView::Rotate(int angle)
     m_angle = (m_angle >= 360) ? m_angle - 360 : m_angle;
     m_angle = (m_angle < 0)    ? m_angle + 360 : m_angle;
 
-    ThumbItem *item = m_itemList.at(m_pos);
+    ThumbItem *item = getCurrentItem();
     if (item)
         item->SetRotationAngle(m_angle);
 


### PR DESCRIPTION
Slideshows can take a long time to start if there are lots of files and directories in the album tree. The solution is to scan the album on a different thread while the slideshow is already running. This makes the `imageview` more complicated, because of the inter-thread coordination. Fortunately the changes can mostly be contained in the `imageview`. The benefits to the user are noticeable.