### PR TITLE
Added ChildID to VideoService VideoMetadataInfo for Video Services API

### DIFF
--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoMetadataInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoMetadataInfo.h
@@ -44,6 +44,7 @@ class SERVICE_PUBLIC VideoMetadataInfo : public QObject
     Q_PROPERTY( QDateTime       ReleaseDate     READ ReleaseDate      WRITE setReleaseDate    )
     Q_PROPERTY( QDateTime       AddDate         READ AddDate          WRITE setAddDate        )
     Q_PROPERTY( float           UserRating      READ UserRating       WRITE setUserRating     )
+    Q_PROPERTY( int             ChildID         READ ChildID          WRITE setChildID        )
     Q_PROPERTY( int             Length          READ Length           WRITE setLength         )
     Q_PROPERTY( int             PlayCount       READ PlayCount        WRITE setPlayCount      )
     Q_PROPERTY( int             Season          READ Season           WRITE setSeason         )
@@ -79,6 +80,7 @@ class SERVICE_PUBLIC VideoMetadataInfo : public QObject
     PROPERTYIMP    ( QDateTime  , ReleaseDate    )
     PROPERTYIMP    ( QDateTime  , AddDate        )
     PROPERTYIMP    ( float      , UserRating     )
+    PROPERTYIMP    ( int        , ChildID        )
     PROPERTYIMP    ( int        , Length         )
     PROPERTYIMP    ( int        , PlayCount      )
     PROPERTYIMP    ( int        , Season         )
@@ -114,6 +116,7 @@ class SERVICE_PUBLIC VideoMetadataInfo : public QObject
                           m_Id            ( 0      ),
                           m_Collectionref ( 0      ),
                           m_UserRating    ( 0      ),
+                          m_ChildID       ( 0      ),
                           m_Length        ( 0      ),
                           m_PlayCount     ( 0      ),
                           m_Season        ( 0      ),

--- a/mythtv/libs/libmythservicecontracts/services/videoServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/videoServices.h
@@ -41,7 +41,7 @@
 class SERVICE_PUBLIC VideoServices : public Service  //, public QScriptable ???
 {
     Q_OBJECT
-    Q_CLASSINFO( "version"    , "1.3" );
+    Q_CLASSINFO( "version"    , "1.4" );
     Q_CLASSINFO( "AddVideo_Method",                    "POST" )
     Q_CLASSINFO( "RemoveVideoFromDB_Method",           "POST" )
     Q_CLASSINFO( "UpdateVideoWatchedStatus_Method",    "POST" )

--- a/mythtv/programs/mythbackend/services/serviceUtil.cpp
+++ b/mythtv/programs/mythbackend/services/serviceUtil.cpp
@@ -372,6 +372,7 @@ void FillVideoMetadataInfo (
         QDateTime(pMetadata->GetInsertdate(),
                   QTime(0,0),Qt::LocalTime).toUTC());
     pVideoMetadataInfo->setUserRating(pMetadata->GetUserRating());
+    pVideoMetadataInfo->setChildID(pMetadata->GetChildID());
     pVideoMetadataInfo->setLength(pMetadata->GetLength());
     pVideoMetadataInfo->setPlayCount(pMetadata->GetPlayCount());
     pVideoMetadataInfo->setSeason(pMetadata->GetSeason());


### PR DESCRIPTION
Simple patch adding ChildID to the VideoMetadataInfo so that people who have multi-part videos have a way of re-assembling via the service API.