### PR TITLE
fix as in trac #12458

### DIFF
--- a/mythtv/bindings/python/MythTV/dataheap.py
+++ b/mythtv/bindings/python/MythTV/dataheap.py
@@ -865,9 +865,9 @@ class Video( CMPVideo, VideoSchema, DBDataWrite ):
                     self._fill_cm(self._db)
                 if self.category.lower() not in self._cm_toid:
                     with self._db.cursor(self._log) as cursor:
-                        cursor.execute("""INSERT INTO videocategory
-                                          SET category=%s""",
-                                      self.category)
+                        cursor.execute("""INSERT INTO videocategory (category)
+                                          VALUES (%s)""",
+                                      [self.category])
                         self._cm_toid[self.category] = cursor.lastrowid
                 self.category = self._cm_toid[self.category]
             except AttributeError:


### PR DESCRIPTION
fix for Python bindings no longer add missing 'videocategory'.'category' during method update() for Video object

https://code.mythtv.org/trac/ticket/12458