### PR TITLE
Textarea widget displaying recording wall clock time in OSD

### DIFF
--- a/mythtv/libs/libmythtv/mythplayer.cpp
+++ b/mythtv/libs/libmythtv/mythplayer.cpp
@@ -5135,7 +5135,6 @@ void MythPlayer::calcSliderPos(osdInfo &info, bool paddedFields)
         int sbsecs = (secsbehind - sbhours * 3600 - sbmins * 60);
 
         QDateTime wallclock = player_ctx->playingRecStart.addSecs(secsplayed);
-        
         QString text1, text2, text3;
         if (paddedFields)
         {
@@ -5176,7 +5175,7 @@ void MythPlayer::calcSliderPos(osdInfo &info, bool paddedFields)
         info.text[relPrefix + "description"] = desc;
         info.text[relPrefix + "playedtime"] = text1;
         info.text[relPrefix + "totaltime"] = text2;
-        info.text[relPrefix + "wallclocktime"] = wallclock.toString("hh:mm:ss");
+        info.text[relPrefix + "wallclocktime"] = wallclock.toLocalTime().toString("hh:mm:ss");
         info.text[relPrefix + "remainingtime"] = islive ? QString() : text3;
         info.text[relPrefix + "behindtime"] = islive ? text3 : QString();
     }

--- a/mythtv/libs/libmythtv/mythplayer.cpp
+++ b/mythtv/libs/libmythtv/mythplayer.cpp
@@ -5134,6 +5134,8 @@ void MythPlayer::calcSliderPos(osdInfo &info, bool paddedFields)
         int sbmins = (secsbehind - sbhours * 3600) / 60;
         int sbsecs = (secsbehind - sbhours * 3600 - sbmins * 60);
 
+        QDateTime wallclock = player_ctx->playingRecStart.addSecs(secsplayed);
+        
         QString text1, text2, text3;
         if (paddedFields)
         {
@@ -5174,6 +5176,7 @@ void MythPlayer::calcSliderPos(osdInfo &info, bool paddedFields)
         info.text[relPrefix + "description"] = desc;
         info.text[relPrefix + "playedtime"] = text1;
         info.text[relPrefix + "totaltime"] = text2;
+        info.text[relPrefix + "wallclocktime"] = wallclock.toString("hh:mm:ss");
         info.text[relPrefix + "remainingtime"] = islive ? QString() : text3;
         info.text[relPrefix + "behindtime"] = islive ? text3 : QString();
     }

--- a/mythtv/libs/libmythtv/osd.cpp
+++ b/mythtv/libs/libmythtv/osd.cpp
@@ -435,7 +435,7 @@ void OSD::SetText(const QString &window, const InfoMap &map,
         MythUIStateType *state = dynamic_cast<MythUIStateType *> (win->GetChild("audiochannels"));
         if (state)
             state->DisplayState(map["audiochannels"]);
-    }
+    } 
     if (map.contains("chanid"))
     {
         MythUIImage *icon = dynamic_cast<MythUIImage *> (win->GetChild("iconpath"));
@@ -542,6 +542,13 @@ void OSD::SetText(const QString &window, const InfoMap &map,
         bar->SetStart(0);
         bar->SetTotal(1000);
     }
+ 
+	if (map.contains("wallclock"))
+    {
+        MythUIStateType *state = dynamic_cast<MythUIStateType *> (win->GetChild("wallclock"));
+        if (state)
+            state->DisplayState(map["wallclock"]);
+    }  
 
     win->SetVisible(true);
 

--- a/mythtv/libs/libmythtv/osd.cpp
+++ b/mythtv/libs/libmythtv/osd.cpp
@@ -543,13 +543,6 @@ void OSD::SetText(const QString &window, const InfoMap &map,
         bar->SetTotal(1000);
     }
  
-	if (map.contains("wallclock"))
-    {
-        MythUIStateType *state = dynamic_cast<MythUIStateType *> (win->GetChild("wallclock"));
-        if (state)
-            state->DisplayState(map["wallclock"]);
-    }  
-
     win->SetVisible(true);
 
     if (win == m_Dialog)

--- a/mythtv/libs/libmythtv/osd.cpp
+++ b/mythtv/libs/libmythtv/osd.cpp
@@ -435,7 +435,7 @@ void OSD::SetText(const QString &window, const InfoMap &map,
         MythUIStateType *state = dynamic_cast<MythUIStateType *> (win->GetChild("audiochannels"));
         if (state)
             state->DisplayState(map["audiochannels"]);
-    } 
+    }
     if (map.contains("chanid"))
     {
         MythUIImage *icon = dynamic_cast<MythUIImage *> (win->GetChild("iconpath"));
@@ -542,7 +542,7 @@ void OSD::SetText(const QString &window, const InfoMap &map,
         bar->SetStart(0);
         bar->SetTotal(1000);
     }
- 
+
     win->SetVisible(true);
 
     if (win == m_Dialog)

--- a/mythtv/libs/libmythtv/playercontext.cpp
+++ b/mythtv/libs/libmythtv/playercontext.cpp
@@ -47,6 +47,7 @@ PlayerContext::PlayerContext(const QString &inUseID) :
     pipState(kPIPOff), pipRect(0,0,0,0), parentWidget(NULL), pipLocation(0),
     useNullVideo(false)
 {
+    playingRecStart = QDateTime();
     lastSignalMsgTime.start();
     lastSignalMsgTime.addMSecs(-2 * (int)kSMExitTimeout);
 }
@@ -884,6 +885,7 @@ void PlayerContext::SetPlayingInfo(const ProgramInfo *info)
         if (!ignoreDB)
             playingInfo->MarkAsInUse(true, recUsage);
         playingLen = playingInfo->GetSecondsInRecording();
+        playingRecStart = playingInfo->GetRecordingStartTime();
     }
 }
 

--- a/mythtv/libs/libmythtv/playercontext.h
+++ b/mythtv/libs/libmythtv/playercontext.h
@@ -12,6 +12,7 @@ using namespace std;
 #include <QHash>
 #include <QRect>
 #include <QObject>
+#include <QDateTime>
 
 // MythTV headers
 #include "videoouttypes.h"
@@ -156,6 +157,7 @@ class MTV_PUBLIC PlayerContext
     RingBuffer         *buffer;
     ProgramInfo        *playingInfo; ///< Currently playing info
     long long           playingLen;  ///< Initial CalculateLength()
+    QDateTime           playingRecStart;
     bool                nohardwaredecoders; // < Disable use of VDPAU decoding
     int                 last_cardid; ///< CardID of current/last recorder
     /// 0 == normal, +1 == fast forward, -1 == rewind


### PR DESCRIPTION
Ticket: https://code.mythtv.org/trac/ticket/12969#ticket

This adds a textarea widget named "wallclocktime" to the OSD that will display the local playing wall clock time of the recording being played. Its very useful to me, don't if others will want it. I've being using it for 3 week without issues.

Example snippet from my osd.xml theme file, moving the description text widget down and showing the recording time in its place.


```xml
       <textarea name="wallclocktime">                                                                                                                                                                                                
            <font>small</font>
            <area>10,5,1700,40</area>
            <align>hcenter, bottom</align>
            <template>Wall clock: %1</template>
        </textarea> 
        <textarea name="description">
            <font>small</font>
            <area>10,70,1700,40</area>
            <align>hcenter,bottom</align>
            <template>%DESCRIPTION%
            %(|REMAININGTIME|)%%(|BEHINDTIME|)%%VALUE%%UNITS%</template>
        </textarea> 
```