### PR TITLE
UPnP - add different groupings for content in video

### DIFF
--- a/mythtv/programs/mythbackend/upnpcdsvideo.cpp
+++ b/mythtv/programs/mythbackend/upnpcdsvideo.cpp
@@ -31,14 +31,151 @@ UPnpCDSRootInfo UPnpCDSVideo::g_RootNodes[] =
             "FROM videometadata "
             "%1 "
             "ORDER BY title",
-        "", "title" }
+        "", "title" },
+
+    {   "By Folder", 
+        "fldr.folder",
+        "SELECT "
+            "fldr.folder          AS id, "
+            "fldr.folder          AS name, "
+            "COUNT( fldr.folder ) AS children "
+          "FROM ( "
+            "SELECT "
+                "SUBSTRING_INDEX(SUBSTRING_INDEX(filename,'/',-2),'/',1) "
+                  "AS folder "
+              "FROM videometadata "
+          ") AS fldr "
+          "%1 "
+          "GROUP BY fldr.folder "
+          "ORDER BY fldr.folder",
+        "WHERE fldr.folder =  :KEY", "title" },
+
+    {   "By Length (10min int)",
+        "ROUND(length+4,-1)",
+        "SELECT "
+            "ROUND(length+4,-1)          AS id, "
+            "ROUND(length+4,-1)          AS name, "
+            "COUNT( ROUND(length+4,-1) ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY name "
+          "ORDER BY ROUND(length+4,-1)",
+        "WHERE ROUND(length+4,-1) = :KEY", "title" },
+
+    {   "By User Rating (rounded)", 
+        "ROUND(userrating)",
+        "SELECT "
+            "ROUND(userrating)          AS id, "
+            "ROUND(userrating)          AS name, "
+            "COUNT( ROUND(userrating) ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY ROUND(userrating) "
+          "ORDER BY ROUND(userrating)",
+        "WHERE ROUND(userrating)=ROUND(:KEY)", "title" },
+
+    {   "By Maturity Rating", 
+        "rating",
+        "SELECT "
+            "rating          AS id, "
+            "rating          AS name, "
+            "COUNT( rating ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY rating "
+          "ORDER BY rating",
+        "WHERE rating=:KEY", "title" },
+
+    {   "By Category", 
+        "category",
+        "SELECT "
+            "videometadata.category          AS id, "
+            "videocategory.category          AS name, "
+            "COUNT( videometadata.category ) AS children "
+          "FROM videometadata "
+            "LEFT JOIN videocategory ON videocategory.intid = videometadata.category "
+          "%1 "
+          "GROUP BY videometadata.category "
+          "ORDER BY videometadata.category",
+        "WHERE videometadata.category=:KEY", "title" },
+
+    {   "By Director", 
+        "director",
+        "SELECT "
+            "director          AS id, "
+            "director          AS name, "
+            "COUNT( director ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY director "
+          "ORDER BY director",
+        "WHERE director=:KEY", "title" },
+
+    {   "By Studio", 
+        "studio",
+        "SELECT "
+            "studio          AS id, "
+            "studio          AS name, "
+            "COUNT( studio ) AS children "
+          "FROM videometadata "
+            "%1 "
+            "GROUP BY studio "
+            "ORDER BY studio",
+        "WHERE studio=:KEY", "title" },
+
+    {   "By Homepage", 
+        "homepage",
+        "SELECT "
+            "homepage          AS id, "
+            "homepage          AS name, "
+            "COUNT( homepage ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY homepage "
+          "ORDER BY homepage",
+        "WHERE homepage=:KEY", "title" },
+
+    {   "By Year", 
+        "year",
+        "SELECT "
+            "year          AS id, "
+            "year          AS name, "
+            "COUNT( year ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY year "
+          "ORDER BY year",
+        "WHERE year=:KEY", "title" },
+
+    {   "By Content Type", 
+        "contenttype",
+        "SELECT "
+            "contenttype          AS id, "
+            "contenttype          AS name, "
+            "COUNT( contenttype ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY contenttype "
+          "ORDER BY contenttype",
+        "WHERE contenttype=:KEY", "title" },
+
+    {   "By Season", 
+        "season",
+        "SELECT "
+            "season          AS id, "
+            "season          AS name, "
+            "COUNT( season ) AS children "
+          "FROM videometadata "
+          "%1 "
+          "GROUP BY season "
+          "ORDER BY season",
+        "WHERE season=:KEY", "title" }
+
 
 };
 
-int UPnpCDSVideo::g_nRootCount = 1;
-
-//int UPnpCDSVideo::g_nRootCount;
-// = sizeof( g_RootNodes ) / sizeof( UPnpCDSRootInfo );
+int UPnpCDSVideo::g_nRootCount
+  = sizeof( UPnpCDSVideo::g_RootNodes ) / sizeof( UPnpCDSRootInfo );
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -67,7 +204,11 @@ int UPnpCDSVideo::GetRootCount()
 
 QString UPnpCDSVideo::GetTableName( QString sColumn )
 {
-    return "videometadata";
+    if(sColumn == "fldr.folder")
+        return "( SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(filename,'/',-2),'/',1) "
+                           "AS folder from videometadata ) "
+               "AS fldr";
+    else return "videometadata";
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -76,9 +217,24 @@ QString UPnpCDSVideo::GetTableName( QString sColumn )
 
 QString UPnpCDSVideo::GetItemListSQL( QString sColumn )
 {
-    return "SELECT intid, title, subtitle, filename, director, plot, "
-            "rating, year, userrating, length, " 
-            "season, episode, coverfile, insertdate, host FROM videometadata";
+    return
+      "SELECT "
+          "videometadata.intid, title, subtitle, filename, director, plot, "
+          "rating, year, userrating, length, "
+          "season, episode, coverfile, insertdate, host, "
+          "category, studio, collectionref, homepage, contenttype, "
+          "round(length+4,-1) AS length10, "
+          "fldr.folder AS folder , " 
+          "playcount "
+        "FROM videometadata "
+           "INNER JOIN ( "
+             "SELECT "
+                 "intid,SUBSTRING_INDEX(SUBSTRING_INDEX(filename,'/',-2),'/',1) "
+                   "AS folder "
+               "FROM videometadata "
+           ") AS fldr ON fldr.intid=videometadata.intid"
+            ;
+
 
 }
 
@@ -213,18 +369,7 @@ bool UPnpCDSVideo::IsSearchRequestForUs( UPnpCDSRequest *pRequest )
 
 int UPnpCDSVideo::GetDistinctCount( UPnpCDSRootInfo *pInfo )
 {
-    int nCount = 0;
-
-    MSqlQuery query(MSqlQuery::InitCon());
-
-    query.prepare("SELECT COUNT(*) FROM videometadata");
-
-    if (query.exec() && query.next())
-    {
-        nCount = query.value(0).toInt();
-    }
-
-    return nCount;
+    return UPnpCDSExtension::GetDistinctCount( pInfo );
 }
 
 
@@ -255,6 +400,10 @@ void UPnpCDSVideo::AddItem( const UPnpCDSRequest    *pRequest,
     QDateTime      dtInsertDate =
         MythDate::as_utc(query.value(13).toDateTime());
     QString        sHostName    = query.value(14).toString();
+//    int            nCategory    = query.value(15).toInt();
+//    QString        sStudio      = query.value(16).toString();
+//    QString        sHomePage    = query.value(17).toString();
+//    QString        sContentType = query.value(18).toString();
 
     // ----------------------------------------------------------------------
     // Cache Host ip Address & Port


### PR DESCRIPTION
Video section in UPnP lack any sub-classification like in Recordings section. This makes it very hard to orient as soon as the user has more than a few videos. When I started to use MythTV as DLNA server,
this is what I lacked the most. Surprisingly it is extremely simple to add new grouping. The code is practically prepared for that, since the beginning. I  would be very happy to add this feature with my patch.

This patch adds eleven new groupings. these are :
- by folder (that is, by last directory name in which is the file located. i.e. not the full path)
- by length (rounded to nearest 10)
- by user rating (rounded to integer)
- by maturity rating (i.e. 12, 18, PG, etc.)
- by category
- by director
- by studio
- by homepage
- by year
- by content type
- by season

All these groupings are only 1 level groupings, but in my opinion quite useful. For example folder name in which the file resides is relatively useful classification. Grouping by length rounded to nearest divisible by 10 minutes usually groups together the same series, making them easy to find. Most of these groupings are based on videometadata table, which may be updated automatically or they may be filled manually with reasonable data.

I think even if somebody does not use all the groupings, it definitely does not harm to have it.
