### PR TITLE
Added dvr services call for setting and getting bookmark position

### DIFF
--- a/mythtv/libs/libmyth/programinfo.h
+++ b/mythtv/libs/libmyth/programinfo.h
@@ -626,9 +626,21 @@ class MPUBLIC ProgramInfo
                          int64_t min_frm = -1, int64_t max_frm = -1) const;
     void SavePositionMapDelta(frm_pos_map_t &, MarkTypes type) const;
 
-    // Get position/duration for keyframe
-    bool QueryKeyFramePosition(uint64_t *, uint64_t keyframe, bool backwards) const;
-    bool QueryKeyFrameDuration(uint64_t *, uint64_t keyframe, bool backwards) const;
+    // Get position/duration for keyframe and vice versa
+    bool QueryKeyFrameInfo(uint64_t *, uint64_t position_or_keyframe,
+                           bool backwards,
+                           MarkTypes type, const char *from_filemarkup_asc,
+                           const char *from_filemarkup_desc,
+                           const char *from_recordedseek_asc,
+                           const char *from_recordedseek_desc) const;
+    bool QueryKeyFramePosition(uint64_t *, uint64_t keyframe,
+                               bool backwards) const;
+    bool QueryPositionKeyFrame(uint64_t *, uint64_t position,
+                               bool backwards) const;
+    bool QueryKeyFrameDuration(uint64_t *, uint64_t keyframe,
+                               bool backwards) const;
+    bool QueryDurationKeyFrame(uint64_t *, uint64_t duration,
+                               bool backwards) const;
 
     // Get/set all markup
     struct MarkupEntry

--- a/mythtv/libs/libmythservicecontracts/services/dvrServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/dvrServices.h
@@ -45,11 +45,12 @@
 class SERVICE_PUBLIC DvrServices : public Service  //, public QScriptable ???
 {
     Q_OBJECT
-    Q_CLASSINFO( "version"    , "6.1" );
+    Q_CLASSINFO( "version"    , "6.2" );
     Q_CLASSINFO( "RemoveRecorded_Method",                       "POST" )
     Q_CLASSINFO( "DeleteRecording_Method",                      "POST" )
     Q_CLASSINFO( "UnDeleteRecording",                           "POST" )
     Q_CLASSINFO( "UpdateRecordedWatchedStatus_Method",          "POST" )
+    Q_CLASSINFO( "SetSavedBookmark_Method",                     "POST" )
     Q_CLASSINFO( "AddRecordSchedule_Method",                    "POST" )
     Q_CLASSINFO( "UpdateRecordSchedule_Method",                 "POST" )
     Q_CLASSINFO( "RemoveRecordSchedule_Method",                 "POST" )
@@ -110,6 +111,17 @@ class SERVICE_PUBLIC DvrServices : public Service  //, public QScriptable ???
                                                                  int   ChanId,
                                                                  const QDateTime &StartTime,
                                                                  bool  Watched) = 0;
+
+        virtual long              GetSavedBookmark       ( int              RecordedId,
+                                                           int              ChanId,
+                                                           const QDateTime &StartTime,
+                                                           const QString   &OffsetType ) = 0;
+
+        virtual bool              SetSavedBookmark       ( int              RecordedId,
+                                                           int              ChanId,
+                                                           const QDateTime &StartTime,
+                                                           const QString   &OffsetType,
+                                                           long             Offset ) = 0;
 
         virtual DTC::CutList*      GetRecordedCutList    ( int              RecordedId,
                                                            int              ChanId,

--- a/mythtv/programs/mythbackend/services/dvr.h
+++ b/mythtv/programs/mythbackend/services/dvr.h
@@ -75,6 +75,18 @@ class Dvr : public DvrServices
                                                         const QDateTime &StartTime,
                                                         bool  Watched);
 
+       long              GetSavedBookmark     ( int              RecordedId,
+                                                int              ChanId,
+                                                const QDateTime &StartTime,
+                                                const QString   &OffsetType );
+
+       bool              SetSavedBookmark     ( int              RecordedId,
+                                                int              ChanId,
+                                                const QDateTime &StartTime,
+                                                const QString   &OffsetType,
+                                                long             Offset
+                                                );
+
         DTC::CutList*     GetRecordedCutList  ( int              RecordedId,
                                                 int              ChanId,
                                                 const QDateTime &StartTime,


### PR DESCRIPTION
This PR adds two functions GetSavedBookmark and SetSavedBookmark they were done largely in the style of #12090. I thought about adding the ability to pull the full markup (in fact I am not sure the other GetRecordedCutList shouldn't do this and let the user sort the types out) but this still left how best to set a bookmark without adding a more complex markup setting function.
I think this simplified version of just Get/Set bookmark adds the remaining  missing hunk to the services api for markup, no it doesn't add the metadata of #11491 but that probably should come from elsewhere.
Both functions take very similar args to #12090.
I did refactor the QueryKeyFramePosition and QueryKeyFrameDuration main function code into one function, as I was adding two more (QueryPositionKeyFrame,QueryDurationKeyFrame) and they were nearly identical I figured I would slim down the code.  If you prefer 4 functions with duplicate code however I can update the code for that.
