### PR TITLE
Fix bleed through of background when playing video with OpenMAX

### DIFF
--- a/mythtv/libs/libmythtv/tv_play.cpp
+++ b/mythtv/libs/libmythtv/tv_play.cpp
@@ -2610,7 +2610,11 @@ void TV::HandleStateChange(PlayerContext *mctx, PlayerContext *ctx)
             QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
         mainWindow->setGeometry(player_bounds);
         mainWindow->ResizePainterWindow(player_bounds.size());
-        if (!weDisabledGUI)
+        // PGB Do not disable the GUI when using openmax decoder,
+        // to ensure that space next to letterbox pictures
+        // is painted.
+        QString decName = ctx->player->GetDecoder()->GetCodecDecoderName();
+        if (decName != "openmax" && !weDisabledGUI)
         {
             weDisabledGUI = true;
             GetMythMainWindow()->PushDrawDisabled();

--- a/mythtv/libs/libmythtv/videoout_omx.h
+++ b/mythtv/libs/libmythtv/videoout_omx.h
@@ -77,6 +77,7 @@ class VideoOutputOMX : public VideoOutput, private OMXComponentCtx
     QVector<void*> m_bufs;
     MythRenderEGL *m_context;
     MythPainter *m_osdpainter;
+    MythScreenType *m_backgroundscreen;
 };
 
 #endif // ndef VIDEOOUT_OMX_H

--- a/mythtv/themes/default/base.xml
+++ b/mythtv/themes/default/base.xml
@@ -1460,4 +1460,16 @@
         </buttonlist>
     </window>
 
+    <!-- Black background for OpenMAX videos to prevent bleed through-->
+    <window name="videobackground">
+
+        <shape name="shape1">
+            <area>0,0,100%,100%</area>
+            <type>box</type>
+            <fill color="#000000" alpha="255"/>
+        </shape>
+
+    </window>
+
+
 </mythuitheme>


### PR DESCRIPTION
This fixes the bug in ticket: https://code.mythtv.org/trac/ticket/12691
Fixes:
1. With OpenMAX playback profile if you play a video that is letterbox or pillarbox, the blank areas next to the video shows artifacts from the playback window, depending on the theme.
2. When changing resolution the screen displays "Please Wait", or the whole playback window, depending on the theme

These are fixed by creating a video background window that is black if OpenMAX is being used.