### PR TITLE
QUERY_CUTLIST, QUERY_COMMBREAK

### DIFF
--- a/mythtv/libs/libmyth/programinfo.cpp
+++ b/mythtv/libs/libmyth/programinfo.cpp
@@ -3861,6 +3861,175 @@ void ProgramInfo::SavePositionMapDelta(
     }
 }
 
+static const char *from_filemarkup_offset_asc =
+    "SELECT mark, offset FROM filemarkup"
+    " WHERE filename = :PATH"
+    " AND type = :TYPE"
+    " AND mark >= :MARK"
+    " ORDER BY filename ASC, type ASC, mark ASC LIMIT 1;";
+static const char *from_filemarkup_offset_desc =
+    "SELECT mark, offset FROM filemarkup"
+    " WHERE filename = :PATH"
+    " AND type = :TYPE"
+    " AND mark <= :MARK"
+    " ORDER BY filename DESC, type DESC, mark DESC LIMIT 1;";
+static const char *from_recordedseek_offset_asc =
+    "SELECT mark, offset FROM recordedseek"
+    " WHERE chanid = :CHANID"
+    " AND starttime = :STARTTIME"
+    " AND type = :TYPE"
+    " AND mark >= :MARK"
+    " ORDER BY chanid ASC, starttime ASC, type ASC, mark ASC LIMIT 1;";
+static const char *from_recordedseek_offset_desc =
+    "SELECT mark, offset FROM recordedseek"
+    " WHERE chanid = :CHANID"
+    " AND starttime = :STARTTIME"
+    " AND type = :TYPE"
+    " AND mark <= :MARK"
+    " ORDER BY chanid DESC, starttime DESC, type DESC, mark DESC LIMIT 1;";
+    
+bool ProgramInfo::QueryKeyFramePosition(uint64_t *position, uint64_t keyframe, bool backwards) const
+{
+    MSqlQuery query(MSqlQuery::InitCon());
+
+    if (IsVideo())
+    {
+        if (backwards)
+            query.prepare(from_filemarkup_offset_desc);
+        else
+            query.prepare(from_filemarkup_offset_asc);
+        query.bindValue(":PATH", StorageGroup::GetRelativePathname(pathname));
+    }
+    else if (IsRecording())
+    {
+        if (backwards)
+            query.prepare(from_recordedseek_offset_desc);
+        else
+            query.prepare(from_recordedseek_offset_asc);
+        query.bindValue(":CHANID", chanid);
+        query.bindValue(":STARTTIME", recstartts);
+    }
+    query.bindValue(":TYPE", MARK_GOP_BYFRAME);
+    query.bindValue(":MARK", (unsigned long long)keyframe);
+
+    if (!query.exec())
+    {
+        MythDB::DBError("QueryKeyFramePosition", query);
+        return false;
+    }
+
+    if (query.next())
+    {
+        *position = query.value(1).toULongLong();
+        return true;
+    }
+
+    if (IsVideo())
+    {
+        if (backwards)
+            query.prepare(from_filemarkup_offset_asc);
+        else
+            query.prepare(from_filemarkup_offset_desc);
+        query.bindValue(":PATH", StorageGroup::GetRelativePathname(pathname));
+    }
+    else if (IsRecording())
+    {
+        if (backwards)
+            query.prepare(from_recordedseek_offset_asc);
+        else
+            query.prepare(from_recordedseek_offset_desc);
+        query.bindValue(":CHANID", chanid);
+        query.bindValue(":STARTTIME", recstartts);
+    }
+    query.bindValue(":TYPE", MARK_GOP_BYFRAME);
+    query.bindValue(":MARK", (unsigned long long)keyframe);
+
+    if (!query.exec())
+    {
+        MythDB::DBError("QueryKeyFramePosition", query);
+        return false;
+    }
+
+    if (query.next())
+    {
+        *position = query.value(1).toULongLong();
+        return true;
+    }
+
+    return false;
+}
+
+bool ProgramInfo::QueryKeyFrameDuration(uint64_t *duration, uint64_t keyframe, bool backwards) const
+{
+    MSqlQuery query(MSqlQuery::InitCon());
+
+    if (IsVideo())
+    {
+        if (backwards)
+            query.prepare(from_filemarkup_offset_desc);
+        else
+            query.prepare(from_filemarkup_offset_asc);
+        query.bindValue(":PATH", StorageGroup::GetRelativePathname(pathname));
+    }
+    else if (IsRecording())
+    {
+        if (backwards)
+            query.prepare(from_recordedseek_offset_desc);
+        else
+            query.prepare(from_recordedseek_offset_asc);
+        query.bindValue(":CHANID", chanid);
+        query.bindValue(":STARTTIME", recstartts);
+    }
+    query.bindValue(":TYPE", MARK_DURATION_MS);
+    query.bindValue(":MARK", (unsigned long long)keyframe);
+
+    if (!query.exec())
+    {
+        MythDB::DBError("QueryKeyFrameDuration", query);
+        return false;
+    }
+
+    if (query.next())
+    {
+        *duration = query.value(1).toULongLong();
+        return true;
+    }
+
+    if (IsVideo())
+    {
+        if (backwards)
+            query.prepare(from_filemarkup_offset_asc);
+        else
+            query.prepare(from_filemarkup_offset_desc);
+        query.bindValue(":PATH", StorageGroup::GetRelativePathname(pathname));
+    }
+    else if (IsRecording())
+    {
+        if (backwards)
+            query.prepare(from_recordedseek_offset_asc);
+        else
+            query.prepare(from_recordedseek_offset_desc);
+        query.bindValue(":CHANID", chanid);
+        query.bindValue(":STARTTIME", recstartts);
+    }
+    query.bindValue(":TYPE", MARK_DURATION_MS);
+    query.bindValue(":MARK", (unsigned long long)keyframe);
+
+    if (!query.exec())
+    {
+        MythDB::DBError("QueryKeyFrameDuration", query);
+        return false;
+    }
+
+    if (query.next())
+    {
+        *duration = query.value(1).toULongLong();
+        return true;
+    }
+
+    return false;
+}
+
 /// \brief Store aspect ratio of a frame in the recordedmark table
 /// \note  All frames until the next one with a stored aspect ratio
 ///        are assumed to have the same aspect ratio

--- a/mythtv/libs/libmyth/programinfo.h
+++ b/mythtv/libs/libmyth/programinfo.h
@@ -615,6 +615,10 @@ class MPUBLIC ProgramInfo
                          int64_t min_frm = -1, int64_t max_frm = -1) const;
     void SavePositionMapDelta(frm_pos_map_t &, MarkTypes type) const;
 
+    // Get position/duration for keyframe
+    bool QueryKeyFramePosition(uint64_t *, uint64_t keyframe, bool backwards) const;
+    bool QueryKeyFrameDuration(uint64_t *, uint64_t keyframe, bool backwards) const;
+
     // Get/set all markup
     struct MarkupEntry
     {

--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -781,17 +781,35 @@ void MainServer::ProcessRequestWork(MythSocket *sock)
     }
     else if (command == "QUERY_COMMBREAK")
     {
-        if (tokens.size() != 3)
-            LOG(VB_GENERAL, LOG_ERR, LOC + "Bad QUERY_COMMBREAK");
-        else
+        if (tokens.size() == 3)
             HandleCommBreakQuery(tokens[1], tokens[2], pbs);
+        else if (tokens.size() == 4)
+        {
+            if (tokens[3] == "Position")
+                HandleCommBreakQuery(tokens[1], tokens[2], pbs, 1);
+            else if (tokens[3] == "Duration")
+                HandleCommBreakQuery(tokens[1], tokens[2], pbs, 2);
+            else
+                HandleCommBreakQuery(tokens[1], tokens[2], pbs);
+        }
+        else
+            LOG(VB_GENERAL, LOG_ERR, LOC + "Bad QUERY_COMMBREAK");
     }
     else if (command == "QUERY_CUTLIST")
     {
-        if (tokens.size() != 3)
-            LOG(VB_GENERAL, LOG_ERR, LOC + "Bad QUERY_CUTLIST");
-        else
+        if (tokens.size() == 3)
             HandleCutlistQuery(tokens[1], tokens[2], pbs);
+        else if (tokens.size() == 4)
+        {
+            if (tokens[3] == "Position")
+                HandleCutlistQuery(tokens[1], tokens[2], pbs, 1);
+            else if (tokens[3] == "Duration")
+                HandleCutlistQuery(tokens[1], tokens[2], pbs, 2);
+            else
+                HandleCutlistQuery(tokens[1], tokens[2], pbs);
+        }
+        else
+            LOG(VB_GENERAL, LOG_ERR, LOC + "Bad QUERY_CUTLIST");
     }
     else if (command == "QUERY_BOOKMARK")
     {
@@ -5033,7 +5051,8 @@ bool MainServer::HandleDeleteFile(QString filename, QString storagegroup,
 // Helper function for the guts of HandleCommBreakQuery + HandleCutlistQuery
 void MainServer::HandleCutMapQuery(const QString &chanid,
                                    const QString &starttime,
-                                   PlaybackSock *pbs, bool commbreak)
+                                   PlaybackSock *pbs, bool commbreak,
+                                   int offsettype)
 {
     MythSocket *pbssock = NULL;
     if (pbs)
@@ -5056,10 +5075,36 @@ void MainServer::HandleCutMapQuery(const QString &chanid,
 
         for (it = markMap.begin(); it != markMap.end(); ++it)
         {
-            rowcnt++;
-            QString intstr = QString("%1").arg(*it);
-            retlist << intstr;
-            retlist << QString::number(it.key());
+            bool isend = ((*it) == MARK_CUT_END || (*it) == MARK_COMM_END) ? true : false;
+            if (offsettype == 0)
+            {
+                rowcnt++;
+                QString intstr = QString("%1").arg(*it);
+                retlist << intstr;
+                retlist << QString::number(it.key());
+            }
+            else if (offsettype == 1)
+            {
+                uint64_t offset;
+                if (pginfo.QueryKeyFramePosition(&offset, it.key(), isend))
+                {
+                  rowcnt++;
+                  QString intstr = QString("%1").arg(*it);
+                  retlist << intstr;
+                  retlist << QString::number(offset);
+                }
+            }
+            else if (offsettype == 2)
+            {
+                uint64_t offset;
+                if (pginfo.QueryKeyFrameDuration(&offset, it.key(), isend))
+                {
+                  rowcnt++;
+                  QString intstr = QString("%1").arg(*it);
+                  retlist << intstr;
+                  retlist << QString::number(offset);
+                }
+            }
         }
     }
 
@@ -5076,7 +5121,8 @@ void MainServer::HandleCutMapQuery(const QString &chanid,
 
 void MainServer::HandleCommBreakQuery(const QString &chanid,
                                       const QString &starttime,
-                                      PlaybackSock *pbs)
+                                      PlaybackSock *pbs,
+                                      int offsettype)
 {
 // Commercial break query
 // Format:  QUERY_COMMBREAK <chanid> <starttime>
@@ -5086,12 +5132,13 @@ void MainServer::HandleCommBreakQuery(const QString &chanid,
 // Return structure is [number of rows] followed by a triplet of values:
 //   each triplet : [type] [long portion 1] [long portion 2]
 // type is the value in the map, right now 4 = commbreak start, 5= end
-    return HandleCutMapQuery(chanid, starttime, pbs, true);
+    return HandleCutMapQuery(chanid, starttime, pbs, true, offsettype);
 }
 
 void MainServer::HandleCutlistQuery(const QString &chanid,
                                     const QString &starttime,
-                                    PlaybackSock *pbs)
+                                    PlaybackSock *pbs,
+                                    int offsettype)
 {
 // Cutlist query
 // Format:  QUERY_CUTLIST <chanid> <starttime>
@@ -5101,7 +5148,7 @@ void MainServer::HandleCutlistQuery(const QString &chanid,
 // Return structure is [number of rows] followed by a triplet of values:
 //   each triplet : [type] [long portion 1] [long portion 2]
 // type is the value in the map, right now 0 = commbreak start, 1 = end
-    return HandleCutMapQuery(chanid, starttime, pbs, false);
+    return HandleCutMapQuery(chanid, starttime, pbs, false, offsettype);
 }
 
 

--- a/mythtv/programs/mythbackend/mainserver.h
+++ b/mythtv/programs/mythbackend/mainserver.h
@@ -35,21 +35,21 @@ class FileSystemInfo;
 class MetadataFactory;
 class FreeSpaceUpdater;
 
-class DeleteStruct 
+class DeleteStruct
 {
     friend class MainServer;
   public:
     DeleteStruct(MainServer *ms, QString filename, QString title,
-                 uint chanid, QDateTime recstartts, QDateTime recendts, 
-                 bool forceMetadataDelete) : 
-        m_ms(ms), m_filename(filename), m_title(title), 
-        m_chanid(chanid), m_recstartts(recstartts), 
+                 uint chanid, QDateTime recstartts, QDateTime recendts,
+                 bool forceMetadataDelete) :
+        m_ms(ms), m_filename(filename), m_title(title),
+        m_chanid(chanid), m_recstartts(recstartts),
         m_recendts(recendts),
         m_forceMetadataDelete(forceMetadataDelete), m_fd(-1), m_size(0)
     {
     }
 
-    DeleteStruct(MainServer *ms, QString filename, int fd, off_t size) : 
+    DeleteStruct(MainServer *ms, QString filename, int fd, off_t size) :
         m_ms(ms), m_filename(filename), m_chanid(0),
         m_forceMetadataDelete(false), m_fd(fd), m_size(size)
     {
@@ -71,7 +71,7 @@ class DeleteThread : public QRunnable, public DeleteStruct
 {
   public:
     DeleteThread(MainServer *ms, QString filename, QString title, uint chanid,
-                 QDateTime recstartts, QDateTime recendts, 
+                 QDateTime recstartts, QDateTime recendts,
                  bool forceMetadataDelete) :
                      DeleteStruct(ms, filename, title, chanid, recstartts,
                                   recendts, forceMetadataDelete)  {}
@@ -163,7 +163,7 @@ class MainServer : public QObject, public MythSocketCBs
     void HandleUndeleteRecording(QStringList &slist, PlaybackSock *pbs);
     void DoHandleUndeleteRecording(RecordingInfo &recinfo, PlaybackSock *pbs);
     void HandleForgetRecording(QStringList &slist, PlaybackSock *pbs);
-    void HandleRescheduleRecordings(const QStringList &request, 
+    void HandleRescheduleRecordings(const QStringList &request,
                                     PlaybackSock *pbs);
     void HandleGoToSleep(PlaybackSock *pbs);
     void HandleQueryFreeSpace(PlaybackSock *pbs, bool allBackends);
@@ -205,11 +205,11 @@ class MainServer : public QObject, public MythSocketCBs
     void HandleLockTuner(PlaybackSock *pbs, int cardid = -1);
     void HandleFreeTuner(int cardid, PlaybackSock *pbs);
     void HandleCutMapQuery(const QString &chanid, const QString &starttime,
-                           PlaybackSock *pbs, bool commbreak);
+                           PlaybackSock *pbs, bool commbreak, int offsettype = 0);
     void HandleCommBreakQuery(const QString &chanid, const QString &starttime,
-                              PlaybackSock *pbs);
+                              PlaybackSock *pbs, int offsettype = 0);
     void HandleCutlistQuery(const QString &chanid, const QString &starttime,
-                            PlaybackSock *pbs);
+                            PlaybackSock *pbs, int offsettype = 0);
     void HandleBookmarkQuery(const QString &chanid, const QString &starttime,
                              PlaybackSock *pbs);
     void HandleSetBookmark(QStringList &tokens, PlaybackSock *pbs);


### PR DESCRIPTION
Return 'offset' also by position or duration depending of optional request parameter { "Position", "Duration" }
Without optional parameter, commands keep same behavior returning framecount.
