### PR TITLE
UPnP : Fix recordings thumbnail images broken in some clients

### DIFF
--- a/mythtv/programs/mythbackend/upnpcdstv.cpp
+++ b/mythtv/programs/mythbackend/upnpcdstv.cpp
@@ -465,10 +465,10 @@ void UPnpCDSTv::AddItem( const UPnpCDSRequest    *pRequest,
 
     sURI = QString( "%1GetPreviewImage%2%3").arg( sURIBase   )
                                             .arg( sURIParams )
-                                            .arg( "&amp;Width=160" );
+                                            .arg( "&amp;Width=160&amp;Format=JPG" );
 
-    // TODO: Must be JPG for minimal compliance
-    sProtocol = QString( "http-get:*:image/png:DLNA.ORG_PN=PNG_TN");
+    // Must be JPG for minimal compliance
+    sProtocol = QString( "http-get:*:image/png:DLNA.ORG_PN=JPEG_TN");
     pItem->AddResource( sProtocol, sURI );
 
     // ----------------------------------------------------------------------
@@ -480,7 +480,7 @@ void UPnpCDSTv::AddItem( const UPnpCDSRequest    *pRequest,
                                               .arg( sInetRef   );
 
     QList<Property*> propList = pItem->GetProperties("albumArtURI");
-    if (propList.size() >= 4)
+    if (propList.size() >= 4  && sInetRef != "")
     {
         // Prefer JPEG over PNG here, although PNG is allowed JPEG probably
         // has wider device support and crucially the filesizes are smaller


### PR DESCRIPTION
Thumbnails functionality in UPnP in Recordings section was recently added (or fixed) in master branch by commit https://github.com/MythTV/mythtv/commit/378fe051f1d96d4e341391a1a21c6f0adec83f65

Unfortunately, this solution does not work with all clients, for example with my LG SmartTV client.

The first problem is that my client accepts only JPG thumbnails. Fortunately, another recent commit :

  https://github.com/MythTV/mythtv/commit/d2a14f2366e362e40c8a98bd1b0bcd9f0fd3d56a

added support to JPG into services API, so it is easy to fix the &lt;res/&gt; tag so that it would produce JPG thumbnail. (this is marked with TODO in original code, so it is right time to implements this)

The second problem is, that the original commit have also re-worked the &lt;albumArtURI/&gt; so that it produces output based on API

Content/GetRecordingArtwork?Type=coverart?Inetref=

This intends to take the artwork downloaded from Internet and use it as thumbnail. In my case, unfortunately, Inetref is empty for most recordings, and even if Inetref is non-empty, no artwork image is present, so it never works. To make this worse, presence of this tag beats any thumbnails based on <res/> tag for my UPnP client, so &lt;res/&gt; tag, which is fixed above, is ignored in all cases. This means, that I never see any thumbnail for any recording at all, even if res tag is fixed. So, I propose to place test of emptiness of sInetRef variable into the code. If it is empty, no &lt;albumArtURI/&gt; tag would be produced (in patch). Ideally another test should be added whether the image file for album art exists and whether is jpeg type (not in patch).
