### PR TITLE
Changed frame initialization default alignment from 64 to 0 avoiding …

### DIFF
--- a/mythtv/libs/libmythtv/mythframe.h
+++ b/mythtv/libs/libmythtv/mythframe.h
@@ -95,7 +95,7 @@ static inline void init(VideoFrame *vf, VideoFrameType _codec,
                         const int *p = 0,
                         const int *o = 0,
                         float _aspect = -1.0f, double _rate = -1.0f,
-                        int _aligned = 64) MUNUSED;
+                        int _aligned = 0) MUNUSED;
 static inline void clear(VideoFrame *vf);
 static inline bool compatible(const VideoFrame *a,
                               const VideoFrame *b) MUNUSED;


### PR DESCRIPTION
…segfault in analogic tv recording (libs/libmythtv/recorders/NuppelVideoRecorder.cpp)

Since the changes to libs/libmythtv/recorders/NuppelVideoRecorder.cpp on commit f513db7548ba14ed52fda13fa1108b478dbf0c23 the analogic tv recording segfaults, I narrowed down the problem to the usage of 64 as the alignment in mythframe init (the offsets and pitches have wrong values when the alignment is not 0). Using 0 in the call fixes this but I considered that hard coding the parameters in the call was too ugly and in this commit I changed the default.

