### PR TITLE
Random slideshow with a seasonal theme

### DIFF
--- a/mythplugins/mythgallery/mythgallery/galleryutil.h
+++ b/mythplugins/mythgallery/mythgallery/galleryutil.h
@@ -20,6 +20,7 @@
 #ifndef GALLERYUTIL_H
 #define GALLERYUTIL_H
 
+#include <QDateTime>
 #include <QFileInfo>
 
 #include "iconview.h"
@@ -44,6 +45,7 @@ class GalleryUtil
     static long GetNaturalRotation(const QString &filePath);
 
     static QString GetCaption(const QString &filePath);
+    static QDateTime GetTimestamp(const QString &filePath);
 
     static bool LoadDirectory(ThumbList &itemList, const QString &dir,
                               const GalleryFilter& flt, bool recurse,

--- a/mythplugins/mythgallery/mythgallery/glsingleview.cpp
+++ b/mythplugins/mythgallery/mythgallery/glsingleview.cpp
@@ -453,7 +453,7 @@ void GLSingleView::keyPressEvent(QKeyEvent *e)
             m_movieState = 1;
         }
         else if (action == "PLAY" || action == "SLIDESHOW" ||
-                 action == "RANDOMSHOW")
+                 action == "RANDOMSHOW" || action == "SEASONALSHOW")
         {
             m_source_x   = 0;
             m_source_y   = 0;

--- a/mythplugins/mythgallery/mythgallery/glsingleview.h
+++ b/mythplugins/mythgallery/mythgallery/glsingleview.h
@@ -161,13 +161,10 @@ class GLSingleView : public QGLWidget, public ImageView
 class KenBurnsImageLoader : public MThread
 {
 public:
-    KenBurnsImageLoader(GLSingleView *singleView, ThumbList &itemList, QSize m_texSize, QSize m_screenSize);
-    void Initialize(int pos);
+    KenBurnsImageLoader(GLSingleView *singleView, QSize m_texSize, QSize m_screenSize);
     void run();
 private:
     GLSingleView *m_singleView;
-    ThumbList     m_itemList;
-    int           m_pos;
     bool          m_tex1First;
     QSize         m_screenSize;
     QSize         m_texSize;

--- a/mythplugins/mythgallery/mythgallery/iconview.cpp
+++ b/mythplugins/mythgallery/mythgallery/iconview.cpp
@@ -45,6 +45,7 @@ using namespace std;
 #include <mythmediamonitor.h>
 
 // MythGallery headers
+#include "config.h"
 #include "galleryutil.h"
 #include "gallerysettings.h"
 #include "galleryfilter.h"
@@ -474,6 +475,8 @@ bool IconView::keyPressEvent(QKeyEvent *event)
                 HandleSlideShow();
             else if (action == "RANDOMSHOW")
                 HandleRandomShow();
+            else if (action == "SEASONALSHOW")
+                HandleSeasonalShow();
             else
                 handled = false;
         }
@@ -572,6 +575,13 @@ void IconView::HandleRandomShow(void)
     SetFocusWidget(m_imageList);
 }
 
+void IconView::HandleSeasonalShow(void)
+{
+    HandleImageSelect("SEASONALSHOW");
+
+    SetFocusWidget(m_imageList);
+}
+
 bool IconView::HandleImageSelect(const QString &action)
 {
     ThumbItem *thumbitem = GetCurrentThumb();
@@ -580,7 +590,8 @@ bool IconView::HandleImageSelect(const QString &action)
         return false;
 
     int slideShow = ((action == "PLAY" || action == "SLIDESHOW") ? 1 :
-                     (action == "RANDOMSHOW") ? 2 : 0);
+                     (action == "RANDOMSHOW") ? 2 :
+                     (action == "SEASONALSHOW" ? 3 : 0));
 
     int pos = m_imageList->GetCurrentPos();
 
@@ -795,16 +806,24 @@ void IconView::customEvent(QEvent *event)
                 case 1:
                     HandleRandomShow();
                     break;
+#ifdef EXIF_SUPPORT
                 case 2:
+                    HandleSeasonalShow();
                     break;
-                case 3:
+#define BUTTONNUM_OFFSET 1
+#else // !EXIF_SUPPORT
+#define BUTTONNUM_OFFSET 0
+#endif // !EXIF_SUPPORT
+                case 2 + BUTTONNUM_OFFSET:
                     break;
-                case 4:
+                case 3 + BUTTONNUM_OFFSET:
+                    break;
+                case 4 + BUTTONNUM_OFFSET:
                     HandleSubMenuFilter();
                     break;
-                case 5:
+                case 5 + BUTTONNUM_OFFSET:
                     break;
-                case 6:
+                case 6 + BUTTONNUM_OFFSET:
                     HandleSettings();
                     break;
             }
@@ -889,6 +908,9 @@ void IconView::HandleMainMenu(void)
 
     menu->AddItem(tr("SlideShow"));
     menu->AddItem(tr("Random"));
+#ifdef EXIF_SUPPORT
+    menu->AddItem(tr("Seasonal"));
+#endif // EXIF_SUPPORT
     menu->AddItem(tr("Meta Data Options"), NULL, CreateMetadataMenu());
     menu->AddItem(tr("Marking Options"), NULL, CreateMarkingMenu());
     menu->AddItem(tr("Filter / Sort..."));

--- a/mythplugins/mythgallery/mythgallery/iconview.h
+++ b/mythplugins/mythgallery/mythgallery/iconview.h
@@ -61,6 +61,7 @@ class IconView : public MythScreenType
     bool keyPressEvent(QKeyEvent *);
     void customEvent(QEvent*);
     void HandleRandomShow(void);
+    void HandleSeasonalShow(void);
 
     QString GetError(void) { return m_errorStr; }
 

--- a/mythplugins/mythgallery/mythgallery/imageview.cpp
+++ b/mythplugins/mythgallery/mythgallery/imageview.cpp
@@ -18,18 +18,46 @@
  * 
  * ============================================================ */
 
+// STL headers
+#include <algorithm>
+
 // Qt headers
 #include <QDir>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QRunnable>
+#include <QWaitCondition>
 
 // MythTV plugin headers
 #include <mythcontext.h>
 #include <lcddevice.h>
+#include <mthread.h>
 #include <mythuihelper.h>
 
 // MythGallery headers
 #include "imageview.h"
 #include "galleryutil.h"
 #include "thumbgenerator.h"
+
+class ImageView::LoadAlbumRunnable : public QRunnable {
+    ImageView *m_parent;
+    ThumbList m_dirList;
+    int m_sortorder;
+    int m_slideshow_sequencing;
+    QMutex m_isAliveLock;
+    bool m_isAlive;
+
+public:
+    LoadAlbumRunnable(ImageView *parent, const ThumbList &roots, int sortorder,
+            int slideshow_sequencing);
+
+    void abort();
+    virtual void run();
+
+    /** Separate the input into files and directories */
+    static void filterDirectories(const ThumbList &input,
+            ThumbList &fileList, ThumbList &dirList);
+};
 
 ImageView::ImageView(const ThumbList &itemList,
                      int *pos, int slideShow, int sortorder)
@@ -38,7 +66,6 @@ ImageView::ImageView(const ThumbList &itemList,
       m_hmult(1.0f),
       m_pos(*pos),
       m_savedPos(pos),
-      m_itemList(itemList),
       m_movieState(0),
       m_zoom(1.0f),
 
@@ -50,7 +77,6 @@ ImageView::ImageView(const ThumbList &itemList,
       m_slideshow_running(false),
       m_slideshow_sequencing(slideShow),
       m_slideshow_sequencing_inc_order(sortorder),
-      m_slideshow_sequence(NULL),
       m_slideshow_frame_delay(2),
       m_slideshow_frame_delay_state(m_slideshow_frame_delay * 1000),
       m_slideshow_timer(NULL),
@@ -59,7 +85,13 @@ ImageView::ImageView(const ThumbList &itemList,
       m_effect_running(false),
       m_effect_current_frame(0),
       m_effect_method(QString::null),
-      m_effect_random(false)
+      m_effect_random(false),
+
+      m_loaderRunnable(NULL),
+      m_listener(this),
+      m_loaderThread(NULL),
+      m_itemList(itemList),
+      m_slideshow_sequence(NULL)
 {
 
     int xbase, ybase, screenwidth, screenheight;
@@ -72,27 +104,26 @@ ImageView::ImageView(const ThumbList &itemList,
     bool recurse = gCoreContext->GetNumSetting("GalleryRecursiveSlideshow", 0);
 
     ThumbItem *origItem = NULL;
-    if (m_pos < m_itemList.size())
-        origItem = m_itemList.at(m_pos);
+    if (m_pos < itemList.size())
+        origItem = itemList.at(m_pos);
 
-    // Load pictures from all directories if requested
-    for (int x = 0; recurse && x < m_itemList.size(); ++x)
-    {
-        ThumbItem *item = m_itemList.at(x);
-        if (item->IsDir())
-                GalleryUtil::LoadDirectory(m_itemList, item->GetPath(),
-                                           sortorder, recurse, NULL, NULL);
-    }
+    ThumbList fileList, dirList;
+    LoadAlbumRunnable::filterDirectories(itemList, fileList, dirList);
+    AddItems(fileList);
 
-    //remove all dirs from m_itemList;
-    for (int x = 0; x < m_itemList.size(); ++x)
+    if (recurse)
     {
-        ThumbItem *item = m_itemList.at(x);
-        if (item->IsDir())
-        {
-            m_itemList.takeAt(x);
-            --x;
-        }
+        // Load pictures from all directories on a different thread.
+        m_loaderRunnable = new LoadAlbumRunnable(this, dirList, sortorder,
+                                                 m_slideshow_sequencing);
+        m_loaderThread = new MThread("LoadAlbum", m_loaderRunnable);
+        QObject::connect(m_loaderThread->qthread(), SIGNAL(finished()),
+                &m_listener, SLOT(finishLoading()));
+        m_loaderThread->start();
+
+        // Wait for at least one image to be loaded.
+        QMutexLocker guard(&m_itemListLock);
+        m_imagesLoaded.wait(&m_itemListLock);
     }
 
     // --------------------------------------------------------------------
@@ -102,6 +133,7 @@ ImageView::ImageView(const ThumbList &itemList,
         m_pos = m_itemList.indexOf(origItem);
 
     m_pos = (!origItem || (m_pos == -1)) ? 0 : m_pos;
+    m_pos = m_slideshow_sequence->index(m_pos);
 
     // --------------------------------------------------------------------
 
@@ -114,27 +146,37 @@ ImageView::ImageView(const ThumbList &itemList,
 
     if (slideShow > 1)
     {
-        m_slideshow_sequence = new SequenceShuffle(m_itemList.size());
         m_slideshow_mode = QT_TR_NOOP("Random Slideshow");
-        m_pos = 0;
     }
     else
     {
-        m_slideshow_sequence = new SequenceInc(m_itemList.size());
         m_slideshow_mode = QT_TR_NOOP("Slideshow");
     }
-
-    m_pos = m_slideshow_sequence->index(m_pos);
 }
 
 ImageView::~ImageView()
 {
     UpdateLCD(NULL);
+    if (m_loaderRunnable && m_loaderThread)
+    {
+        m_loaderRunnable->abort();
+        m_loaderThread->wait();
+    }
 
     if (m_slideshow_sequence)
     {
         delete m_slideshow_sequence;
         m_slideshow_sequence = NULL;
+    }
+
+    if (m_loaderRunnable) {
+        delete m_loaderRunnable;
+        m_loaderRunnable = NULL;
+    }
+
+    if (m_loaderThread) {
+        delete m_loaderThread;
+        m_loaderThread = NULL;
     }
 
     *m_savedPos = m_pos;
@@ -205,4 +247,131 @@ void ImageView::GetScreenShot(QImage& image, const ThumbItem *item)
             image = *img;
         }
     }
+}
+
+void ImageView::AddItems(const ThumbList &itemList)
+{
+    QMutexLocker guard(&m_itemListLock);
+
+    m_itemList.append(itemList);
+
+    if (m_slideshow_sequence)
+    {
+        delete m_slideshow_sequence;
+        m_slideshow_sequence = NULL;
+    }
+
+    if (m_slideshow_sequencing > 1)
+    {
+        m_slideshow_sequence = new SequenceShuffle(m_itemList.size());
+    }
+    else
+    {
+        m_slideshow_sequence = new SequenceInc(m_itemList.size());
+    }
+
+    if (!m_itemList.empty()) {
+        m_imagesLoaded.wakeAll();
+    }
+}
+
+ThumbItem *ImageView::getCurrentItem() const
+{
+    QMutexLocker guard(&m_itemListLock);
+    return m_itemList.at(m_pos);
+}
+
+ThumbItem *ImageView::advanceItem()
+{
+    QMutexLocker guard(&m_itemListLock);
+    m_pos = m_slideshow_sequence->next();
+    return m_itemList.at(m_pos);
+}
+
+ThumbItem *ImageView::retreatItem()
+{
+    QMutexLocker guard(&m_itemListLock);
+    m_pos = m_slideshow_sequence->prev();
+    return m_itemList.at(m_pos);
+}
+
+void ImageView::finishLoading()
+{
+    QMutexLocker guard(&m_itemListLock);
+    m_imagesLoaded.wakeAll();
+}
+
+ImageView::LoadAlbumRunnable::LoadAlbumRunnable(
+        ImageView *parent, const ThumbList &roots, int sortorder,
+        int slideshow_sequencing)
+    : m_parent(parent),
+      m_dirList(roots),
+      m_sortorder(sortorder),
+      m_slideshow_sequencing(slideshow_sequencing),
+      m_isAlive(true)
+{
+}
+
+/** Request that all processing stop */
+void ImageView::LoadAlbumRunnable::abort() {
+    QMutexLocker guard(&m_isAliveLock);
+    m_isAlive = false;
+}
+
+void ImageView::LoadAlbumRunnable::run()
+{
+    while (!m_dirList.empty())
+    {
+        ThumbItem *dir = m_dirList.takeFirst();
+        ThumbList children;
+        GalleryUtil::LoadDirectory(children, dir->GetPath(),
+                                   m_sortorder, false, NULL, NULL);
+
+        {
+            QMutexLocker guard(&m_isAliveLock);
+            if (!m_isAlive)
+            {
+                break;
+            }
+        }
+
+        // The first images should not always come from the first directory.
+        if (m_slideshow_sequencing > 1)
+        {
+            std::random_shuffle(children.begin(), children.end());
+        }
+
+        ThumbList fileList;
+        filterDirectories(children, fileList, m_dirList);
+        if (!fileList.empty())
+        {
+            m_parent->AddItems(fileList);
+        }
+    }
+}
+
+/** Separate the input into files and directories */
+void ImageView::LoadAlbumRunnable::filterDirectories(const ThumbList &input,
+        ThumbList &fileList, ThumbList &dirList)
+{
+    for (int i = 0; i < input.size(); ++i)
+    {
+        ThumbItem *item = input.at(i);
+        ThumbList &targetList = item->IsDir() ? dirList : fileList;
+        targetList.append(item);
+    }
+}
+
+LoadAlbumListener::LoadAlbumListener(ImageView *parent)
+    : m_parent(parent)
+{
+}
+
+LoadAlbumListener::~LoadAlbumListener()
+{
+}
+
+void LoadAlbumListener::finishLoading() const
+{
+    m_parent->finishLoading();
 }

--- a/mythplugins/mythgallery/mythgallery/imageview.h
+++ b/mythplugins/mythgallery/mythgallery/imageview.h
@@ -46,7 +46,7 @@ public:
     LoadAlbumListener(ImageView *parent);
     virtual ~LoadAlbumListener();
 private slots:
-    void finishLoading() const;
+    void FinishLoading() const;
 };  
 
 class ImageView
@@ -60,6 +60,8 @@ class ImageView
     virtual ~ImageView();
 
   protected:
+    static SequenceBase *ComposeSlideshowSequence(int slideshow_sequencing);
+
     // Commands
     virtual void Rotate(int angle) = 0;
     virtual void DisplayNext(bool reset, bool loadImage) = 0;
@@ -83,7 +85,8 @@ class ImageView
 
   private:
     friend class LoadAlbumListener;
-    void finishLoading();
+    void FinishLoading();
+    double GetSeasonalWeight(ThumbItem *item);
 
   protected:
     QSize                  m_screenSize;

--- a/mythplugins/mythgallery/mythgallery/imageview.h
+++ b/mythplugins/mythgallery/mythgallery/imageview.h
@@ -124,6 +124,7 @@ private:
     mutable QMutex         m_itemListLock;
     ThumbList              m_itemList;
     SequenceBase          *m_slideshow_sequence;
+    bool                   m_finishedLoading;
 };
 
 #endif /* IMAGEVIEW_H */

--- a/mythplugins/mythgallery/mythgallery/main.cpp
+++ b/mythplugins/mythgallery/mythgallery/main.cpp
@@ -98,9 +98,13 @@ static void setupKeys(void)
     REG_KEY("Gallery", "END", QT_TRANSLATE_NOOP("MythControls",
         "Go to the last image in thumbnail view"), "End");
     REG_KEY("Gallery", "SLIDESHOW", QT_TRANSLATE_NOOP("MythControls",
-        "Start Slideshow in thumbnail view"), "S");
+        "Start slideshow in thumbnail view"), "S");
     REG_KEY("Gallery", "RANDOMSHOW", QT_TRANSLATE_NOOP("MythControls",
-        "Start Random Slideshow in thumbnail view"), "R");
+        "Start random slideshow in thumbnail view"), "R");
+#ifdef EXIF_SUPPORT
+    REG_KEY("Gallery", "SEASONALSHOW", QT_TRANSLATE_NOOP("MythControls",
+        "Start random slideshow with seasonal theme in thumbnail view"), "");
+#endif // EXIF_SUPPORT
 
     REG_KEY("Gallery", "ROTRIGHT", QT_TRANSLATE_NOOP("MythControls",
         "Rotate image right 90 degrees"), "],3");

--- a/mythplugins/mythgallery/mythgallery/sequence.h
+++ b/mythplugins/mythgallery/mythgallery/sequence.h
@@ -1,7 +1,7 @@
 /* ============================================================
  * File  : sequence.h
- * Description : 
- *   A set of classes providing a sequence of numbers within a 
+ * Description :
+ *   A set of classes providing a sequence of numbers within a
  *   specified range allowing navigation in the sequence.
  *     SequenceBase       - Base for all Sequence classes.
  *     SequenceInc        - An incrementing sequence.
@@ -9,217 +9,301 @@
  *     SequenceRandomBase - Base for all 'random' Sequence classes.
  *     SequenceRandom     - A random sequence (can have duplicates).
  *     SequenceShuffle    - A random sequence (no duplicates).
- * 
+ *     SequenceWeighted   - A random sequence (duplicates and weighted items).
+ *
 
  * This program is free software; you can redistribute it
  * and/or modify it under the terms of the GNU General
  * Public License as published bythe Free Software Foundation;
  * either version 2, or (at your option)
  * any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * ============================================================ */
 
 #ifndef SEQUENCE_H
 #define SEQUENCE_H
 
-#include <stdlib.h>
+#include <algorithm>
+#include <iterator>
+#include <vector>
 
-class SequenceBase  
+const size_t MAX_HISTORY_SIZE = 1024;
+
+class SequenceBase
 {
 public:
-    SequenceBase(int _len, bool _reset = true) 
-    : len(_len), idx(0) 
-    { 
-        if (_reset)
+    SequenceBase()
+    : len(0), idx(0)
+    { }
+
+    virtual ~SequenceBase() { }
+
+    virtual void set(size_t _idx) = 0;
+
+    virtual void extend(size_t items)
+    {
+        len += items;
+    }
+
+    size_t next()
+    {
+        ++idx;
+        if (idx == len)
         {
-            reset(_len); 
+            idx = 0;
         }
-    };
+        return get();
+    }
 
-    virtual ~SequenceBase() { };
-
-    virtual void reset(int _len) 
+    size_t prev()
     {
-        len = _len; 
-        idx = 0;
-    };
-
-    virtual void extend(int _len)
-    {
-        len = _len; 
-    };
-
-    int index(int _idx) { idx = _idx; return index(); };
-    int next(void)      { idx++; return index(); };
-    int prev(void)      { idx--; return index(); };
-    
-    
-protected:
-    int index(void)
-    {
-        if( idx < 0 )
+        if (idx == 0)
         {
-            idx += len; 
-        } 
-        idx %= len; 
-        int retval = get(); 
-        return retval;
-    };
+            idx = len;
+        }
+        --idx;
+        return get();
+    }
 
-    virtual int get(void) = 0;
+protected:
+    virtual size_t get() = 0;
 
-    int  len;
-    int  idx;
+    size_t  len;
+    size_t  idx;
 };
 
 class SequenceInc : public SequenceBase
 {
-public: 
-    SequenceInc(int _len) 
-    : SequenceBase(_len) { };
-
 protected:
-    virtual int get(void) { return idx; };
+    virtual void set(size_t _idx)
+    {
+        idx = _idx;
+    }
+
+    virtual size_t get() { return idx; }
 };
 
 class SequenceDec : public SequenceBase
 {
-public: 
-    SequenceDec(int _len) 
-    : SequenceBase(_len) { };
-
 protected:
-    virtual int get(void)
-    { 
-        return len - idx - 1; 
-    };
+    virtual void set(size_t _idx)
+    {
+        idx = len - _idx - 1;
+    }
+
+    virtual size_t get()
+    {
+        return len - idx - 1;
+    }
 };
 
 class SequenceRandomBase : public SequenceBase
 {
-  public:
-    SequenceRandomBase(int _len, bool _reset = true)
-    : SequenceBase(_len, _reset), seq(0)
-    { 
-        if( _reset )
+public:
+    SequenceRandomBase()
+    : eviction_idx(0)
+    { }
+
+    virtual void set(size_t _idx)
+    {
+        size_t seq_idx = (idx + 1) % seq.size();
+        seq[seq_idx] = _idx;
+    }
+
+    virtual void extend(size_t items)
+    {
+        size_t extension = std::min(len + items, MAX_HISTORY_SIZE) - len;
+        SequenceBase::extend(extension);
+        vector<ssize_t>::iterator insertion_iter = seq.begin();
+        std::advance(insertion_iter, eviction_idx);
+        seq.insert(insertion_iter, extension, -1);
+        if (idx > eviction_idx)
         {
-            reset(_len);
-        } 
-    };
-
-    virtual ~SequenceRandomBase()
-    { 
-        if(seq)
-        { 
-            delete[] seq; 
+            idx += extension;
         }
-    };
-
-    virtual void reset(int _len)
-    { 
-        SequenceBase::reset(_len); 
-        if(seq)
-        { 
-            delete[] seq; 
-        } 
-
-        seq = new int[len];
-
-        for( int i = 0 ; i < len ; i++ )
-        { 
-            seq[i] = -1; 
-        } 
-    };
+        eviction_idx += extension;
+        if (eviction_idx == len)
+        {
+            eviction_idx = (idx + 1) % len;
+        }
+    }
 
 protected:
-    virtual int get(void)
-    { 
-        if( seq[idx] == -1 )
-        { 
-            seq[idx] = create(); 
-        } 
-        return seq[idx]; 
-    };
+    virtual size_t get()
+    {
+        if (idx == eviction_idx)
+        {
+            // The end was reached from the left.
+            evict(eviction_idx);
+            ++eviction_idx;
+            if (eviction_idx == len)
+            {
+                eviction_idx = 0;
+            }
+        }
+        else if (idx == (eviction_idx + 1) % len)
+        {
+            // The end was reached from the right.
+            evict(eviction_idx + 1);
+            if (eviction_idx == 0)
+            {
+                eviction_idx = len;
+            }
+            --eviction_idx;
+        }
 
-    virtual int create(void) = 0;
+        size_t seq_idx = idx % seq.size();
+        if (seq[seq_idx] == -1)
+        {
+            seq[seq_idx] = create();
+        }
+        return seq[seq_idx];
+    }
 
-    int *seq;
+    virtual void evict(size_t i)
+    {
+        // Evict portions of the history that are far away.
+        seq[i] = -1;
+    }
+
+    virtual size_t create() = 0;
+
+    vector<ssize_t> seq;
+    size_t eviction_idx;
 };
 
 class SequenceRandom : public SequenceRandomBase
 {
 public:
-    SequenceRandom(int _len) 
-    : SequenceRandomBase(_len) {};
+    SequenceRandom()
+    : items(0)
+    {
+        SequenceRandomBase::extend(MAX_HISTORY_SIZE);
+    }
+
+    virtual void extend(size_t _items)
+    {
+        items += _items;
+        // The parent len was already extended enough, so it is not called.
+    }
 
 protected:
-    virtual int create(void)
-    { 
-        return (int)(((double)random()) * len / RAND_MAX); 
-    };
-};
+    virtual size_t create()
+    {
+        return (size_t)(((double)random()) * items / RAND_MAX);
+    }
 
-#define MAP_IDX(idx)     map[((idx) / sizeof(int))]
-#define MAP_MSK(idx)     (1 << ((idx) % sizeof(int)))
-#define MAP_SET(map,idx) MAP_IDX(idx) |= MAP_MSK(idx)
-#define MAP_CLR(map,idx) MAP_IDX(idx) &= ~MAP_MSK(idx)
-#define MAP(map,idx)     (MAP_IDX(idx) & MAP_MSK(idx))
+    size_t items;
+};
 
 class SequenceShuffle : public SequenceRandomBase
 {
 public:
-    SequenceShuffle(int _len)
-      : SequenceRandomBase(_len, false), map(0), used(0)
-    { 
-        reset(_len); 
-    };
+    SequenceShuffle()
+    : unseen(0)
+    { }
 
-    virtual ~SequenceShuffle()
-    { 
-        if (map)
-        { 
-            delete[] map; 
-        } 
-    };
+    virtual void set(size_t _idx)
+    {
+        size_t seq_idx = (idx + 1) % seq.size();
+        evict(seq_idx);
+        ++eviction_idx;
+        if (eviction_idx == len)
+        {
+            eviction_idx = 0;
+        }
+        if (map[_idx])
+        {
+            vector<ssize_t>::iterator old_iter = std::find(seq.begin(),
+                seq.end(), _idx);
+            *old_iter = -1;
+        }
+        else
+        {
+            map[_idx] = true;
+            --unseen;
+        }
+        SequenceRandomBase::set(_idx);
+    }
 
-    virtual void reset(int _len)
-    { 
-        SequenceRandomBase::reset(_len); 
-
-        if(map)
-        { 
-           delete[] map;
-        } 
-
-        map = new int[(len / sizeof(int)) + 1];
-
-        for( int i = 0 ; i < len ; i++ )
-        { 
-           MAP_CLR(map,i); 
-        } 
-    }; 
+    virtual void extend(size_t items)
+    {
+        SequenceRandomBase::extend(items);
+        map.resize(len, 0);
+        unseen += items;
+    }
 
 protected:
-    virtual int create(void)
-    { 
-        while(1)
-        { 
-            int i = (int)(((double)random()) * len / RAND_MAX); 
-            if( !MAP(map,i) )
-            { 
-                MAP_SET(map,i); 
-                return i; 
-            } 
-        } 
-    };
+    virtual size_t create()
+    {
+        size_t unseen_idx = (size_t)(((double)random()) * unseen / RAND_MAX);
+        for (size_t i = 0; ; ++i)
+        {
+            if (!map[i])
+            {
+                if (!unseen_idx)
+                {
+                    map[i] = true;
+                    --unseen;
+                    return i;
+                }
+                --unseen_idx;
+            }
+        }
+    }
 
-    int *map;
-    int used;
+    virtual void evict(size_t i)
+    {
+        ssize_t evicted = seq[i];
+        if (evicted != -1)
+        {
+            map[evicted] = false;
+            ++unseen;
+        }
+        SequenceRandomBase::evict(i);
+    }
+
+    vector<bool> map;
+    size_t unseen;
+};
+
+class SequenceWeighted : public SequenceRandom
+{
+public:
+    SequenceWeighted()
+    : weightCursor(0), totalWeight(0)
+    { }
+
+    virtual void extend(size_t items)
+    {
+        weights.resize(weights.size() + items, totalWeight);
+        SequenceRandom::extend(items);
+    }
+
+    void add(double weight)
+    {
+        totalWeight += weight;
+        weights[weightCursor++] = totalWeight;
+    }
+
+protected:
+    virtual size_t create()
+    {
+        double slot = (((double)random()) * totalWeight / RAND_MAX);
+        vector<double>::iterator slot_iter = std::upper_bound(
+            weights.begin(), weights.end(), slot);
+        size_t slot_idx = std::distance(weights.begin(), slot_iter);
+        return slot_idx;
+    }
+
+    vector<double> weights;
+    size_t weightCursor;
+    double totalWeight;
 };
 
 #endif // ndef SEQUENCE_H

--- a/mythplugins/mythgallery/mythgallery/singleview.cpp
+++ b/mythplugins/mythgallery/mythgallery/singleview.cpp
@@ -499,7 +499,7 @@ void SingleView::keyPressEvent(QKeyEvent *e)
             m_slideshow_running = wasRunning;
         }
         else if (action == "PLAY" || action == "SLIDESHOW" ||
-                 action == "RANDOMSHOW")
+                 action == "RANDOMSHOW" || action == "SEASONALSHOW")
         {
             m_source_loc = QPoint(0, 0);
             m_zoom = 1.0f;

--- a/mythplugins/mythgallery/mythgallery/singleview.cpp
+++ b/mythplugins/mythgallery/mythgallery/singleview.cpp
@@ -187,7 +187,7 @@ void SingleView::paintEvent(QPaintEvent *)
     {
         m_movieState = 2;
 
-        ThumbItem *item = m_itemList.at(m_pos);
+        ThumbItem *item = getCurrentItem();
 
         if (item)
             GalleryUtil::PlayVideo(item->GetPath());
@@ -248,7 +248,7 @@ void SingleView::paintEvent(QPaintEvent *)
             }
             else if (m_caption_show && !m_caption_timer->isActive())
             {
-                ThumbItem *item = m_itemList.at(m_pos);
+                ThumbItem *item = getCurrentItem();
                 if (!item->HasCaption())
                     item->InitCaption(true);
 
@@ -307,7 +307,7 @@ void SingleView::paintEvent(QPaintEvent *)
 
                 QPainter p(&pix);
                 p.initFrom(this);
-                ThumbItem *item = m_itemList.at(m_pos);
+                ThumbItem *item = getCurrentItem();
                 QString info = QString::null;
                 if (item)
                 {
@@ -489,7 +489,7 @@ void SingleView::keyPressEvent(QKeyEvent *e)
         }
         else if (action == "DELETE")
         {
-            ThumbItem *item = m_itemList.at(m_pos);
+            ThumbItem *item = getCurrentItem();
             if (item && GalleryUtil::Delete(item->GetPath()))
             {
                 item->SetPixmap(NULL);
@@ -566,8 +566,7 @@ void SingleView::DisplayNext(bool reset, bool loadImage)
     int oldpos = m_pos;
     while (true)
     {
-        m_pos = m_slideshow_sequence->next();
-        item = m_itemList.at(m_pos);
+        item = advanceItem();
         if (item)
         {
             if (QFile::exists(item->GetPath()))
@@ -600,9 +599,7 @@ void SingleView::DisplayPrev(bool reset, bool loadImage)
     int oldpos = m_pos;
     while (true)
     {
-        m_pos = m_slideshow_sequence->prev();
-
-        ThumbItem *item = m_itemList.at(m_pos);
+        ThumbItem *item = retreatItem();
         if (item && QFile::exists(item->GetPath()))
             break;
 
@@ -623,7 +620,7 @@ void SingleView::Load(void)
 
     SetPixmap(NULL);
 
-    ThumbItem *item = m_itemList.at(m_pos);
+    ThumbItem *item = getCurrentItem();
     if (!item)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + QString("No item at %1").arg(m_pos));
@@ -660,7 +657,7 @@ void SingleView::Rotate(int angle)
     m_angle = (m_angle >= 360) ? m_angle - 360 : m_angle;
     m_angle = (m_angle < 0)    ? m_angle + 360 : m_angle;
 
-    ThumbItem *item = m_itemList.at(m_pos);
+    ThumbItem *item = getCurrentItem();
     if (item)
         item->SetRotationAngle(m_angle);
 

--- a/mythplugins/mythgallery/mythgallery/thumbview.cpp
+++ b/mythplugins/mythgallery/mythgallery/thumbview.cpp
@@ -59,6 +59,12 @@ void ThumbItem::InitCaption(bool get_caption)
         SetCaption(m_name);
 }
 
+void ThumbItem::InitTimestamp()
+{
+    if (!HasTimestamp())
+        SetTimestamp(GalleryUtil::GetTimestamp(m_path));
+}
+
 void ThumbItem::SetRotationAngle(int angle)
 {
     MSqlQuery query(MSqlQuery::InitCon());

--- a/mythplugins/mythgallery/mythgallery/thumbview.h
+++ b/mythplugins/mythgallery/mythgallery/thumbview.h
@@ -4,6 +4,7 @@
 #define _THUMBVIEW_H_
 
 // Qt headers
+#include <QDateTime>
 #include <QString>
 #include <QList>
 #include <QHash>
@@ -29,6 +30,7 @@ class ThumbItem
     // commands
     bool Remove(void);
     void InitCaption(bool get_caption);
+    void InitTimestamp();
 
     // sets
     void SetRotationAngle(int angle);
@@ -36,6 +38,8 @@ class ThumbItem
         { m_name = name; m_name.detach(); }
     void SetCaption(const QString &caption)
         { m_caption = caption; m_caption.detach(); }
+    void SetTimestamp(const QDateTime &timestamp)
+        { m_timestamp = timestamp; }
     void SetPath(const QString &path, bool isDir)
         { m_path = path; m_path.detach(), m_isDir = isDir; }
     void SetImageFilename(const QString &filename)
@@ -49,6 +53,8 @@ class ThumbItem
     QString GetName(void)    const { return m_name;               }
     bool    HasCaption(void) const { return !m_caption.trimmed().isEmpty(); }
     QString GetCaption(void) const { return m_caption;            }
+    bool    HasTimestamp(void) const { return m_timestamp.isValid(); }
+    QDateTime GetTimestamp(void) const { return m_timestamp;      }
     QString GetImageFilename(void) const { return m_imageFilename; }
     QString GetPath(void)    const { return m_path;               }
     bool    IsDir(void)      const { return m_isDir;              }
@@ -62,6 +68,7 @@ class ThumbItem
   private:
     QString  m_name;
     QString  m_caption;
+    QDateTime m_timestamp;
     QString  m_path;
     QString  m_imageFilename;
     bool     m_isDir;


### PR DESCRIPTION
This creates a new mode of slideshow, called "Seasonal," to supplement the existing sequential and random slideshows. It shows a random slideshow but with a larger weight given to photos from the same time of year. The feature is only enabled if EXIF support is present. I also made some fixes to the sequence classes, so that they tracked history better and could run forever without leaking memory.

I wrote this on top of a related feature, (https://github.com/MythTV/mythtv/pull/75), because otherwise pulling both would cause merge conflicts.