### PR TITLE
libmythtv: Fix build failure on GCC versions less than 4.8

### DIFF
--- a/mythtv/libs/libmythtv/cardutil.h
+++ b/mythtv/libs/libmythtv/cardutil.h
@@ -42,7 +42,7 @@ typedef enum
 class MTV_PUBLIC CardUtil
 {
   public:
-    using InputTypes = QMap<QString, QString>;
+    typedef QMap<QString, QString> InputTypes;
 
     /// \brief all the different inputs
     enum INPUT_TYPES

--- a/mythtv/libs/libmythtv/driveroption.h
+++ b/mythtv/libs/libmythtv/driveroption.h
@@ -16,8 +16,8 @@ struct DriverOption
     enum type_t { UNKNOWN_TYPE, INTEGER, BOOLEAN, STRING, MENU,
                   BUTTON, BITMASK };
 
-    using menu_t  = QMap<int, QString >;
-    using Options = QMap<category_t, DriverOption >;
+    typedef QMap<int, QString> menu_t;
+    typedef QMap<category_t, DriverOption> Options;
 
     DriverOption(void) : category(UNKNOWN_CAT), minimum(0), maximum(0),
                          default_value(0), current(0), step(0), flags(0),


### PR DESCRIPTION
A couple of C++11 constructs snuck in, causing a build failure
on GCC 4.6.  Convert these to their compatible counterparts.