### PR TITLE
Fix segmentation fault in QMetaObject::indexOfClassInfo() #12782

### DIFF
--- a/mythtv/libs/libmythupnp/serializers/xmlSerializer.cpp
+++ b/mythtv/libs/libmythupnp/serializers/xmlSerializer.cpp
@@ -120,14 +120,15 @@ void XmlSerializer::AddProperty( const QString       &sName,
 {
     m_pXmlWriter->writeStartElement( sName );
 
-    if ((pMetaProp != NULL) &&
-        (pMetaProp->isEnumType() || pMetaProp->isFlagType()))
+    if (pMetaProp != NULL)
     {
-        RenderEnum ( sName, vValue, pMetaProp );
+        if (pMetaProp->isEnumType() || pMetaProp->isFlagType())
+        {
+            RenderEnum( sName, vValue, pMetaProp );
+        }
+        else
+            RenderValue( GetContentName( sName, pMetaParent, pMetaProp ), vValue );
     }
-    else
-        RenderValue( GetContentName( sName, pMetaParent, pMetaProp ), vValue );
-
     m_pXmlWriter->writeEndElement();
 }
 


### PR DESCRIPTION
The NULL check for pMetaProp in xmlSerializer.cpp should protect the GetContentName() call too.
Related (already existing) ticket: https://code.mythtv.org/trac/ticket/12782