### PR TITLE
Fixes for visualization under 24-bit and 32-bit audio

### DIFF
--- a/mythplugins/mythmusic/mythmusic/inlines.h
+++ b/mythplugins/mythmusic/mythmusic/inlines.h
@@ -81,6 +81,30 @@ static inline void stereo16_from_stereopcm16(register short *l,
 }
 
 
+static inline void stereo16_from_stereopcm32(register short *l,
+                         register short *r,
+                         register int *s,
+                         long cnt)
+{
+    while (cnt--) {
+		*l++ = (short)(*s++ >> 16);
+		*r++ = (short)(*s++ >> 16);
+    }
+}
+
+
+static inline void stereo16_from_stereopcmfloat(register short *l,
+                         register short *r,
+                         register float *s,
+                         long cnt)
+{
+    while (cnt--) {
+		*l++ = (short)(*s++ * 32767.0f);
+		*r++ = (short)(*s++ * 32767.0f);
+    }
+}
+
+
 static inline void mono16_from_monopcm8(register short *l,
 					register uchar *c,
 					long cnt)
@@ -131,6 +155,25 @@ static inline void mono16_from_monopcm16(register short *l,
 	}
     }
 }
+
+
+static inline void mono16_from_monopcm32(register short *l,
+                         register int *s,
+                         long cnt)
+{
+    while (cnt--)
+		*l++ = (short)(*s++ >> 16);
+}
+
+
+static inline void mono16_from_monopcmfloat(register short *l,
+                         register float *s,
+                         long cnt)
+{
+    while (cnt--)
+		*l++ = (short)(*s++ * 32767.0f);
+}
+
 
 #if FFTW3_SUPPORT
 static inline void fast_short_set(register short *p,

--- a/mythplugins/mythmusic/mythmusic/mainvisual.cpp
+++ b/mythplugins/mythmusic/mythmusic/mainvisual.cpp
@@ -151,7 +151,16 @@ void MainVisual::add(uchar *buffer, unsigned long b_len, unsigned long timecode,
 {
     unsigned long len = b_len, cnt;
     short *l = 0, *r = 0;
-
+    bool s32le = false;
+    
+    // 24 bit samples are stored as s32le in the buffer.
+    // 32 bit samples are stored as float. Flag the difference.
+    if (bits_per_sample == 24)
+    {
+        s32le = true;
+        bits_per_sample = 32;
+    }
+    
     // len is length of buffer in fully converted samples
     len /= source_channels;
     len /= (bits_per_sample / 8);
@@ -170,6 +179,12 @@ void MainVisual::add(uchar *buffer, unsigned long b_len, unsigned long timecode,
             stereo16_from_stereopcm8(l, r, buffer, cnt);
         else if (bits_per_sample == 16)
             stereo16_from_stereopcm16(l, r, (short *) buffer, cnt);
+        else if (s32le)
+            stereo16_from_stereopcm32(l, r, (int *) buffer, cnt);
+        else if (bits_per_sample == 32)
+            stereo16_from_stereopcmfloat(l, r, (float *) buffer, cnt);
+        else
+            len = 0;
     }
     else if (source_channels == 1)
     {
@@ -179,6 +194,12 @@ void MainVisual::add(uchar *buffer, unsigned long b_len, unsigned long timecode,
             mono16_from_monopcm8(l, buffer, cnt);
         else if (bits_per_sample == 16)
             mono16_from_monopcm16(l, (short *) buffer, cnt);
+        else if (s32le)
+            mono16_from_monopcm32(l, (int *) buffer, cnt);
+        else if (bits_per_sample == 32)
+            mono16_from_monopcmfloat(l, (float *) buffer, cnt);
+        else
+            len = 0;
     }
     else
         len = 0;


### PR DESCRIPTION
I noticed that the visualizer was rendering garbage whenever I played a vorbis file or a 24-bit flac. It seems that the visualizers require a 16-bit stereo feed, and currently only convert between 8 and 16 bit (mono and stereo). The 24-bit FLAC decoder outputs 32bit signed integers, and the Ogg Vorbis decoder outputs 32 bit float (even for stuff encoded from a 16-bit source). The only way to pick the difference between the two (and choose the correct cast) is that FLAC reports 24-bit, even though both are outputting 32.

I have also stopped it from rendering uninitialised memory for an unsupported sample format, the same way it does when there is an unsupported channel count.

Note: Raised on trac as ticket #12445