### PR TITLE
Make bare file URLs actually file: URLs

### DIFF
--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -1867,7 +1867,7 @@ void MainServer::HandleAnnounce(QStringList &slist, QStringList commands,
         LOG(VB_NETWORK, LOG_INFO, LOC +
             QString("adding: %1 as a remote file transfer") .arg(commands[2]));
         QStringList::const_iterator it = slist.begin();
-        QUrl qurl = *(++it);
+        QUrl qurl = QUrl::fromLocalFile(*(++it)); 
         QString wantgroup = *(++it);
         QString filename;
         QStringList checkfiles;


### PR DESCRIPTION
QUrl will mangle the content of a string, in particular it will convert the first letter to lower case if the string contains a colon.

So properly form filenames as file URLs by prefixing them with file:

Tracked in https://code.mythtv.org/trac/ticket/13006