### PR TITLE
UPnP - Avoid showing deleted recordings

### DIFF
--- a/mythtv/libs/libmythupnp/upnpcds.h
+++ b/mythtv/libs/libmythupnp/upnpcds.h
@@ -196,6 +196,7 @@ class UPNP_PUBLIC UPnpCDSExtension
         virtual QString          GetTableName  ( QString sColumn      ) = 0;
         virtual QString          GetItemListSQL( QString sColumn = "" ) = 0;
         virtual void             BuildItemQuery( MSqlQuery &query, const QStringMap &mapParams ) = 0;
+        virtual QString          BuildSQLWhere ( QString sColumn, QString sWhere = "" );
 
         virtual void       AddItem( const UPnpCDSRequest    *pRequest,
                                     const QString           &sObjectId,

--- a/mythtv/programs/mythbackend/upnpcdstv.cpp
+++ b/mythtv/programs/mythbackend/upnpcdstv.cpp
@@ -173,6 +173,21 @@ void UPnpCDSTv::BuildItemQuery( MSqlQuery &query, const QStringMap &mapParams )
 //
 /////////////////////////////////////////////////////////////////////////////
 
+QString UPnpCDSTv::BuildSQLWhere ( QString sColumn, QString sWhere )
+{
+    if ( sColumn != "recgroup" )
+    {
+        if ( sWhere == "" ) sWhere = "recgroup <> 'Deleted'";
+        else sWhere += " AND recgroup <> 'Deleted'";
+    }
+
+    return UPnpCDSExtension::BuildSQLWhere ( sColumn, sWhere );
+}
+
+/////////////////////////////////////////////////////////////////////////////
+//
+/////////////////////////////////////////////////////////////////////////////
+
 bool UPnpCDSTv::IsBrowseRequestForUs( UPnpCDSRequest *pRequest )
 {
     // ----------------------------------------------------------------------

--- a/mythtv/programs/mythbackend/upnpcdstv.h
+++ b/mythtv/programs/mythbackend/upnpcdstv.h
@@ -36,6 +36,7 @@ class UPnpCDSTv : public UPnpCDSExtension
         virtual int              GetRootCount  ( );
         virtual QString          GetTableName  ( QString sColumn );
         virtual QString          GetItemListSQL( QString sColumn = "" );
+        virtual QString          BuildSQLWhere ( QString sColumn, QString sWhere = "" );
 
         virtual void             BuildItemQuery( MSqlQuery        &query,
                                                  const QStringMap &mapParams );


### PR DESCRIPTION
Deleted recordings are now moved to "Deleted" recgroup. This was not reflected in UPnP code yet, so they are normally visible in UPnP client.

With this patch, UPnP behaves as Mythweb. That is, deleted recordings are not visible anywhere except for the Deleted recording group.
