### PR TITLE
Add support for DVB-T2 for tuners that do not auto-switch

### DIFF
--- a/mythtv/libs/libmythtv/cardutil.cpp
+++ b/mythtv/libs/libmythtv/cardutil.cpp
@@ -431,9 +431,13 @@ QString CardUtil::ProbeDVBType(const QString &device)
 
     DTVTunerType type(info.type);
 #if HAVE_FE_CAN_2G_MODULATION
-    if (type == DTVTunerType::kTunerTypeDVBS1 &&
-        (info.caps & FE_CAN_2G_MODULATION))
-        type = DTVTunerType::kTunerTypeDVBS2;
+    if (info.caps & FE_CAN_2G_MODULATION)
+    {
+        if (type == DTVTunerType::kTunerTypeDVBS1)
+            type = DTVTunerType::kTunerTypeDVBS2;
+        else if (type == DTVTunerType::kTunerTypeDVBT)
+            type = DTVTunerType::kTunerTypeDVBT2;
+    }
 #endif // HAVE_FE_CAN_2G_MODULATION
     ret = (type.toString() != "UNKNOWN") ? type.toString().toUpper() : ret;
 #endif // USING_DVB

--- a/mythtv/libs/libmythtv/cardutil.h
+++ b/mythtv/libs/libmythtv/cardutil.h
@@ -68,6 +68,7 @@ class MTV_PUBLIC CardUtil
         ASI       = 16,
         CETON     = 17,
         EXTERNAL  = 18,
+        DVBT2     = 19,
     };
 
     static enum CARD_TYPES toCardType(const QString &name)
@@ -110,6 +111,8 @@ class MTV_PUBLIC CardUtil
             return CETON;
         if ("EXTERNAL" == name)
             return EXTERNAL;
+        if ("DVB_T2" == name)
+            return DVBT2;
         return ERROR_UNKNOWN;
     }
 

--- a/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
@@ -305,6 +305,7 @@ void ChannelScanSM::HandleAllGood(void)
         UpdateScanPercentCompleted();
         m_waitingForTables = false;
         m_nextIt = m_current.nextTransport();
+        m_dvbt2Tried = true;
     }
 }
 
@@ -941,6 +942,18 @@ bool ChannelScanSM::UpdateChannelInfo(bool wait_until_complete)
             LOG(VB_CHANSCAN, LOG_INFO, LOC +
                 QString("Adding %1, offset %2 to channelList.")
                     .arg((*m_current).tuning.toString()).arg(m_current.offset()));
+
+            TransportScanItem &item = *m_current;
+            item.tuning.frequency = item.freq_offset(m_current.offset());
+
+            if (m_scanDTVTunerType == DTVTunerType::kTunerTypeDVBT2)
+            {
+                if (m_dvbt2Tried)
+                    item.tuning.mod_sys = DTVModulationSystem::kModulationSystem_DVBT2;
+                else
+                    item.tuning.mod_sys = DTVModulationSystem::kModulationSystem_DVBT;
+            }
+
             m_channelList << ChannelListItem(m_current, m_currentInfo);
             m_currentInfo = NULL;
         }
@@ -993,6 +1006,7 @@ bool ChannelScanSM::UpdateChannelInfo(bool wait_until_complete)
             UpdateScanPercentCompleted();
             m_waitingForTables = false;
             m_nextIt = m_current.nextTransport();
+            m_dvbt2Tried = true;
         }
         else
         {
@@ -1612,6 +1626,21 @@ void ChannelScanSM::HandleActiveScan(void)
     if (!HasTimedOut())
         return;
 
+    if (0 == m_nextIt.offset() && m_nextIt == m_scanTransports.begin())
+    {
+        m_channelList.clear();
+        m_channelsFound = 0;
+        m_dvbt2Tried = true;
+    }
+
+    if ((m_scanDTVTunerType == DTVTunerType::kTunerTypeDVBT2) && ! m_dvbt2Tried)
+    {
+        // If we failed to get a lock with DVB-T try DVB-T2.
+        m_dvbt2Tried = true;
+        ScanTransport(m_current);
+        return;
+    }
+
     if (0 == m_nextIt.offset() && m_nextIt != m_scanTransports.begin())
     {
         // Add channel to scanned list and potentially check decryption
@@ -1624,13 +1653,8 @@ void ChannelScanSM::HandleActiveScan(void)
         locker.relock();
     }
 
-    if (0 == m_nextIt.offset() && m_nextIt == m_scanTransports.begin())
-    {
-        m_channelList.clear();
-        m_channelsFound = 0;
-    }
-
     m_current = m_nextIt; // Increment current
+    m_dvbt2Tried = false;
 
     if (m_current != m_scanTransports.end())
     {
@@ -1694,6 +1718,15 @@ bool ChannelScanSM::Tune(const transport_scan_items_it_t &transport)
     const uint64_t freq = item.freq_offset(transport.offset());
     DTVMultiplex tuning = item.tuning;
     tuning.frequency = freq;
+
+    if (m_scanDTVTunerType == DTVTunerType::kTunerTypeDVBT2)
+    {
+        if (m_dvbt2Tried)
+            tuning.mod_sys = DTVModulationSystem::kModulationSystem_DVBT2;
+        else
+            tuning.mod_sys = DTVModulationSystem::kModulationSystem_DVBT;
+    }
+
     return GetDTVChannel()->Tune(tuning, m_inputName);
 }
 

--- a/mythtv/libs/libmythtv/channelscan/channelscan_sm.h
+++ b/mythtv/libs/libmythtv/channelscan/channelscan_sm.h
@@ -238,6 +238,7 @@ class ChannelScanSM : public MPEGStreamListener,
     QMap<uint, uint>            m_currentEncryptionStatus;
     QMap<uint, bool>            m_currentEncryptionStatusChecked;
     QMap<uint64_t, QString>     m_defAuthorities;
+    bool                        m_dvbt2Tried;
 
     /// Found Channel Info
     ChannelList       m_channelList;

--- a/mythtv/libs/libmythtv/channelscan/channelscanmiscsettings.h
+++ b/mythtv/libs/libmythtv/channelscan/channelscanmiscsettings.h
@@ -348,6 +348,18 @@ class ScanModSys: public ComboBoxSetting, public TransientStorage
     };
 };
 
+class ScanDVBTModSys: public ComboBoxSetting, public TransientStorage
+{
+    public:
+    ScanDVBTModSys() : ComboBoxSetting(this)
+    {
+        setLabel(QObject::tr("Mod Sys"));
+        setHelpText(QObject::tr("Modulation system (Default: DVB-T)"));
+        addSelection("DVB-T");
+        addSelection("DVB-T2");
+    };
+};
+
 class ScanRollOff: public ComboBoxSetting, public TransientStorage
 {
     public:

--- a/mythtv/libs/libmythtv/channelscan/channelscanner.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner.cpp
@@ -135,6 +135,7 @@ void ChannelScanner::Scan(
     if ((ScanTypeSetting::FullScan_ATSC   == scantype) ||
         (ScanTypeSetting::FullScan_DVBC   == scantype) ||
         (ScanTypeSetting::FullScan_DVBT   == scantype) ||
+        (ScanTypeSetting::FullScan_DVBT2  == scantype) ||
         (ScanTypeSetting::FullScan_Analog == scantype))
     {
         LOG(VB_CHANSCAN, LOG_INFO, LOC + QString("ScanTransports(%1, %2, %3)")
@@ -155,6 +156,7 @@ void ChannelScanner::Scan(
             sourceid, freq_std, mod, tbl, tbl_start, tbl_end);
     }
     else if ((ScanTypeSetting::NITAddScan_DVBT  == scantype) ||
+             (ScanTypeSetting::NITAddScan_DVBT2 == scantype) ||
              (ScanTypeSetting::NITAddScan_DVBS  == scantype) ||
              (ScanTypeSetting::NITAddScan_DVBS2 == scantype) ||
              (ScanTypeSetting::NITAddScan_DVBC  == scantype))
@@ -261,7 +263,8 @@ DTVConfParser::return_t ChannelScanner::ImportDVBUtils(
     channels.clear();
 
     DTVConfParser::cardtype_t type = DTVConfParser::UNKNOWN;
-    type = (CardUtil::DVBT == cardtype) ? DTVConfParser::OFDM : type;
+    type = ((CardUtil::DVBT == cardtype) ||
+            (CardUtil::DVBT2 == cardtype)) ? DTVConfParser::OFDM : type;
     type = (CardUtil::QPSK == cardtype) ? DTVConfParser::QPSK : type;
     type = (CardUtil::DVBC == cardtype) ? DTVConfParser::QAM  : type;
     type = (CardUtil::DVBS2 == cardtype) ? DTVConfParser::DVBS2 : type;
@@ -441,8 +444,14 @@ void ChannelScanner::PreScanCommon(
         case ScanTypeSetting::FullScan_DVBT:
             sigmonScanner->SetScanDTVTunerType(DTVTunerType::kTunerTypeDVBT);
             break;
+        case ScanTypeSetting::FullScan_DVBT2:
+            sigmonScanner->SetScanDTVTunerType(DTVTunerType::kTunerTypeDVBT2);
+            break;
         case ScanTypeSetting::NITAddScan_DVBT:
             sigmonScanner->SetScanDTVTunerType(DTVTunerType::kTunerTypeDVBT);
+            break;
+        case ScanTypeSetting::NITAddScan_DVBT2:
+            sigmonScanner->SetScanDTVTunerType(DTVTunerType::kTunerTypeDVBT2);
             break;
         case ScanTypeSetting::NITAddScan_DVBS:
             sigmonScanner->SetScanDTVTunerType(DTVTunerType::kTunerTypeDVBS1);

--- a/mythtv/libs/libmythtv/channelscan/panedvbt2.h
+++ b/mythtv/libs/libmythtv/channelscan/panedvbt2.h
@@ -1,0 +1,85 @@
+/* -*- Mode: c++ -*-
+ * vim: set expandtab tabstop=4 shiftwidth=4:
+ *
+ * Original Project
+ *      MythTV      http://www.mythtv.org
+ *
+ * Copyright (c) 2004, 2005 John Pullan <john@pullan.org>
+ * Copyright (c) 2005 - 2007 Daniel Kristjansson
+ * Copyright (c) 2014 David C J Matthews
+ *
+ * Description:
+ *     Collection of classes to provide channel scanning functionallity
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ * Or, point your browser to http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#ifndef _PANE_DVBT2_H_
+#define _PANE_DVBT2_H_
+
+// MythTV headers
+#include "channelscanmiscsettings.h"
+
+class PaneDVBT2 : public HorizontalConfigurationGroup
+{
+  public:
+    PaneDVBT2() : HorizontalConfigurationGroup(false, false, true, true)
+    {
+        setUseFrame(false);
+        VerticalConfigurationGroup *left =
+            new VerticalConfigurationGroup(false,true,true,false);
+        VerticalConfigurationGroup *right =
+            new VerticalConfigurationGroup(false,true,true,false);
+        left->addChild(pfrequency       = new ScanFrequency());
+        left->addChild(pbandwidth       = new ScanBandwidth());
+        left->addChild(pinversion       = new ScanInversion());
+        left->addChild(pconstellation   = new ScanConstellation());
+        left->addChild(pmod_sys         = new ScanDVBTModSys());
+        right->addChild(pcoderate_lp    = new ScanCodeRateLP());
+        right->addChild(pcoderate_hp    = new ScanCodeRateHP());
+        right->addChild(ptrans_mode     = new ScanTransmissionMode());
+        right->addChild(pguard_interval = new ScanGuardInterval());
+        right->addChild(phierarchy      = new ScanHierarchy());
+        addChild(left);
+        addChild(right);
+    }
+
+    QString frequency(void)      const { return pfrequency->getValue();     }
+    QString bandwidth(void)      const { return pbandwidth->getValue();     }
+    QString inversion(void)      const { return pinversion->getValue();     }
+    QString constellation(void)  const { return pconstellation->getValue(); }
+    QString coderate_lp(void)    const { return pcoderate_lp->getValue();   }
+    QString coderate_hp(void)    const { return pcoderate_hp->getValue();   }
+    QString trans_mode(void)     const { return ptrans_mode->getValue();    }
+    QString guard_interval(void) const { return pguard_interval->getValue(); }
+    QString hierarchy(void)      const { return phierarchy->getValue();     }
+    QString mod_sys(void)        const { return pmod_sys->getValue();    }
+
+  protected:
+    ScanFrequency        *pfrequency;
+    ScanInversion        *pinversion;
+    ScanBandwidth        *pbandwidth;
+    ScanConstellation    *pconstellation;
+    ScanCodeRateLP       *pcoderate_lp;
+    ScanCodeRateHP       *pcoderate_hp;
+    ScanTransmissionMode *ptrans_mode;
+    ScanGuardInterval    *pguard_interval;
+    ScanHierarchy        *phierarchy;
+    ScanDVBTModSys       *pmod_sys;
+};
+
+#endif // _PANE_DVBT2_H_

--- a/mythtv/libs/libmythtv/channelscan/scanwizardconfig.cpp
+++ b/mythtv/libs/libmythtv/channelscan/scanwizardconfig.cpp
@@ -12,6 +12,7 @@
 #include "panedvbs2.h"
 #include "panedvbc.h"
 #include "panedvbt.h"
+#include "panedvbt2.h"
 #include "paneatsc.h"
 #include "paneanalog.h"
 #include "panesingle.h"
@@ -120,6 +121,16 @@ void ScanTypeSetting::SetInput(const QString &cardids_inputname)
             addSelection(tr("Import existing scan"),
                          QString::number(ExistingScanImport));
             break;
+        case CardUtil::DVBT2:
+            addSelection(tr("Full Scan"),
+                         QString::number(FullScan_DVBT2), true);
+            addSelection(tr("Full Scan (Tuned)"),
+                         QString::number(NITAddScan_DVBT2));
+//             addSelection(tr("Import channels.conf"),
+//                          QString::number(DVBUtilsImport));
+            addSelection(tr("Import existing scan"),
+                         QString::number(ExistingScanImport));
+            break;
         case CardUtil::DVBS:
             addSelection(tr("Full Scan (Tuned)"),
                          QString::number(NITAddScan_DVBS));
@@ -209,12 +220,14 @@ ScanOptionalConfig::ScanOptionalConfig(ScanTypeSetting *_scan_type) :
     scanType(_scan_type),
     country(new ScanCountry()),
     network(new ScanNetwork()),
-    paneDVBT(new PaneDVBT()),     paneDVBS(new PaneDVBS()),
-    paneDVBS2(new PaneDVBS2()),   paneATSC(new PaneATSC()),
+    paneDVBT(new PaneDVBT()),     paneDVBT2(new PaneDVBT2()),
+    paneDVBS(new PaneDVBS()),     paneDVBS2(new PaneDVBS2()),
+    paneATSC(new PaneATSC()),
     paneDVBC(new PaneDVBC()),     paneAnalog(new PaneAnalog()),
     paneSingle(new PaneSingle()), paneAll(new PaneAll()),
     paneDVBUtilsImport(new PaneDVBUtilsImport()),
     paneExistingScanImport(new PaneExistingScanImport())
+
 {
     setTrigger(scanType);
 
@@ -233,11 +246,15 @@ ScanOptionalConfig::ScanOptionalConfig(ScanTypeSetting *_scan_type) :
               paneDVBS2);
     addTarget(QString::number(ScanTypeSetting::NITAddScan_DVBT),
               paneDVBT);
+    addTarget(QString::number(ScanTypeSetting::NITAddScan_DVBT2),
+              paneDVBT2);
     addTarget(QString::number(ScanTypeSetting::FullScan_ATSC),
               paneATSC);
     addTarget(QString::number(ScanTypeSetting::FullScan_DVBC),
               network);
     addTarget(QString::number(ScanTypeSetting::FullScan_DVBT),
+              country);
+    addTarget(QString::number(ScanTypeSetting::FullScan_DVBT2),
               country);
     addTarget(QString::number(ScanTypeSetting::FullScan_Analog),
               paneAnalog);
@@ -278,6 +295,7 @@ QString ScanOptionalConfig::GetFrequencyStandard(void) const
         case ScanTypeSetting::FullScan_DVBC:
             return "dvbc";
         case ScanTypeSetting::FullScan_DVBT:
+        case ScanTypeSetting::FullScan_DVBT2:
             return "dvbt";
         case ScanTypeSetting::FullScan_Analog:
             return "analog";
@@ -297,6 +315,7 @@ QString ScanOptionalConfig::GetModulation(void) const
         case ScanTypeSetting::FullScan_DVBC:
             return "qam";
         case ScanTypeSetting::FullScan_DVBT:
+        case ScanTypeSetting::FullScan_DVBT2:
             return "ofdm";
         case ScanTypeSetting::FullScan_Analog:
             return "analog";
@@ -316,6 +335,7 @@ QString ScanOptionalConfig::GetFrequencyTable(void) const
         case ScanTypeSetting::FullScan_DVBC:
             return network->getValue();
         case ScanTypeSetting::FullScan_DVBT:
+        case ScanTypeSetting::FullScan_DVBT2:
             return country->getValue();
         case ScanTypeSetting::FullScan_Analog:
             return paneAnalog->GetFrequencyTable();
@@ -403,6 +423,23 @@ QMap<QString,QString> ScanOptionalConfig::GetStartChan(void) const
         startChan["trans_mode"]     = pane->trans_mode();
         startChan["guard_interval"] = pane->guard_interval();
         startChan["hierarchy"]      = pane->hierarchy();
+    }
+    else if (ScanTypeSetting::NITAddScan_DVBT2 == st)
+    {
+        const PaneDVBT2 *pane = paneDVBT2;
+
+        startChan["std"]            = "dvb";
+        startChan["type"]           = "DVB_T2";
+        startChan["frequency"]      = pane->frequency();
+        startChan["inversion"]      = pane->inversion();
+        startChan["bandwidth"]      = pane->bandwidth();
+        startChan["coderate_hp"]    = pane->coderate_hp();
+        startChan["coderate_lp"]    = pane->coderate_lp();
+        startChan["constellation"]  = pane->constellation();
+        startChan["trans_mode"]     = pane->trans_mode();
+        startChan["guard_interval"] = pane->guard_interval();
+        startChan["hierarchy"]      = pane->hierarchy();
+        startChan["mod_sys"]        = pane->mod_sys();
     }
     else if (ScanTypeSetting::NITAddScan_DVBS == st)
     {

--- a/mythtv/libs/libmythtv/channelscan/scanwizardconfig.h
+++ b/mythtv/libs/libmythtv/channelscan/scanwizardconfig.h
@@ -49,6 +49,7 @@ class PaneAll;
 class PaneATSC;
 class PaneAnalog;
 class PaneDVBT;
+class PaneDVBT2;
 class PaneDVBC;
 class PaneDVBS;
 class PaneDVBS2;
@@ -69,9 +70,11 @@ class ScanTypeSetting : public ComboBoxSetting, public TransientStorage
         FullScan_ATSC,
         FullScan_DVBC,
         FullScan_DVBT,
+        FullScan_DVBT2,
         // Scans starting on one frequency that adds each transport
         // seen in the Network Information Tables to the scan.
         NITAddScan_DVBT,
+        NITAddScan_DVBT2,
         NITAddScan_DVBS,
         NITAddScan_DVBS2,
         NITAddScan_DVBC,
@@ -128,6 +131,7 @@ class ScanOptionalConfig : public TriggeredConfigurationGroup
     ScanCountry          *country;
     ScanNetwork          *network;
     PaneDVBT             *paneDVBT;
+    PaneDVBT2            *paneDVBT2;
     PaneDVBS             *paneDVBS;
     PaneDVBS2            *paneDVBS2;
     PaneATSC             *paneATSC;

--- a/mythtv/libs/libmythtv/dtvconfparserhelpers.cpp
+++ b/mythtv/libs/libmythtv/dtvconfparserhelpers.cpp
@@ -42,6 +42,7 @@ const int DTVTunerType::kTunerTypeDVBS1   = 0x0000;
 const int DTVTunerType::kTunerTypeDVBS2   = 0x0020;
 const int DTVTunerType::kTunerTypeDVBC    = 0x0001;
 const int DTVTunerType::kTunerTypeDVBT    = 0x0002;
+const int DTVTunerType::kTunerTypeDVBT2   = 0x0022;
 const int DTVTunerType::kTunerTypeATSC    = 0x0003;
 const int DTVTunerType::kTunerTypeASI     = 0x1000;
 const int DTVTunerType::kTunerTypeOCUR    = 0x2000;
@@ -55,6 +56,7 @@ void DTVTunerType::initStr(void)
     QMutexLocker locker(&dtv_tt_canonical_str_lock);
     dtv_tt_canonical_str[kTunerTypeATSC]    = "ATSC";
     dtv_tt_canonical_str[kTunerTypeDVBT]    = "OFDM";
+    dtv_tt_canonical_str[kTunerTypeDVBT2]   = "DVB_T2";
     dtv_tt_canonical_str[kTunerTypeDVBC]    = "QAM";
     dtv_tt_canonical_str[kTunerTypeDVBS1]   = "QPSK";
     dtv_tt_canonical_str[kTunerTypeDVBS2]   = "DVB_S2";
@@ -77,6 +79,7 @@ const DTVParamHelperStruct DTVTunerType::parseTable[] =
     { "QPSK",    kTunerTypeDVBS1   },
     { "QAM",     kTunerTypeDVBC    },
     { "OFDM",    kTunerTypeDVBT    },
+    { "DVB_T2",  kTunerTypeDVBT2   },
     { "ATSC",    kTunerTypeATSC    },
     { "DVB_S2",  kTunerTypeDVBS2   },
     { "ASI",     kTunerTypeASI     },
@@ -448,6 +451,7 @@ const DTVParamHelperStruct DTVModulationSystem::confTable[] =
     { "SYS_DVBC_ANNEX_AC", kModulationSystem_DVBC_ANNEX_AC },
     { "SYS_DVBC_ANNEX_B",  kModulationSystem_DVBC_ANNEX_B  },
     { "SYS_DVBT",          kModulationSystem_DVBT          },
+    { "SYS_DVBT2",         kModulationSystem_DVBT2         },
     { "SYS_DSS",           kModulationSystem_DSS           },
     { "SYS_DVBS",          kModulationSystem_DVBS          },
     { "SYS_DVBS2",         kModulationSystem_DVBS2         },
@@ -476,6 +480,7 @@ const DTVParamHelperStruct DTVModulationSystem::parseTable[] =
     { "DVBC_AC",   kModulationSystem_DVBC_ANNEX_AC },
     { "DVBC_B",    kModulationSystem_DVBC_ANNEX_B  },
     { "DVBT",      kModulationSystem_DVBT          },
+    { "DVB-T2",    kModulationSystem_DVBT2         },
     { "DSS",       kModulationSystem_DSS           },
     { "DVB-S",     kModulationSystem_DVBS          },
     { "DVB-S2",    kModulationSystem_DVBS2         },
@@ -509,6 +514,7 @@ const char *DTVModulationSystem::dbStr[DTVModulationSystem::kDBStrCnt] =
     "DMBTH",     ///< kModulationSystem_DMBTH
     "CMMB",      ///< kModulationSystem_CMMB
     "DAB",       ///< kModulationSystem_DAB
+    "DVB-T2",    ///< kModulationSystem_DVBT2
 };
 
 const DTVParamHelperStruct DTVRollOff::confTable[] =

--- a/mythtv/libs/libmythtv/dtvconfparserhelpers.cpp
+++ b/mythtv/libs/libmythtv/dtvconfparserhelpers.cpp
@@ -479,7 +479,7 @@ const DTVParamHelperStruct DTVModulationSystem::parseTable[] =
     { "UNDEFINED", kModulationSystem_UNDEFINED     },
     { "DVBC_AC",   kModulationSystem_DVBC_ANNEX_AC },
     { "DVBC_B",    kModulationSystem_DVBC_ANNEX_B  },
-    { "DVBT",      kModulationSystem_DVBT          },
+    { "DVB-T",     kModulationSystem_DVBT          },
     { "DVB-T2",    kModulationSystem_DVBT2         },
     { "DSS",       kModulationSystem_DSS           },
     { "DVB-S",     kModulationSystem_DVBS          },
@@ -501,7 +501,7 @@ const char *DTVModulationSystem::dbStr[DTVModulationSystem::kDBStrCnt] =
     "UNDEFINED", ///< kModulationSystem_UNDEFINED
     "DVBCAC",    ///< kModulationSystem_DVBC_ANNEX_AC
     "DVBC_B",    ///< kModulationSystem_DVBC_ANNEX_B
-    "DVBT",      ///< kModulationSystem_DVBT
+    "DVB-T",     ///< kModulationSystem_DVBT
     "DSS",       ///< kModulationSystem_DSS
     "DVB-S",     ///< kModulationSystem_DVBS
     "DVB-S2",    ///< kModulationSystem_DVBS2

--- a/mythtv/libs/libmythtv/dtvconfparserhelpers.h
+++ b/mythtv/libs/libmythtv/dtvconfparserhelpers.h
@@ -89,6 +89,7 @@ class DTVTunerType : public DTVParamHelper
     static const int kTunerTypeDVBS2; // QPSK, 8PSK, 16APSK, 32APSK
     static const int kTunerTypeDVBC;  // QAM-64, QAM-256
     static const int kTunerTypeDVBT;  // OFDM
+    static const int kTunerTypeDVBT2; // OFDM
     static const int kTunerTypeATSC;  // 8-VSB, 16-VSB,
                                       // QAM-16, QAM-64, QAM-256, QPSK
     static const int kTunerTypeASI;   // baseband
@@ -498,7 +499,7 @@ class DTVModulationSystem : public DTVParamHelper
     static const DTVParamHelperStruct confTable[];
     static const DTVParamHelperStruct vdrTable[];
     static const DTVParamHelperStruct parseTable[];
-    static const uint kDBStrCnt = 16;
+    static const uint kDBStrCnt = 17;
     static const char *dbStr[kDBStrCnt];
 
   public:
@@ -520,6 +521,7 @@ class DTVModulationSystem : public DTVParamHelper
         kModulationSystem_DMBTH,
         kModulationSystem_CMMB,
         kModulationSystem_DAB,
+        kModulationSystem_DVBT2,
     };
 
     DTVModulationSystem(int _default = kModulationSystem_UNDEFINED)

--- a/mythtv/libs/libmythtv/dtvmultiplex.cpp
+++ b/mythtv/libs/libmythtv/dtvmultiplex.cpp
@@ -458,7 +458,7 @@ bool DTVMultiplex::FillFromDeliverySystemDesc(DTVTunerType type,
                     cd.BandwidthString(),               cd.CodeRateHPString(),
                     cd.CodeRateLPString(),              cd.ConstellationString(),
                     cd.TransmissionModeString(),        cd.GuardIntervalString(),
-                    cd.HierarchyString(), "");
+                    cd.HierarchyString(),               "DVB-T");
             }
         }
         case DescriptorID::satellite_delivery_system:

--- a/mythtv/libs/libmythtv/dtvmultiplex.h
+++ b/mythtv/libs/libmythtv/dtvmultiplex.h
@@ -60,6 +60,13 @@ class DTVMultiplex
         const QString &modulation,   const QString &polarity,
         const QString &mod_sys,      const QString &rolloff);
 
+    bool ParseDVB_T2(
+        const QString &frequency,   const QString &inversion,
+        const QString &bandwidth,   const QString &coderate_hp,
+        const QString &coderate_lp, const QString &constellation,
+        const QString &trans_mode,  const QString &guard_interval,
+        const QString &hierarchy,   const QString &mod_sys);
+
     bool ParseTuningParams(
         DTVTunerType type,
         QString frequency,    QString inversion,      QString symbolrate,

--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -530,6 +530,7 @@ using_backend {
     HEADERS += channelscan/panedvbs.h
     HEADERS += channelscan/panedvbs2.h
     HEADERS += channelscan/panedvbt.h
+    HEADERS += channelscan/panedvbt2.h
     HEADERS += channelscan/panedvbutilsimport.h
     HEADERS += channelscan/panesingle.h
     HEADERS += channelscan/scanmonitor.h

--- a/mythtv/libs/libmythtv/recorders/dvbchannel.cpp
+++ b/mythtv/libs/libmythtv/recorders/dvbchannel.cpp
@@ -790,7 +790,7 @@ bool DVBChannel::Tune(const DTVMultiplex &tuning,
         }
 
 #if DVB_API_VERSION >=5
-        if (true || DTVTunerType::kTunerTypeDVBS2 == tunerType ||
+        if (DTVTunerType::kTunerTypeDVBS2 == tunerType ||
             DTVTunerType::kTunerTypeDVBT2 == tunerType)
         {
             struct dtv_property p_clear;

--- a/mythtv/libs/libmythtv/recorders/dvbchannel.cpp
+++ b/mythtv/libs/libmythtv/recorders/dvbchannel.cpp
@@ -255,9 +255,13 @@ bool DVBChannel::Open(DVBChannel *who)
     frontend_name       = info.name;
     tunerType           = info.type;
 #if HAVE_FE_CAN_2G_MODULATION
-    if (tunerType == DTVTunerType::kTunerTypeDVBS1 &&
-        (info.caps & FE_CAN_2G_MODULATION))
-        tunerType = DTVTunerType::kTunerTypeDVBS2;
+    if (info.caps & FE_CAN_2G_MODULATION)
+    {
+        if (tunerType == DTVTunerType::kTunerTypeDVBS1)
+            tunerType = DTVTunerType::kTunerTypeDVBS2;
+        else if (tunerType == DTVTunerType::kTunerTypeDVBT)
+            tunerType = DTVTunerType::kTunerTypeDVBT2;
+    }
 #endif // HAVE_FE_CAN_2G_MODULATION
     capabilities        = info.caps;
     frequency_minimum   = info.frequency_min;
@@ -409,7 +413,8 @@ void DVBChannel::CheckOptions(DTVMultiplex &tuning) const
            "Selected modulation parameter unsupported by this driver.");
     }
 
-    if (DTVTunerType::kTunerTypeDVBT != tunerType)
+    if (DTVTunerType::kTunerTypeDVBT != tunerType &&
+        DTVTunerType::kTunerTypeDVBT2 != tunerType)
     {
         LOG(VB_CHANNEL, LOG_INFO, LOC + tuning.toString());
         return;
@@ -554,7 +559,8 @@ static struct dtv_properties *dtvmultiplex_to_dtvproperties(
     if (tuner_type != DTVTunerType::kTunerTypeDVBT  &&
         tuner_type != DTVTunerType::kTunerTypeDVBC  &&
         tuner_type != DTVTunerType::kTunerTypeDVBS1 &&
-        tuner_type != DTVTunerType::kTunerTypeDVBS2)
+        tuner_type != DTVTunerType::kTunerTypeDVBS2 &&
+        tuner_type != DTVTunerType::kTunerTypeDVBT2)
     {
         LOG(VB_GENERAL, LOG_ERR, "DVBChan: Unsupported tuner type " +
             tuner_type.toString());
@@ -565,7 +571,7 @@ static struct dtv_properties *dtvmultiplex_to_dtvproperties(
     if (!cmdseq)
         return NULL;
 
-    cmdseq->props = (struct dtv_property*) calloc(11, sizeof(*(cmdseq->props)));
+    cmdseq->props = (struct dtv_property*) calloc(12, sizeof(*(cmdseq->props)));
     if (!(cmdseq->props))
     {
         free(cmdseq);
@@ -577,7 +583,8 @@ static struct dtv_properties *dtvmultiplex_to_dtvproperties(
     if (tuning.mod_sys == DTVModulationSystem::kModulationSystem_DVBS2)
         can_fec_auto = false;
 
-    if (tuner_type == DTVTunerType::kTunerTypeDVBS2)
+    if (tuner_type == DTVTunerType::kTunerTypeDVBS2 ||
+        tuner_type == DTVTunerType::kTunerTypeDVBT2)
     {
         cmdseq->props[c].cmd      = DTV_DELIVERY_SYSTEM;
         cmdseq->props[c++].u.data = tuning.mod_sys;
@@ -604,7 +611,8 @@ static struct dtv_properties *dtvmultiplex_to_dtvproperties(
         cmdseq->props[c++].u.data = can_fec_auto ? FEC_AUTO : tuning.fec;
     }
 
-    if (tuner_type == DTVTunerType::kTunerTypeDVBT)
+    if (tuner_type == DTVTunerType::kTunerTypeDVBT ||
+        tuner_type == DTVTunerType::kTunerTypeDVBT2)
     {
         cmdseq->props[c].cmd      = DTV_BANDWIDTH_HZ;
         cmdseq->props[c++].u.data = (8-tuning.bandwidth) * 1000000;
@@ -782,7 +790,8 @@ bool DVBChannel::Tune(const DTVMultiplex &tuning,
         }
 
 #if DVB_API_VERSION >=5
-        if (DTVTunerType::kTunerTypeDVBS2 == tunerType)
+        if (true || DTVTunerType::kTunerTypeDVBS2 == tunerType ||
+            DTVTunerType::kTunerTypeDVBT2 == tunerType)
         {
             struct dtv_property p_clear;
             struct dtv_properties cmdseq_clear;
@@ -1306,7 +1315,8 @@ static struct dvb_frontend_parameters dtvmultiplex_to_dvbparams(
         params.u.qam.modulation   = (fe_modulation_t) (int) tuning.modulation;
     }
 
-    if (DTVTunerType::kTunerTypeDVBT == tuner_type)
+    if (DTVTunerType::kTunerTypeDVBT == tuner_type ||
+        DTVTunerType::kTunerTypeDVBT2 == tuner_type)
     {
         params.u.ofdm.bandwidth             =
             (fe_bandwidth_t) (int) tuning.bandwidth;
@@ -1355,7 +1365,8 @@ static DTVMultiplex dvbparams_to_dtvmultiplex(
         tuning.modulation     = params.u.qam.modulation;
     }
 
-    if (DTVTunerType::kTunerTypeDVBT   == tuner_type)
+    if (DTVTunerType::kTunerTypeDVBT   == tuner_type ||
+        DTVTunerType::kTunerTypeDVBT2  == tuner_type)
     {
         tuning.bandwidth      = params.u.ofdm.bandwidth;
         tuning.hp_code_rate   = params.u.ofdm.code_rate_HP;

--- a/mythtv/libs/libmythtv/scanwizard.cpp
+++ b/mythtv/libs/libmythtv/scanwizard.cpp
@@ -97,6 +97,11 @@ void ScanWizard::SetPage(const QString &pageTitle)
         start_chan = configPane->GetStartChan();
         parse_type = DTVTunerType::kTunerTypeDVBT;
     }
+    else if (scantype == ScanTypeSetting::NITAddScan_DVBT2)
+    {
+        start_chan = configPane->GetStartChan();
+        parse_type = DTVTunerType::kTunerTypeDVBT2;
+    }
     else if (scantype == ScanTypeSetting::NITAddScan_DVBS)
     {
         start_chan = configPane->GetStartChan();
@@ -127,6 +132,7 @@ void ScanWizard::SetPage(const QString &pageTitle)
              (scantype == ScanTypeSetting::CurrentTransportScan) ||
              (scantype == ScanTypeSetting::FullScan_DVBC)     ||
              (scantype == ScanTypeSetting::FullScan_DVBT)     ||
+             (scantype == ScanTypeSetting::FullScan_DVBT2)    ||
              (scantype == ScanTypeSetting::FullScan_Analog))
     {
         ;


### PR DESCRIPTION
This patch provides support for DVB-T2 in the same way as DVB-S2 is supported.  The drivers for the first DVB-T2 tuners (e.g. PCTV-290)  automatically switched between DVB-T and DVB-T2 so that there was no need for the application to treat it specially.  More recent drivers, such as that for the Si2168 in the DVBSky T9580 and PCTV 292e require explicit switching.

There are separate commits for the basic support and for channel scanning.  The channel scanner includes support for editing transports and for a full scan.  The full scan tries to lock each frequency with DVB-T and only tries DVB-T2 if that fails.  This avoids creating duplicate entries when scanning with a device that ignores the DVB-T/T2 setting and locks to either.  There is currently no support for PLPs (physical layer pipes).