### PR TITLE
Add a new default video display profile called OpenMAX Normal for raspberry pi

### DIFF
--- a/mythtv/libs/libmythtv/videodisplayprofile.cpp
+++ b/mythtv/libs/libmythtv/videodisplayprofile.cpp
@@ -1173,6 +1173,17 @@ void VideoDisplayProfile::CreateVAAPIProfiles(const QString &hostname)
                   "");
 }
 
+void VideoDisplayProfile::CreateOpenMAXProfiles(const QString &hostname)
+{
+    (void) QObject::tr("OpenMAX Normal", "Sample: OpenMAX Normal");
+    DeleteProfileGroup("OpenMAX Normal", hostname);
+    uint groupid = CreateProfileGroup("OpenMAX Normal", hostname);
+    CreateProfile(groupid, 1, ">", 0, 0, "", 0, 0,
+                  "openmax", 1, true, "openmax", "softblend", false,
+                  "openmaxadvanced", "none",
+                  "");
+}
+
 void VideoDisplayProfile::CreateProfiles(const QString &hostname)
 {
     CreateNewProfiles(hostname);

--- a/mythtv/libs/libmythtv/videodisplayprofile.cpp
+++ b/mythtv/libs/libmythtv/videodisplayprofile.cpp
@@ -1180,7 +1180,7 @@ void VideoDisplayProfile::CreateOpenMAXProfiles(const QString &hostname)
     uint groupid = CreateProfileGroup("OpenMAX Normal", hostname);
     CreateProfile(groupid, 1, ">", 0, 0, "", 0, 0,
                   "openmax", 1, true, "openmax", "softblend", false,
-                  "openmaxadvanced", "none",
+                  "openmaxadvanced", "onefield",
                   "");
 }
 

--- a/mythtv/libs/libmythtv/videodisplayprofile.h
+++ b/mythtv/libs/libmythtv/videodisplayprofile.h
@@ -153,6 +153,7 @@ class MTV_PUBLIC VideoDisplayProfile
     static void        CreateVDAProfiles(const QString &hostname);
     static void        CreateOpenGLProfiles(const QString &hostname);
     static void        CreateVAAPIProfiles(const QString &hostname);
+    static void        CreateOpenMAXProfiles(const QString &hostname);
 
     static QStringList GetVideoRenderers(const QString &decoder);
     static QString     GetVideoRendererHelp(const QString &renderer);

--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -1246,6 +1246,15 @@ PlaybackProfileConfigs::PlaybackProfileConfigs(const QString &str) :
     }
 #endif
 
+#ifdef USING_OPENMAX
+    if (!profiles.contains("OpenMAX Normal"))
+    {
+        VideoDisplayProfile::CreateOpenMAXProfiles(host);
+        profiles = VideoDisplayProfile::GetProfiles(host);
+    }
+#endif
+
+
     QString profile = VideoDisplayProfile::GetDefaultProfileName(host);
     if (!profiles.contains(profile))
     {


### PR DESCRIPTION
Raspberry pi needs to use OpenMAX decoder and renderer. There should be a default display profile to assist in the frontend video playback setup. This pull request adds that to the frontend setup.

Ticket for this pull request:
https://code.mythtv.org/trac/ticket/12675