### PR TITLE
Correction to commit: ff37862c27cc678ae201e55a5aad3af2ac3a66e3

### DIFF
--- a/mythtv/libs/libmythtv/videobuffers.cpp
+++ b/mythtv/libs/libmythtv/videobuffers.cpp
@@ -303,7 +303,7 @@ VideoFrame *VideoBuffers::GetNextFreeFrame(BufferType enqueue_to)
                 QString("GetNextFreeFrame() TryLock has "
                         "spun %1 times, this is a lot.").arg(tries));
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(TRY_LOCK_SPIN_WAIT));
+        std::this_thread::sleep_for(std::chrono::microseconds(TRY_LOCK_SPIN_WAIT));
     }
 
     return NULL;


### PR DESCRIPTION
Corrects a mistake in the commit referenced above. In that commit a
sleep was increased from 100 microseconds to 100 milliseconds. This
proposed change reverts the sleep to the original 100 microseconds.

Thank you for contributing to MythTV.

As many of our developers do not visit GitHub it is important to track
all contributions at our central ticket tracker over at code.mythtv.org

To prevent your contributions being overlooked please create a new ticket
there and refer to this pull request. (Bonus points for linking to the
ticket in the pull request, too. It helps us noticed potentially overlooked
pull requests due to missing tickets.)

https://code.mythtv.org/trac/wiki/TicketHowTo
https://code.mythtv.org/trac/newticket
