### PR TITLE
UPnP - Fix broken FFWD/REW/JUMP in playback for recordings with startoffset

### DIFF
--- a/mythtv/programs/mythbackend/upnpcdstv.cpp
+++ b/mythtv/programs/mythbackend/upnpcdstv.cpp
@@ -426,7 +426,7 @@ void UPnpCDSTv::AddItem( const UPnpCDSRequest    *pRequest,
     query2.prepare( "SELECT data FROM recordedmarkup WHERE chanid=:CHANID AND "
                     "starttime=:STARTTIME AND type = 33" );
     query2.bindValue(":CHANID", (int)nChanid);
-    query2.bindValue(":STARTTIME", dtProgStart);
+    query2.bindValue(":STARTTIME", dtStartTime);
     if (query2.exec() && query2.next())
         uiDur = query2.value(0).toUInt() / 1000;
 


### PR DESCRIPTION
I would like to propose this simple fix that affects some LG SmartTV DLNA clients. I think it can be applied to current stable branch as bugfix and definitely to the master branch. This fixes error in playback navigation through FFWD/REW buttons and through the navigation bar. The patch replaces dtProgStart by dtStartTime in the query into recordedmarkup table.

Without this patch, and if the recording is recorded with non-zero startoffset, dtProgStart differ from dtStartTime and the query fails. Correct playback duration is not found and asfallback, the duration attribute for <res/> tag is filled by the value from EIT data, which may differ from the actual length of playback. The DLNA client concerned, unfortunately relies on duration attribute, and the playback navigation is then completely broken. 

If the patch is applied, the correct playback duration is send to the DLNA client and it works without problems.

These are clients affected : LG SmartTV series 2012, probably also other series that share the same code, 2011 and 2013. Windows Media Player is not affected.

Symptoms : If you Jump forward (with FFWD button) or jump backward (with RWND button) or you navigate through the recording using the navigation bar, the playback jumps to the position that seems not to be related to where you intended to jump. Sometimes forward jump might go backwards and vice versa. It is quite frustrating. Consequently, WAF is completely ruined.

I have tested this well with current stable build from mythbuntu distribution 2:0.27.1+fixes.20140612.050bf9d.
