### PR TITLE
Consolidated DVB SI rework

### DIFF
--- a/mythtv/.gitignore
+++ b/mythtv/.gitignore
@@ -6,3 +6,9 @@ Makefile.*.debug
 config.*
 version.cpp
 TMPMAK
+.project
+.cproject
+.settings
+logs
+errs
+src

--- a/mythtv/bindings/perl/MythTV.pm
+++ b/mythtv/bindings/perl/MythTV.pm
@@ -115,7 +115,7 @@ package MythTV;
 # schema version supported in the main code.  We need to check that the schema
 # version in the database is as expected by the bindings, which are expected
 # to be kept in sync with the main code.
-    our $SCHEMA_VERSION = "1348";
+    our $SCHEMA_VERSION = "1347";
 
 # NUMPROGRAMLINES is defined in mythtv/libs/libmythtv/programinfo.h and is
 # the number of items in a ProgramInfo QStringList group used by

--- a/mythtv/bindings/python/MythTV/static.py
+++ b/mythtv/bindings/python/MythTV/static.py
@@ -5,7 +5,7 @@ Contains any static and global variables for MythTV Python Bindings
 """
 
 OWN_VERSION = (0,28,-1,0)
-SCHEMA_VERSION = 1348
+SCHEMA_VERSION = 1347
 NVSCHEMA_VERSION = 1007
 MUSICSCHEMA_VERSION = 1018
 PROTO_VERSION = '91'

--- a/mythtv/docs/doxygen-create-developer-docs.cfg
+++ b/mythtv/docs/doxygen-create-developer-docs.cfg
@@ -382,7 +382,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # the optimal cache size from a speed point of view.
 # Minimum value: 0, maximum value: 9, default value: 0.
 
-LOOKUP_CACHE_SIZE      = 1
+LOOKUP_CACHE_SIZE      = 2
 
 #---------------------------------------------------------------------------
 # Build related configuration options

--- a/mythtv/filters/greedyhdeint/greedyhmacros.h
+++ b/mythtv/filters/greedyhdeint/greedyhmacros.h
@@ -2,16 +2,16 @@
 // Copyright (c) 2001 Tom Barry.  All rights reserved.
 /////////////////////////////////////////////////////////////////////////////
 //
-//	This file is subject to the terms of the GNU General Public License as
-//	published by the Free Software Foundation.  A copy of this license is
-//	included with this software distribution in the file COPYING.  If you
-//	do not have a copy, you may obtain a copy by writing to the Free
-//	Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+// This file is subject to the terms of the GNU General Public License as
+// published by the Free Software Foundation.  A copy of this license is
+// included with this software distribution in the file COPYING.  If you
+// do not have a copy, you may obtain a copy by writing to the Free
+// Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
 //
-//	This software is distributed in the hope that it will be useful,
-//	but WITHOUT ANY WARRANTY; without even the implied warranty of
-//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//	GNU General Public License for more details
+// This software is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details
 //
 /////////////////////////////////////////////////////////////////////////////
 
@@ -27,12 +27,12 @@
 //      V_PAVGB(mmr1, mmr2, mmr work register, smask) mmr2 may = mmrw if you can trash it
 
 #define V_PAVGB_MMXT(mmr1, mmr2, mmrw, smask) \
-	"movq    "mmr2",  "mmrw"\n\t"            \
-	"pand    "smask", "mmrw"\n\t"            \
-	"psrlw   $1,      "mmrw"\n\t"            \
-	"pand    "smask", "mmr1"\n\t"            \
-	"psrlw   $1,      "mmr1"\n\t"            \
-	"paddusb "mmrw",  "mmr1"\n\t"
+    "movq    "mmr2",  "mmrw"\n\t"            \
+    "pand    "smask", "mmrw"\n\t"            \
+    "psrlw   $1,      "mmrw"\n\t"            \
+    "pand    "smask", "mmr1"\n\t"            \
+    "psrlw   $1,      "mmr1"\n\t"            \
+    "paddusb "mmrw",  "mmr1"\n\t"
 #define V_PAVGB_SSE(mmr1, mmr2, mmrw, smask)      "pavgb   "mmr2", "mmr1"\n\t"
 #define V_PAVGB_3DNOW(mmr1, mmr2, mmrw, smask)    "pavgusb "mmr2", "mmr1"\n\t"
 #define V_PAVGB(mmr1, mmr2, mmrw, smask)          V_PAVGB2(mmr1, mmr2, mmrw, smask, SSE_TYPE) 

--- a/mythtv/filters/ivtc/pullup.h
+++ b/mythtv/filters/ivtc/pullup.h
@@ -17,53 +17,53 @@
 
 struct pullup_buffer
 {
-	int lock[2];
-	unsigned char **planes;
+    int lock[2];
+    unsigned char **planes;
 };
 
 struct pullup_field
 {
-	int parity;
-	struct pullup_buffer *buffer;
-	unsigned int flags;
-	int breaks;
-	int affinity;
-	int *diffs;
-	int *comb;
-	int *var;
-	struct pullup_field *prev, *next;
+    int parity;
+    struct pullup_buffer *buffer;
+    unsigned int flags;
+    int breaks;
+    int affinity;
+    int *diffs;
+    int *comb;
+    int *var;
+    struct pullup_field *prev, *next;
 };
 
 struct pullup_frame
 {
-	int lock;
-	int length;
-	int parity;
-	struct pullup_buffer **ifields, *ofields[2];
-	struct pullup_buffer *buffer;
+    int lock;
+    int length;
+    int parity;
+    struct pullup_buffer **ifields, *ofields[2];
+    struct pullup_buffer *buffer;
 };
 
 struct pullup_context
 {
-	/* Public interface */
-	int format;
-	int nplanes;
-	int *bpp, *w, *h, *stride, *background;
-	unsigned int cpu;
-	int junk_left, junk_right, junk_top, junk_bottom;
-	int verbose;
-	int metric_plane;
-	int strict_breaks;
-	int strict_pairs;
-	/* Internal data */
-	struct pullup_field *first, *last, *head;
-	struct pullup_buffer *buffers;
-	int nbuffers;
-	int (*diff)(unsigned char *, unsigned char *, int);
-	int (*comb)(unsigned char *, unsigned char *, int);
-	int (*var)(unsigned char *, unsigned char *, int);
-	int metric_w, metric_h, metric_len, metric_offset;
-	struct pullup_frame *frame;
+    /* Public interface */
+    int format;
+    int nplanes;
+    int *bpp, *w, *h, *stride, *background;
+    unsigned int cpu;
+    int junk_left, junk_right, junk_top, junk_bottom;
+    int verbose;
+    int metric_plane;
+    int strict_breaks;
+    int strict_pairs;
+    /* Internal data */
+    struct pullup_field *first, *last, *head;
+    struct pullup_buffer *buffers;
+    int nbuffers;
+    int (*diff)(unsigned char *, unsigned char *, int);
+    int (*comb)(unsigned char *, unsigned char *, int);
+    int (*var)(unsigned char *, unsigned char *, int);
+    int metric_w, metric_h, metric_len, metric_offset;
+    struct pullup_frame *frame;
 };
 
 

--- a/mythtv/libs/libmythbase/loggingserver.cpp
+++ b/mythtv/libs/libmythbase/loggingserver.cpp
@@ -360,7 +360,7 @@ bool SyslogLogger::logmsg(LoggingItem *item)
             "SYSLOG_IDENTIFIER=%s", item->rawAppName(),
             "SYSLOG_PID=%d", item->pid(),
             "MYTH_THREAD=%s", item->rawThreadName(),
-	    NULL
+        NULL
         );
         return true;
     }

--- a/mythtv/libs/libmythbase/mythcdrom-linux.cpp
+++ b/mythtv/libs/libmythbase/mythcdrom-linux.cpp
@@ -354,12 +354,12 @@ MythMediaError MythCDROMLinux::ejectSCSI()
     } fd(qPrintable(m_DevicePath));
 
     LOG(VB_MEDIA, LOG_DEBUG, LOC + ":ejectSCSI");
-	if ((ioctl(fd, SG_GET_VERSION_NUM, &k) < 0) || (k < 30000))
+    if ((ioctl(fd, SG_GET_VERSION_NUM, &k) < 0) || (k < 30000))
     {
-	    // not an sg device, or old sg driver
+        // not an sg device, or old sg driver
         LOG(VB_MEDIA, LOG_DEBUG, "SG_GET_VERSION_NUM ioctl failed" + ENO);
         return MEDIAERR_FAILED;
-	}
+    }
 
     io_hdr.cmd_len = 6;
     io_hdr.mx_sb_len = sizeof(sense_buffer);
@@ -371,36 +371,36 @@ MythMediaError MythCDROMLinux::ejectSCSI()
     if (ioctl(fd, SG_IO, &io_hdr) < 0)
     {
         LOG(VB_MEDIA, LOG_DEBUG, "SG_IO allowRmBlk ioctl failed" + ENO);
-	    return MEDIAERR_FAILED;
+        return MEDIAERR_FAILED;
     }
     else if (io_hdr.host_status != DID_OK || io_hdr.driver_status != DRIVER_OK)
     {
         LOG(VB_MEDIA, LOG_DEBUG, "SG_IO allowRmBlk failed");
-	    return MEDIAERR_FAILED;
+        return MEDIAERR_FAILED;
     }
 
     io_hdr.cmdp = startStop1Blk;
     if (ioctl(fd, SG_IO, &io_hdr) < 0)
     {
         LOG(VB_MEDIA, LOG_DEBUG, "SG_IO START_STOP(start) ioctl failed" + ENO);
-	    return MEDIAERR_FAILED;
+        return MEDIAERR_FAILED;
     }
     else if (io_hdr.host_status != DID_OK || io_hdr.driver_status != DRIVER_OK)
     {
         LOG(VB_MEDIA, LOG_DEBUG, "SG_IO START_STOP(start) failed");
-	    return MEDIAERR_FAILED;
+        return MEDIAERR_FAILED;
     }
 
     io_hdr.cmdp = startStop2Blk;
     if (ioctl(fd, SG_IO, &io_hdr) < 0)
     {
         LOG(VB_MEDIA, LOG_DEBUG, "SG_IO START_STOP(eject) ioctl failed" + ENO);
-	    return MEDIAERR_FAILED;
+        return MEDIAERR_FAILED;
     }
     else if (io_hdr.host_status != DID_OK || io_hdr.driver_status != DRIVER_OK)
     {
         LOG(VB_MEDIA, LOG_DEBUG, "SG_IO START_STOP(eject) failed");
-	    return MEDIAERR_FAILED;
+        return MEDIAERR_FAILED;
     }
 
     /* force kernel to reread partition table when new disc inserted */

--- a/mythtv/libs/libmythbase/mythcommandlineparser.cpp
+++ b/mythtv/libs/libmythbase/mythcommandlineparser.cpp
@@ -2603,8 +2603,8 @@ int MythCommandLineParser::ConfigureLogging(QString mask, unsigned int progress)
     if (journal)
     {
         if (facility >= 0)
-	    return GENERIC_EXIT_INVALID_CMDLINE;
-	facility = SYSTEMD_JOURNAL_FACILITY;
+        return GENERIC_EXIT_INVALID_CMDLINE;
+    facility = SYSTEMD_JOURNAL_FACILITY;
     }
 #endif
     bool dblog = toBool("enabledblog");

--- a/mythtv/libs/libmythbase/mythdbcon.cpp
+++ b/mythtv/libs/libmythbase/mythdbcon.cpp
@@ -184,7 +184,12 @@ bool MSqlDatabase::OpenDatabase(bool skipdb)
                             .arg(m_dbparms.wolCommand));
                 }
 
-                sleep(m_dbparms.wolReconnect);
+                QTime sleepTime = QTime::currentTime().addSecs(m_dbparms.wolReconnect);
+                while (QTime::currentTime() < sleepTime)
+                {
+                     QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 100);
+                     sleep(1); // Must not be longer than the X session manager save session timeout (on xfce 60 seconds).
+                }
                 connected = m_db.open();
             }
 

--- a/mythtv/libs/libmythbase/mythversion.h
+++ b/mythtv/libs/libmythbase/mythversion.h
@@ -64,7 +64,7 @@
  *      mythtv/bindings/php/MythBackend.php
  */
 
-#define MYTH_DATABASE_VERSION "1348"
+#define MYTH_DATABASE_VERSION "1347"
 
 
  MBASE_PUBLIC  const char *GetMythSourceVersion();

--- a/mythtv/libs/libmythbase/unzip.cpp
+++ b/mythtv/libs/libmythbase/unzip.cpp
@@ -39,40 +39,40 @@
 #include <QtDebug>
 
 /*!
-	\class UnZip unzip.h
+    \class UnZip unzip.h
 
-	\brief PKZip 2.0 file decompression.
-	Compatibility with later versions is not ensured as they may use
-	unsupported compression algorithms.
-	Versions after 2.7 may have an incompatible header format and thus be
-	completely incompatible.
+    \brief PKZip 2.0 file decompression.
+    Compatibility with later versions is not ensured as they may use
+    unsupported compression algorithms.
+    Versions after 2.7 may have an incompatible header format and thus be
+    completely incompatible.
 */
 
 /*! \enum UnZip::ErrorCode The result of a decompression operation.
-	\value UnZip::Ok No error occurred.
-	\value UnZip::ZlibInit Failed to init or load the zlib library.
-	\value UnZip::ZlibError The zlib library returned some error.
-	\value UnZip::OpenFailed Unable to create or open a device.
-	\value UnZip::PartiallyCorrupted Corrupted zip archive - some files could be extracted.
-	\value UnZip::Corrupted Corrupted or invalid zip archive.
-	\value UnZip::WrongPassword Unable to decrypt a password protected file.
-	\value UnZip::NoOpenArchive No archive has been opened yet.
-	\value UnZip::FileNotFound Unable to find the requested file in the archive.
-	\value UnZip::ReadFailed Reading of a file failed.
-	\value UnZip::WriteFailed Writing of a file failed.
-	\value UnZip::SeekFailed Seek failed.
-	\value UnZip::CreateDirFailed Could not create a directory.
-	\value UnZip::InvalidDevice A null device has been passed as parameter.
-	\value UnZip::InvalidArchive This is not a valid (or supported) ZIP archive.
-	\value UnZip::HeaderConsistencyError Local header record info does not match with the central directory record info. The archive may be corrupted.
+    \value UnZip::Ok No error occurred.
+    \value UnZip::ZlibInit Failed to init or load the zlib library.
+    \value UnZip::ZlibError The zlib library returned some error.
+    \value UnZip::OpenFailed Unable to create or open a device.
+    \value UnZip::PartiallyCorrupted Corrupted zip archive - some files could be extracted.
+    \value UnZip::Corrupted Corrupted or invalid zip archive.
+    \value UnZip::WrongPassword Unable to decrypt a password protected file.
+    \value UnZip::NoOpenArchive No archive has been opened yet.
+    \value UnZip::FileNotFound Unable to find the requested file in the archive.
+    \value UnZip::ReadFailed Reading of a file failed.
+    \value UnZip::WriteFailed Writing of a file failed.
+    \value UnZip::SeekFailed Seek failed.
+    \value UnZip::CreateDirFailed Could not create a directory.
+    \value UnZip::InvalidDevice A null device has been passed as parameter.
+    \value UnZip::InvalidArchive This is not a valid (or supported) ZIP archive.
+    \value UnZip::HeaderConsistencyError Local header record info does not match with the central directory record info. The archive may be corrupted.
 
-	\value UnZip::Skip Internal use only.
-	\value UnZip::SkipAll Internal use only.
+    \value UnZip::Skip Internal use only.
+    \value UnZip::SkipAll Internal use only.
 */
 
 /*! \enum UnZip::ExtractionOptions Some options for the file extraction methods.
-	\value UnZip::ExtractPaths Default. Does not ignore the path of the zipped files.
-	\value UnZip::SkipPaths Default. Ignores the path of the zipped files and extracts them all to the same root directory.
+    \value UnZip::ExtractPaths Default. Does not ignore the path of the zipped files.
+    \value UnZip::SkipPaths Default. Ignores the path of the zipped files and extracts them all to the same root directory.
 */
 
 //! Local header size (excluding signature, excluding variable length fields)
@@ -123,10 +123,10 @@
 #define UNZIP_EOCD_OFF_COMMLEN 16
 
 /*!
-	Max version handled by this API.
-	0x1B = 2.7 --> full compatibility only up to version 2.0 (0x14)
-	versions from 2.1 to 2.7 may use unsupported compression methods
-	versions after 2.7 may have an incompatible header format
+    Max version handled by this API.
+    0x1B = 2.7 --> full compatibility only up to version 2.0 (0x14)
+    versions from 2.1 to 2.7 may use unsupported compression methods
+    versions after 2.7 may have an incompatible header format
 */
 #define UNZIP_VERSION 0x1B
 //! Full compatibility granted until this version
@@ -137,22 +137,22 @@
 
 //! Checks if some file has been already extracted.
 #define UNZIP_CHECK_FOR_VALID_DATA \
-	{\
-		if (headers != 0)\
-		{\
-			qDebug() << "Corrupted zip archive. Some files might be extracted.";\
-			ec = headers->size() != 0 ? UnZip::PartiallyCorrupted : UnZip::Corrupted;\
-			break;\
-		}\
-		else\
-		{\
-			delete device;\
-			device = 0;\
-			qDebug() << "Corrupted or invalid zip archive";\
-			ec = UnZip::Corrupted;\
-			break;\
-		}\
-	}
+    {\
+        if (headers != 0)\
+        {\
+            qDebug() << "Corrupted zip archive. Some files might be extracted.";\
+            ec = headers->size() != 0 ? UnZip::PartiallyCorrupted : UnZip::Corrupted;\
+            break;\
+        }\
+        else\
+        {\
+            delete device;\
+            device = 0;\
+            qDebug() << "Corrupted or invalid zip archive";\
+            ec = UnZip::Corrupted;\
+            break;\
+        }\
+    }
 
 
 /************************************************************************
@@ -160,320 +160,320 @@
 *************************************************************************/
 
 /*!
-	Creates a new Zip file decompressor.
+    Creates a new Zip file decompressor.
 */
 UnZip::UnZip()
 {
-	d = new UnzipPrivate;
+    d = new UnzipPrivate;
 }
 
 /*!
-	Closes any open archive and releases used resources.
+    Closes any open archive and releases used resources.
 */
 UnZip::~UnZip()
 {
-	closeArchive();
-	delete d;
+    closeArchive();
+    delete d;
 }
 
 /*!
-	Returns true if there is an open archive.
+    Returns true if there is an open archive.
 */
 bool UnZip::isOpen() const
 {
-	return d->device != 0;
+    return d->device != 0;
 }
 
 /*!
-	Opens a zip archive and reads the files list. Closes any previously opened archive.
+    Opens a zip archive and reads the files list. Closes any previously opened archive.
 */
 UnZip::ErrorCode UnZip::openArchive(const QString& filename)
 {
-	QFile* file = new QFile(filename);
+    QFile* file = new QFile(filename);
 
-	if (!file->exists()) {
-		delete file;
-		return UnZip::FileNotFound;
-	}
+    if (!file->exists()) {
+        delete file;
+        return UnZip::FileNotFound;
+    }
 
-	if (!file->open(QIODevice::ReadOnly)) {
-		delete file;
-		return UnZip::OpenFailed;
-	}
+    if (!file->open(QIODevice::ReadOnly)) {
+        delete file;
+        return UnZip::OpenFailed;
+    }
 
-	return openArchive(file);
+    return openArchive(file);
 }
 
 /*!
-	Opens a zip archive and reads the entries list.
-	Closes any previously opened archive.
-	\warning The class takes ownership of the device so don't delete it!
+    Opens a zip archive and reads the entries list.
+    Closes any previously opened archive.
+    \warning The class takes ownership of the device so don't delete it!
 */
 UnZip::ErrorCode UnZip::openArchive(QIODevice* device)
 {
-	if (device == 0)
-	{
-		qDebug() << "Invalid device.";
-		return UnZip::InvalidDevice;
-	}
+    if (device == 0)
+    {
+        qDebug() << "Invalid device.";
+        return UnZip::InvalidDevice;
+    }
 
-	return d->openArchive(device);
+    return d->openArchive(device);
 }
 
 /*!
-	Closes the archive and releases all the used resources (like cached passwords).
+    Closes the archive and releases all the used resources (like cached passwords).
 */
 void UnZip::closeArchive()
 {
-	d->closeArchive();
+    d->closeArchive();
 }
 
 QString UnZip::archiveComment() const
 {
-	if (d->device == 0)
-		return QString();
-	return d->comment;
+    if (d->device == 0)
+        return QString();
+    return d->comment;
 }
 
 /*!
-	Returns a locale translated error string for a given error code.
+    Returns a locale translated error string for a given error code.
 */
 QString UnZip::formatError(UnZip::ErrorCode c) const
 {
-	switch (c)
-	{
-	case Ok: return QCoreApplication::translate("UnZip", "ZIP operation completed successfully."); break;
-	case ZlibInit: return QCoreApplication::translate("UnZip", "Failed to initialize or load zlib library."); break;
-	case ZlibError: return QCoreApplication::translate("UnZip", "zlib library error."); break;
-	case OpenFailed: return QCoreApplication::translate("UnZip", "Unable to create or open file."); break;
-	case PartiallyCorrupted: return QCoreApplication::translate("UnZip", "Partially corrupted archive. Some files might be extracted."); break;
-	case Corrupted: return QCoreApplication::translate("UnZip", "Corrupted archive."); break;
-	case WrongPassword: return QCoreApplication::translate("UnZip", "Wrong password."); break;
-	case NoOpenArchive: return QCoreApplication::translate("UnZip", "No archive has been created yet."); break;
-	case FileNotFound: return QCoreApplication::translate("UnZip", "File or directory does not exist."); break;
-	case ReadFailed: return QCoreApplication::translate("UnZip", "File read error."); break;
-	case WriteFailed: return QCoreApplication::translate("UnZip", "File write error."); break;
-	case SeekFailed: return QCoreApplication::translate("UnZip", "File seek error."); break;
-	case CreateDirFailed: return QCoreApplication::translate("UnZip", "Unable to create a directory."); break;
-	case InvalidDevice: return QCoreApplication::translate("UnZip", "Invalid device."); break;
-	case InvalidArchive: return QCoreApplication::translate("UnZip", "Invalid or incompatible zip archive."); break;
-	case HeaderConsistencyError: return QCoreApplication::translate("UnZip", "Inconsistent headers. Archive might be corrupted."); break;
-	default: ;
-	}
+    switch (c)
+    {
+    case Ok: return QCoreApplication::translate("UnZip", "ZIP operation completed successfully."); break;
+    case ZlibInit: return QCoreApplication::translate("UnZip", "Failed to initialize or load zlib library."); break;
+    case ZlibError: return QCoreApplication::translate("UnZip", "zlib library error."); break;
+    case OpenFailed: return QCoreApplication::translate("UnZip", "Unable to create or open file."); break;
+    case PartiallyCorrupted: return QCoreApplication::translate("UnZip", "Partially corrupted archive. Some files might be extracted."); break;
+    case Corrupted: return QCoreApplication::translate("UnZip", "Corrupted archive."); break;
+    case WrongPassword: return QCoreApplication::translate("UnZip", "Wrong password."); break;
+    case NoOpenArchive: return QCoreApplication::translate("UnZip", "No archive has been created yet."); break;
+    case FileNotFound: return QCoreApplication::translate("UnZip", "File or directory does not exist."); break;
+    case ReadFailed: return QCoreApplication::translate("UnZip", "File read error."); break;
+    case WriteFailed: return QCoreApplication::translate("UnZip", "File write error."); break;
+    case SeekFailed: return QCoreApplication::translate("UnZip", "File seek error."); break;
+    case CreateDirFailed: return QCoreApplication::translate("UnZip", "Unable to create a directory."); break;
+    case InvalidDevice: return QCoreApplication::translate("UnZip", "Invalid device."); break;
+    case InvalidArchive: return QCoreApplication::translate("UnZip", "Invalid or incompatible zip archive."); break;
+    case HeaderConsistencyError: return QCoreApplication::translate("UnZip", "Inconsistent headers. Archive might be corrupted."); break;
+    default: ;
+    }
 
-	return QCoreApplication::translate("UnZip", "Unknown error.");
+    return QCoreApplication::translate("UnZip", "Unknown error.");
 }
 
 /*!
-	Returns true if the archive contains a file with the given path and name.
+    Returns true if the archive contains a file with the given path and name.
 */
 bool UnZip::contains(const QString& file) const
 {
-	if (d->headers == 0)
-		return false;
+    if (d->headers == 0)
+        return false;
 
-	return d->headers->contains(file);
+    return d->headers->contains(file);
 }
 
 /*!
-	Returns complete paths of files and directories in this archive.
+    Returns complete paths of files and directories in this archive.
 */
 QStringList UnZip::fileList() const
 {
-	return d->headers == 0 ? QStringList() : d->headers->keys();
+    return d->headers == 0 ? QStringList() : d->headers->keys();
 }
 
 /*!
-	Returns information for each (correctly parsed) entry of this archive.
+    Returns information for each (correctly parsed) entry of this archive.
 */
 QList<UnZip::ZipEntry> UnZip::entryList() const
 {
-	QList<UnZip::ZipEntry> list;
+    QList<UnZip::ZipEntry> list;
 
-	if (d->headers != 0)
-	{
-		for (QMap<QString,ZipEntryP*>::ConstIterator it = d->headers->constBegin(); it != d->headers->constEnd(); ++it)
-		{
-			const ZipEntryP* entry = it.value();
-			Q_ASSERT(entry != 0);
+    if (d->headers != 0)
+    {
+        for (QMap<QString,ZipEntryP*>::ConstIterator it = d->headers->constBegin(); it != d->headers->constEnd(); ++it)
+        {
+            const ZipEntryP* entry = it.value();
+            Q_ASSERT(entry != 0);
 
-			ZipEntry z;
+            ZipEntry z;
 
-			z.filename = it.key();
-			if (!entry->comment.isEmpty())
-				z.comment = entry->comment;
-			z.compressedSize = entry->szComp;
-			z.uncompressedSize = entry->szUncomp;
-			z.crc32 = entry->crc;
-			z.lastModified = d->convertDateTime(entry->modDate, entry->modTime);
+            z.filename = it.key();
+            if (!entry->comment.isEmpty())
+                z.comment = entry->comment;
+            z.compressedSize = entry->szComp;
+            z.uncompressedSize = entry->szUncomp;
+            z.crc32 = entry->crc;
+            z.lastModified = d->convertDateTime(entry->modDate, entry->modTime);
 
-			z.compression = entry->compMethod == 0 ? NoCompression : entry->compMethod == 8 ? Deflated : UnknownCompression;
-			z.type = z.filename.endsWith("/") ? Directory : File;
+            z.compression = entry->compMethod == 0 ? NoCompression : entry->compMethod == 8 ? Deflated : UnknownCompression;
+            z.type = z.filename.endsWith("/") ? Directory : File;
 
-			z.encrypted = entry->isEncrypted();
+            z.encrypted = entry->isEncrypted();
 
-			list.append(z);
-		}
-	}
+            list.append(z);
+        }
+    }
 
-	return list;
+    return list;
 }
 
 /*!
-	Extracts the whole archive to a directory.
+    Extracts the whole archive to a directory.
 */
 UnZip::ErrorCode UnZip::extractAll(const QString& dirname, ExtractionOptions options)
 {
-	return extractAll(QDir(dirname), options);
+    return extractAll(QDir(dirname), options);
 }
 
 /*!
-	Extracts the whole archive to a directory.
+    Extracts the whole archive to a directory.
 */
 UnZip::ErrorCode UnZip::extractAll(const QDir& dir, ExtractionOptions options)
 {
-	// this should only happen if we didn't call openArchive() yet
-	if (d->device == 0)
-		return NoOpenArchive;
+    // this should only happen if we didn't call openArchive() yet
+    if (d->device == 0)
+        return NoOpenArchive;
 
-	if (d->headers == 0)
-		return Ok;
+    if (d->headers == 0)
+        return Ok;
 
-	bool end = false;
-	for (QMap<QString,ZipEntryP*>::Iterator itr = d->headers->begin(); itr != d->headers->end(); ++itr)
-	{
-		ZipEntryP* entry = itr.value();
-		Q_ASSERT(entry != 0);
+    bool end = false;
+    for (QMap<QString,ZipEntryP*>::Iterator itr = d->headers->begin(); itr != d->headers->end(); ++itr)
+    {
+        ZipEntryP* entry = itr.value();
+        Q_ASSERT(entry != 0);
 
-		if ((entry->isEncrypted()) && d->skipAllEncrypted)
-			continue;
+        if ((entry->isEncrypted()) && d->skipAllEncrypted)
+            continue;
 
-		switch (d->extractFile(itr.key(), *entry, dir, options))
-		{
-		case Corrupted:
-			qDebug() << "Removing corrupted entry" << itr.key();
-			d->headers->erase(itr++);
-			if (itr == d->headers->end())
-				end = true;
-			break;
-		case CreateDirFailed:
-			break;
-		case Skip:
-			break;
-		case SkipAll:
-			d->skipAllEncrypted = true;
-			break;
-		default:
-			;
-		}
+        switch (d->extractFile(itr.key(), *entry, dir, options))
+        {
+        case Corrupted:
+            qDebug() << "Removing corrupted entry" << itr.key();
+            d->headers->erase(itr++);
+            if (itr == d->headers->end())
+                end = true;
+            break;
+        case CreateDirFailed:
+            break;
+        case Skip:
+            break;
+        case SkipAll:
+            d->skipAllEncrypted = true;
+            break;
+        default:
+            ;
+        }
 
-		if (end)
-			break;
-	}
+        if (end)
+            break;
+    }
 
-	return Ok;
+    return Ok;
 }
 
 /*!
-	Extracts a single file to a directory.
+    Extracts a single file to a directory.
 */
 UnZip::ErrorCode UnZip::extractFile(const QString& filename, const QString& dirname, ExtractionOptions options)
 {
-	return extractFile(filename, QDir(dirname), options);
+    return extractFile(filename, QDir(dirname), options);
 }
 
 /*!
-	Extracts a single file to a directory.
+    Extracts a single file to a directory.
 */
 UnZip::ErrorCode UnZip::extractFile(const QString& filename, const QDir& dir, ExtractionOptions options)
 {
-	QMap<QString,ZipEntryP*>::Iterator itr = d->headers->find(filename);
-	if (itr != d->headers->end())
-	{
-		ZipEntryP* entry = itr.value();
-		Q_ASSERT(entry != 0);
-		return d->extractFile(itr.key(), *entry, dir, options);
-	}
+    QMap<QString,ZipEntryP*>::Iterator itr = d->headers->find(filename);
+    if (itr != d->headers->end())
+    {
+        ZipEntryP* entry = itr.value();
+        Q_ASSERT(entry != 0);
+        return d->extractFile(itr.key(), *entry, dir, options);
+    }
 
-	return FileNotFound;
+    return FileNotFound;
 }
 
 /*!
-	Extracts a single file to a directory.
+    Extracts a single file to a directory.
 */
 UnZip::ErrorCode UnZip::extractFile(const QString& filename, QIODevice* dev, ExtractionOptions options)
 {
-	if (dev == 0)
-		return InvalidDevice;
+    if (dev == 0)
+        return InvalidDevice;
 
-	QMap<QString,ZipEntryP*>::Iterator itr = d->headers->find(filename);
-	if (itr != d->headers->end()) {
-		ZipEntryP* entry = itr.value();
-		Q_ASSERT(entry != 0);
-		return d->extractFile(itr.key(), *entry, dev, options);
-	}
+    QMap<QString,ZipEntryP*>::Iterator itr = d->headers->find(filename);
+    if (itr != d->headers->end()) {
+        ZipEntryP* entry = itr.value();
+        Q_ASSERT(entry != 0);
+        return d->extractFile(itr.key(), *entry, dev, options);
+    }
 
-	return FileNotFound;
+    return FileNotFound;
 }
 
 /*!
-	Extracts a list of files.
-	Stops extraction at the first error (but continues if a file does not exist in the archive).
+    Extracts a list of files.
+    Stops extraction at the first error (but continues if a file does not exist in the archive).
  */
 UnZip::ErrorCode UnZip::extractFiles(const QStringList& filenames, const QString& dirname, ExtractionOptions options)
 {
-	QDir dir(dirname);
-	ErrorCode ec;
+    QDir dir(dirname);
+    ErrorCode ec;
 
-	for (QStringList::ConstIterator itr = filenames.constBegin(); itr != filenames.constEnd(); ++itr)
-	{
-		ec = extractFile(*itr, dir, options);
-		if (ec == FileNotFound)
-			continue;
-		if (ec != Ok)
-			return ec;
-	}
+    for (QStringList::ConstIterator itr = filenames.constBegin(); itr != filenames.constEnd(); ++itr)
+    {
+        ec = extractFile(*itr, dir, options);
+        if (ec == FileNotFound)
+            continue;
+        if (ec != Ok)
+            return ec;
+    }
 
-	return Ok;
+    return Ok;
 }
 
 /*!
-	Extracts a list of files.
-	Stops extraction at the first error (but continues if a file does not exist in the archive).
+    Extracts a list of files.
+    Stops extraction at the first error (but continues if a file does not exist in the archive).
  */
 UnZip::ErrorCode UnZip::extractFiles(const QStringList& filenames, const QDir& dir, ExtractionOptions options)
 {
-	ErrorCode ec;
+    ErrorCode ec;
 
-	for (QStringList::ConstIterator itr = filenames.constBegin(); itr != filenames.constEnd(); ++itr)
-	{
-		ec = extractFile(*itr, dir, options);
-		if (ec == FileNotFound)
-			continue;
-		if (ec != Ok)
-			return ec;
-	}
+    for (QStringList::ConstIterator itr = filenames.constBegin(); itr != filenames.constEnd(); ++itr)
+    {
+        ec = extractFile(*itr, dir, options);
+        if (ec == FileNotFound)
+            continue;
+        if (ec != Ok)
+            return ec;
+    }
 
-	return Ok;
+    return Ok;
 }
 
 /*!
-	Remove/replace this method to add your own password retrieval routine.
+    Remove/replace this method to add your own password retrieval routine.
 */
 void UnZip::setPassword(const QString& pwd)
 {
-	d->password = pwd;
+    d->password = pwd;
 }
 
 /*!
-	ZipEntry constructor - initialize data. Type is set to File.
+    ZipEntry constructor - initialize data. Type is set to File.
 */
 UnZip::ZipEntry::ZipEntry()
 {
-	compressedSize = uncompressedSize = crc32 = 0;
-	compression = NoCompression;
-	type = File;
-	encrypted = false;
+    compressedSize = uncompressedSize = crc32 = 0;
+    compression = NoCompression;
+    type = File;
+    encrypted = false;
 }
 
 
@@ -484,881 +484,881 @@ UnZip::ZipEntry::ZipEntry()
 //! \internal
 UnzipPrivate::UnzipPrivate()
 {
-	skipAllEncrypted = false;
-	headers = 0;
-	device = 0;
+    skipAllEncrypted = false;
+    headers = 0;
+    device = 0;
 
     memset(buffer1, 0, sizeof(buffer1));
     memset(buffer2, 0, sizeof(buffer2));
 
-	uBuffer = (unsigned char*) buffer1;
-	crcTable = (quint32*) get_crc_table();
+    uBuffer = (unsigned char*) buffer1;
+    crcTable = (quint32*) get_crc_table();
 
-	cdOffset = eocdOffset = 0;
-	cdEntryCount = 0;
-	unsupportedEntryCount = 0;
+    cdOffset = eocdOffset = 0;
+    cdEntryCount = 0;
+    unsupportedEntryCount = 0;
 }
 
 //! \internal Parses a Zip archive.
 UnZip::ErrorCode UnzipPrivate::openArchive(QIODevice* dev)
 {
-	Q_ASSERT(dev != 0);
+    Q_ASSERT(dev != 0);
 
-	if (device != 0)
-		closeArchive();
+    if (device != 0)
+        closeArchive();
 
-	device = dev;
+    device = dev;
 
-	if (!(device->isOpen() || device->open(QIODevice::ReadOnly)))
-	{
-		delete device;
-		device = 0;
+    if (!(device->isOpen() || device->open(QIODevice::ReadOnly)))
+    {
+        delete device;
+        device = 0;
 
-		qDebug() << "Unable to open device for reading";
-		return UnZip::OpenFailed;
-	}
+        qDebug() << "Unable to open device for reading";
+        return UnZip::OpenFailed;
+    }
 
-	UnZip::ErrorCode ec;
+    UnZip::ErrorCode ec;
 
-	ec = seekToCentralDirectory();
-	if (ec != UnZip::Ok)
-	{
-		closeArchive();
-		return ec;
-	}
+    ec = seekToCentralDirectory();
+    if (ec != UnZip::Ok)
+    {
+        closeArchive();
+        return ec;
+    }
 
-	//! \todo Ignore CD entry count? CD may be corrupted.
-	if (cdEntryCount == 0)
-	{
-		return UnZip::Ok;
-	}
+    //! \todo Ignore CD entry count? CD may be corrupted.
+    if (cdEntryCount == 0)
+    {
+        return UnZip::Ok;
+    }
 
-	bool continueParsing = true;
+    bool continueParsing = true;
 
-	while (continueParsing)
-	{
-		if (device->read(buffer1, 4) != 4)
-			UNZIP_CHECK_FOR_VALID_DATA
+    while (continueParsing)
+    {
+        if (device->read(buffer1, 4) != 4)
+            UNZIP_CHECK_FOR_VALID_DATA
 
-		if (! (buffer1[0] == 'P' && buffer1[1] == 'K' && buffer1[2] == 0x01  && buffer1[3] == 0x02) )
-			break;
+        if (! (buffer1[0] == 'P' && buffer1[1] == 'K' && buffer1[2] == 0x01  && buffer1[3] == 0x02) )
+            break;
 
-		if ( (ec = parseCentralDirectoryRecord()) != UnZip::Ok )
-			break;
-	}
+        if ( (ec = parseCentralDirectoryRecord()) != UnZip::Ok )
+            break;
+    }
 
-	if (ec != UnZip::Ok)
-		closeArchive();
+    if (ec != UnZip::Ok)
+        closeArchive();
 
-	return ec;
+    return ec;
 }
 
 /*
-	\internal Parses a local header record and makes some consistency check
-	with the information stored in the Central Directory record for this entry
-	that has been previously parsed.
-	\todo Optional consistency check (as a ExtractionOptions flag)
+    \internal Parses a local header record and makes some consistency check
+    with the information stored in the Central Directory record for this entry
+    that has been previously parsed.
+    \todo Optional consistency check (as a ExtractionOptions flag)
 
-	local file header signature     4 bytes  (0x04034b50)
-	version needed to extract       2 bytes
-	general purpose bit flag        2 bytes
-	compression method              2 bytes
-	last mod file time              2 bytes
-	last mod file date              2 bytes
-	crc-32                          4 bytes
-	compressed size                 4 bytes
-	uncompressed size               4 bytes
-	file name length                2 bytes
-	extra field length              2 bytes
+    local file header signature     4 bytes  (0x04034b50)
+    version needed to extract       2 bytes
+    general purpose bit flag        2 bytes
+    compression method              2 bytes
+    last mod file time              2 bytes
+    last mod file date              2 bytes
+    crc-32                          4 bytes
+    compressed size                 4 bytes
+    uncompressed size               4 bytes
+    file name length                2 bytes
+    extra field length              2 bytes
 
-	file name (variable size)
-	extra field (variable size)
+    file name (variable size)
+    extra field (variable size)
 */
 UnZip::ErrorCode UnzipPrivate::parseLocalHeaderRecord(const QString& path, ZipEntryP& entry)
 {
-	if (!device->seek(entry.lhOffset))
-		return UnZip::SeekFailed;
+    if (!device->seek(entry.lhOffset))
+        return UnZip::SeekFailed;
 
-	// Test signature
-	if (device->read(buffer1, 4) != 4)
-		return UnZip::ReadFailed;
+    // Test signature
+    if (device->read(buffer1, 4) != 4)
+        return UnZip::ReadFailed;
 
-	if ((buffer1[0] != 'P') || (buffer1[1] != 'K') || (buffer1[2] != 0x03) || (buffer1[3] != 0x04))
-		return UnZip::InvalidArchive;
+    if ((buffer1[0] != 'P') || (buffer1[1] != 'K') || (buffer1[2] != 0x03) || (buffer1[3] != 0x04))
+        return UnZip::InvalidArchive;
 
-	if (device->read(buffer1, UNZIP_LOCAL_HEADER_SIZE) != UNZIP_LOCAL_HEADER_SIZE)
-		return UnZip::ReadFailed;
+    if (device->read(buffer1, UNZIP_LOCAL_HEADER_SIZE) != UNZIP_LOCAL_HEADER_SIZE)
+        return UnZip::ReadFailed;
 
-	/*
-		Check 3rd general purpose bit flag.
+    /*
+        Check 3rd general purpose bit flag.
 
-		"bit 3: If this bit is set, the fields crc-32, compressed size
-		and uncompressed size are set to zero in the local
-		header.  The correct values are put in the data descriptor
-		immediately following the compressed data."
-	*/
-	bool hasDataDescriptor = entry.hasDataDescriptor();
+        "bit 3: If this bit is set, the fields crc-32, compressed size
+        and uncompressed size are set to zero in the local
+        header.  The correct values are put in the data descriptor
+        immediately following the compressed data."
+    */
+    bool hasDataDescriptor = entry.hasDataDescriptor();
 
-	bool checkFailed = false;
+    bool checkFailed = false;
 
-	if (!checkFailed)
-		checkFailed = entry.compMethod != getUShort(uBuffer, UNZIP_LH_OFF_CMETHOD);
-	if (!checkFailed)
-		checkFailed = entry.gpFlag[0] != uBuffer[UNZIP_LH_OFF_GPFLAG];
-	if (!checkFailed)
-		checkFailed = entry.gpFlag[1] != uBuffer[UNZIP_LH_OFF_GPFLAG + 1];
-	if (!checkFailed)
-		checkFailed = entry.modTime[0] != uBuffer[UNZIP_LH_OFF_MODT];
-	if (!checkFailed)
-		checkFailed = entry.modTime[1] != uBuffer[UNZIP_LH_OFF_MODT + 1];
-	if (!checkFailed)
-		checkFailed = entry.modDate[0] != uBuffer[UNZIP_LH_OFF_MODD];
-	if (!checkFailed)
-		checkFailed = entry.modDate[1] != uBuffer[UNZIP_LH_OFF_MODD + 1];
-	if (!hasDataDescriptor)
-	{
-		if (!checkFailed)
-			checkFailed = entry.crc != getULong(uBuffer, UNZIP_LH_OFF_CRC32);
-		if (!checkFailed)
-			checkFailed = entry.szComp != getULong(uBuffer, UNZIP_LH_OFF_CSIZE);
-		if (!checkFailed)
-			checkFailed = entry.szUncomp != getULong(uBuffer, UNZIP_LH_OFF_USIZE);
-	}
+    if (!checkFailed)
+        checkFailed = entry.compMethod != getUShort(uBuffer, UNZIP_LH_OFF_CMETHOD);
+    if (!checkFailed)
+        checkFailed = entry.gpFlag[0] != uBuffer[UNZIP_LH_OFF_GPFLAG];
+    if (!checkFailed)
+        checkFailed = entry.gpFlag[1] != uBuffer[UNZIP_LH_OFF_GPFLAG + 1];
+    if (!checkFailed)
+        checkFailed = entry.modTime[0] != uBuffer[UNZIP_LH_OFF_MODT];
+    if (!checkFailed)
+        checkFailed = entry.modTime[1] != uBuffer[UNZIP_LH_OFF_MODT + 1];
+    if (!checkFailed)
+        checkFailed = entry.modDate[0] != uBuffer[UNZIP_LH_OFF_MODD];
+    if (!checkFailed)
+        checkFailed = entry.modDate[1] != uBuffer[UNZIP_LH_OFF_MODD + 1];
+    if (!hasDataDescriptor)
+    {
+        if (!checkFailed)
+            checkFailed = entry.crc != getULong(uBuffer, UNZIP_LH_OFF_CRC32);
+        if (!checkFailed)
+            checkFailed = entry.szComp != getULong(uBuffer, UNZIP_LH_OFF_CSIZE);
+        if (!checkFailed)
+            checkFailed = entry.szUncomp != getULong(uBuffer, UNZIP_LH_OFF_USIZE);
+    }
 
-	if (checkFailed)
-		return UnZip::HeaderConsistencyError;
+    if (checkFailed)
+        return UnZip::HeaderConsistencyError;
 
-	// Check filename
-	quint16 szName = getUShort(uBuffer, UNZIP_LH_OFF_NAMELEN);
-	if (szName == 0)
-		return UnZip::HeaderConsistencyError;
+    // Check filename
+    quint16 szName = getUShort(uBuffer, UNZIP_LH_OFF_NAMELEN);
+    if (szName == 0)
+        return UnZip::HeaderConsistencyError;
 
-	if (device->read(buffer2, szName) != szName)
-		return UnZip::ReadFailed;
+    if (device->read(buffer2, szName) != szName)
+        return UnZip::ReadFailed;
 
-	QString filename = QString::fromLatin1(buffer2, szName);
-	if (filename != path)
-	{
-		qDebug() << "Filename in local header mismatches.";
-		return UnZip::HeaderConsistencyError;
-	}
+    QString filename = QString::fromLatin1(buffer2, szName);
+    if (filename != path)
+    {
+        qDebug() << "Filename in local header mismatches.";
+        return UnZip::HeaderConsistencyError;
+    }
 
-	// Skip extra field
-	quint16 szExtra = getUShort(uBuffer, UNZIP_LH_OFF_XLEN);
-	if (szExtra != 0)
-	{
-		if (!device->seek(device->pos() + szExtra))
-			return UnZip::SeekFailed;
-	}
+    // Skip extra field
+    quint16 szExtra = getUShort(uBuffer, UNZIP_LH_OFF_XLEN);
+    if (szExtra != 0)
+    {
+        if (!device->seek(device->pos() + szExtra))
+            return UnZip::SeekFailed;
+    }
 
-	entry.dataOffset = device->pos();
+    entry.dataOffset = device->pos();
 
-	if (hasDataDescriptor)
-	{
-		/*
-			The data descriptor has this OPTIONAL signature: PK\7\8
-			We try to skip the compressed data relying on the size set in the
-			Central Directory record.
-		*/
-		if (!device->seek(device->pos() + entry.szComp))
-			return UnZip::SeekFailed;
+    if (hasDataDescriptor)
+    {
+        /*
+            The data descriptor has this OPTIONAL signature: PK\7\8
+            We try to skip the compressed data relying on the size set in the
+            Central Directory record.
+        */
+        if (!device->seek(device->pos() + entry.szComp))
+            return UnZip::SeekFailed;
 
-		// Read 4 bytes and check if there is a data descriptor signature
-		if (device->read(buffer2, 4) != 4)
-			return UnZip::ReadFailed;
+        // Read 4 bytes and check if there is a data descriptor signature
+        if (device->read(buffer2, 4) != 4)
+            return UnZip::ReadFailed;
 
-		bool hasSignature = buffer2[0] == 'P' && buffer2[1] == 'K' && buffer2[2] == 0x07 && buffer2[3] == 0x08;
-		if (hasSignature)
-		{
-			if (device->read(buffer2, UNZIP_DD_SIZE) != UNZIP_DD_SIZE)
-				return UnZip::ReadFailed;
-		}
-		else
-		{
-			if (device->read(buffer2 + 4, UNZIP_DD_SIZE - 4) != UNZIP_DD_SIZE - 4)
-				return UnZip::ReadFailed;
-		}
+        bool hasSignature = buffer2[0] == 'P' && buffer2[1] == 'K' && buffer2[2] == 0x07 && buffer2[3] == 0x08;
+        if (hasSignature)
+        {
+            if (device->read(buffer2, UNZIP_DD_SIZE) != UNZIP_DD_SIZE)
+                return UnZip::ReadFailed;
+        }
+        else
+        {
+            if (device->read(buffer2 + 4, UNZIP_DD_SIZE - 4) != UNZIP_DD_SIZE - 4)
+                return UnZip::ReadFailed;
+        }
 
-		// DD: crc, compressed size, uncompressed size
-		if (
-			entry.crc != getULong((unsigned char*)buffer2, UNZIP_DD_OFF_CRC32) ||
-			entry.szComp != getULong((unsigned char*)buffer2, UNZIP_DD_OFF_CSIZE) ||
-			entry.szUncomp != getULong((unsigned char*)buffer2, UNZIP_DD_OFF_USIZE)
-			)
-			return UnZip::HeaderConsistencyError;
-	}
+        // DD: crc, compressed size, uncompressed size
+        if (
+            entry.crc != getULong((unsigned char*)buffer2, UNZIP_DD_OFF_CRC32) ||
+            entry.szComp != getULong((unsigned char*)buffer2, UNZIP_DD_OFF_CSIZE) ||
+            entry.szUncomp != getULong((unsigned char*)buffer2, UNZIP_DD_OFF_USIZE)
+            )
+            return UnZip::HeaderConsistencyError;
+    }
 
-	return UnZip::Ok;
+    return UnZip::Ok;
 }
 
 /*! \internal Attempts to find the start of the central directory record.
 
-	We seek the file back until we reach the "End Of Central Directory"
-	signature PK\5\6.
+    We seek the file back until we reach the "End Of Central Directory"
+    signature PK\5\6.
 
-	end of central dir signature    4 bytes  (0x06054b50)
-	number of this disk             2 bytes
-	number of the disk with the
-	start of the central directory  2 bytes
-	total number of entries in the
-	central directory on this disk  2 bytes
-	total number of entries in
-	the central directory           2 bytes
-	size of the central directory   4 bytes
-	offset of start of central
-	directory with respect to
-	the starting disk number        4 bytes
-	.ZIP file comment length        2 bytes
-	--- SIZE UNTIL HERE: UNZIP_EOCD_SIZE ---
-	.ZIP file comment       (variable size)
+    end of central dir signature    4 bytes  (0x06054b50)
+    number of this disk             2 bytes
+    number of the disk with the
+    start of the central directory  2 bytes
+    total number of entries in the
+    central directory on this disk  2 bytes
+    total number of entries in
+    the central directory           2 bytes
+    size of the central directory   4 bytes
+    offset of start of central
+    directory with respect to
+    the starting disk number        4 bytes
+    .ZIP file comment length        2 bytes
+    --- SIZE UNTIL HERE: UNZIP_EOCD_SIZE ---
+    .ZIP file comment       (variable size)
 */
 UnZip::ErrorCode UnzipPrivate::seekToCentralDirectory()
 {
-	qint64 length = device->size();
-	qint64 offset = length - UNZIP_EOCD_SIZE;
+    qint64 length = device->size();
+    qint64 offset = length - UNZIP_EOCD_SIZE;
 
-	if (length < UNZIP_EOCD_SIZE)
-		return UnZip::InvalidArchive;
+    if (length < UNZIP_EOCD_SIZE)
+        return UnZip::InvalidArchive;
 
-	if (!device->seek( offset ))
-		return UnZip::SeekFailed;
+    if (!device->seek( offset ))
+        return UnZip::SeekFailed;
 
-	if (device->read(buffer1, UNZIP_EOCD_SIZE) != UNZIP_EOCD_SIZE)
-		return UnZip::ReadFailed;
+    if (device->read(buffer1, UNZIP_EOCD_SIZE) != UNZIP_EOCD_SIZE)
+        return UnZip::ReadFailed;
 
-	bool eocdFound = (buffer1[0] == 'P' && buffer1[1] == 'K' && buffer1[2] == 0x05 && buffer1[3] == 0x06);
+    bool eocdFound = (buffer1[0] == 'P' && buffer1[1] == 'K' && buffer1[2] == 0x05 && buffer1[3] == 0x06);
 
-	if (eocdFound)
-	{
-		// Zip file has no comment (the only variable length field in the EOCD record)
-		eocdOffset = offset;
-	}
-	else
-	{
-		qint64 read;
-		char* p = 0;
+    if (eocdFound)
+    {
+        // Zip file has no comment (the only variable length field in the EOCD record)
+        eocdOffset = offset;
+    }
+    else
+    {
+        qint64 read;
+        char* p = 0;
 
-		offset -= UNZIP_EOCD_SIZE;
+        offset -= UNZIP_EOCD_SIZE;
 
-		if (offset <= 0)
-			return UnZip::InvalidArchive;
+        if (offset <= 0)
+            return UnZip::InvalidArchive;
 
-		if (!device->seek( offset ))
-			return UnZip::SeekFailed;
+        if (!device->seek( offset ))
+            return UnZip::SeekFailed;
 
-		while ((read = device->read(buffer1, UNZIP_EOCD_SIZE)) >= 0)
-		{
-			if ( (p = strstr(buffer1, "PK\5\6")) != 0)
-			{
-				// Seek to the start of the EOCD record so we can read it fully
-				// Yes... we could simply read the missing bytes and append them to the buffer
-				// but this is far easier so heck it!
-				device->seek( offset + (p - buffer1) );
-				eocdFound = true;
-				eocdOffset = offset + (p - buffer1);
+        while ((read = device->read(buffer1, UNZIP_EOCD_SIZE)) >= 0)
+        {
+            if ( (p = strstr(buffer1, "PK\5\6")) != 0)
+            {
+                // Seek to the start of the EOCD record so we can read it fully
+                // Yes... we could simply read the missing bytes and append them to the buffer
+                // but this is far easier so heck it!
+                device->seek( offset + (p - buffer1) );
+                eocdFound = true;
+                eocdOffset = offset + (p - buffer1);
 
-				// Read EOCD record
-				if (device->read(buffer1, UNZIP_EOCD_SIZE) != UNZIP_EOCD_SIZE)
-					return UnZip::ReadFailed;
+                // Read EOCD record
+                if (device->read(buffer1, UNZIP_EOCD_SIZE) != UNZIP_EOCD_SIZE)
+                    return UnZip::ReadFailed;
 
-				break;
-			}
+                break;
+            }
 
-			// TODO: This is very slow and only a temporary bug fix. Need some pattern matching algorithm here.
-			offset -= 1 /*UNZIP_EOCD_SIZE*/;
-			if (offset <= 0)
-				return UnZip::InvalidArchive;
+            // TODO: This is very slow and only a temporary bug fix. Need some pattern matching algorithm here.
+            offset -= 1 /*UNZIP_EOCD_SIZE*/;
+            if (offset <= 0)
+                return UnZip::InvalidArchive;
 
-			if (!device->seek( offset ))
-				return UnZip::SeekFailed;
-		}
-	}
+            if (!device->seek( offset ))
+                return UnZip::SeekFailed;
+        }
+    }
 
-	if (!eocdFound)
-		return UnZip::InvalidArchive;
+    if (!eocdFound)
+        return UnZip::InvalidArchive;
 
-	// Parse EOCD to locate CD offset
-	offset = getULong((const unsigned char*)buffer1, UNZIP_EOCD_OFF_CDOFF + 4);
+    // Parse EOCD to locate CD offset
+    offset = getULong((const unsigned char*)buffer1, UNZIP_EOCD_OFF_CDOFF + 4);
 
-	cdOffset = offset;
+    cdOffset = offset;
 
-	cdEntryCount = getUShort((const unsigned char*)buffer1, UNZIP_EOCD_OFF_ENTRIES + 4);
+    cdEntryCount = getUShort((const unsigned char*)buffer1, UNZIP_EOCD_OFF_ENTRIES + 4);
 
-	quint16 commentLength = getUShort((const unsigned char*)buffer1, UNZIP_EOCD_OFF_COMMLEN + 4);
-	if (commentLength != 0)
-	{
-		QByteArray c = device->read(commentLength);
-		if (c.count() != commentLength)
-			return UnZip::ReadFailed;
+    quint16 commentLength = getUShort((const unsigned char*)buffer1, UNZIP_EOCD_OFF_COMMLEN + 4);
+    if (commentLength != 0)
+    {
+        QByteArray c = device->read(commentLength);
+        if (c.count() != commentLength)
+            return UnZip::ReadFailed;
 
-		comment = c;
-	}
+        comment = c;
+    }
 
-	// Seek to the start of the CD record
-	if (!device->seek( cdOffset ))
-		return UnZip::SeekFailed;
+    // Seek to the start of the CD record
+    if (!device->seek( cdOffset ))
+        return UnZip::SeekFailed;
 
-	return UnZip::Ok;
+    return UnZip::Ok;
 }
 
 /*!
-	\internal Parses a central directory record.
+    \internal Parses a central directory record.
 
-	Central Directory record structure:
+    Central Directory record structure:
 
-	[file header 1]
-	.
-	.
-	.
-	[file header n]
-	[digital signature] // PKZip 6.2 or later only
+    [file header 1]
+    .
+    .
+    .
+    [file header n]
+    [digital signature] // PKZip 6.2 or later only
 
-	File header:
+    File header:
 
-	central file header signature   4 bytes  (0x02014b50)
-	version made by                 2 bytes
-	version needed to extract       2 bytes
-	general purpose bit flag        2 bytes
-	compression method              2 bytes
-	last mod file time              2 bytes
-	last mod file date              2 bytes
-	crc-32                          4 bytes
-	compressed size                 4 bytes
-	uncompressed size               4 bytes
-	file name length                2 bytes
-	extra field length              2 bytes
-	file comment length             2 bytes
-	disk number start               2 bytes
-	internal file attributes        2 bytes
-	external file attributes        4 bytes
-	relative offset of local header 4 bytes
+    central file header signature   4 bytes  (0x02014b50)
+    version made by                 2 bytes
+    version needed to extract       2 bytes
+    general purpose bit flag        2 bytes
+    compression method              2 bytes
+    last mod file time              2 bytes
+    last mod file date              2 bytes
+    crc-32                          4 bytes
+    compressed size                 4 bytes
+    uncompressed size               4 bytes
+    file name length                2 bytes
+    extra field length              2 bytes
+    file comment length             2 bytes
+    disk number start               2 bytes
+    internal file attributes        2 bytes
+    external file attributes        4 bytes
+    relative offset of local header 4 bytes
 
-	file name (variable size)
-	extra field (variable size)
-	file comment (variable size)
+    file name (variable size)
+    extra field (variable size)
+    file comment (variable size)
 */
 UnZip::ErrorCode UnzipPrivate::parseCentralDirectoryRecord()
 {
-	// Read CD record
-	if (device->read(buffer1, UNZIP_CD_ENTRY_SIZE_NS) != UNZIP_CD_ENTRY_SIZE_NS)
-		return UnZip::ReadFailed;
+    // Read CD record
+    if (device->read(buffer1, UNZIP_CD_ENTRY_SIZE_NS) != UNZIP_CD_ENTRY_SIZE_NS)
+        return UnZip::ReadFailed;
 
-	bool skipEntry = false;
+    bool skipEntry = false;
 
-	// Get compression type so we can skip non compatible algorithms
-	quint16 compMethod = getUShort(uBuffer, UNZIP_CD_OFF_CMETHOD);
+    // Get compression type so we can skip non compatible algorithms
+    quint16 compMethod = getUShort(uBuffer, UNZIP_CD_OFF_CMETHOD);
 
-	// Get variable size fields length so we can skip the whole record
-	// if necessary
-	quint16 szName = getUShort(uBuffer, UNZIP_CD_OFF_NAMELEN);
-	quint16 szExtra = getUShort(uBuffer, UNZIP_CD_OFF_XLEN);
-	quint16 szComment = getUShort(uBuffer, UNZIP_CD_OFF_COMMLEN);
+    // Get variable size fields length so we can skip the whole record
+    // if necessary
+    quint16 szName = getUShort(uBuffer, UNZIP_CD_OFF_NAMELEN);
+    quint16 szExtra = getUShort(uBuffer, UNZIP_CD_OFF_XLEN);
+    quint16 szComment = getUShort(uBuffer, UNZIP_CD_OFF_COMMLEN);
 
-	quint32 skipLength = szName + szExtra + szComment;
+    quint32 skipLength = szName + szExtra + szComment;
 
-	UnZip::ErrorCode ec = UnZip::Ok;
+    UnZip::ErrorCode ec = UnZip::Ok;
 
-	if ((compMethod != 0) && (compMethod != 8))
-	{
-		qDebug() << "Unsupported compression method. Skipping file.";
-		skipEntry = true;
-	}
+    if ((compMethod != 0) && (compMethod != 8))
+    {
+        qDebug() << "Unsupported compression method. Skipping file.";
+        skipEntry = true;
+    }
 
-	// Header parsing may be a problem if version is bigger than UNZIP_VERSION
-	if (!skipEntry && buffer1[UNZIP_CD_OFF_VERSION] > UNZIP_VERSION)
-	{
-		qDebug() << "Unsupported PKZip version. Skipping file.";
-		skipEntry = true;
-	}
+    // Header parsing may be a problem if version is bigger than UNZIP_VERSION
+    if (!skipEntry && buffer1[UNZIP_CD_OFF_VERSION] > UNZIP_VERSION)
+    {
+        qDebug() << "Unsupported PKZip version. Skipping file.";
+        skipEntry = true;
+    }
 
-	if (!skipEntry && szName == 0)
-	{
-		qDebug() << "Skipping file with no name.";
-		skipEntry = true;
-	}
+    if (!skipEntry && szName == 0)
+    {
+        qDebug() << "Skipping file with no name.";
+        skipEntry = true;
+    }
 
-	if (!skipEntry && device->read(buffer2, szName) != szName)
-	{
-		ec = UnZip::ReadFailed;
-		skipEntry = true;
-	}
+    if (!skipEntry && device->read(buffer2, szName) != szName)
+    {
+        ec = UnZip::ReadFailed;
+        skipEntry = true;
+    }
 
-	if (skipEntry)
-	{
-		if (ec == UnZip::Ok)
-		{
-			if (!device->seek( device->pos() + skipLength ))
-				ec = UnZip::SeekFailed;
+    if (skipEntry)
+    {
+        if (ec == UnZip::Ok)
+        {
+            if (!device->seek( device->pos() + skipLength ))
+                ec = UnZip::SeekFailed;
 
-			unsupportedEntryCount++;
-		}
+            unsupportedEntryCount++;
+        }
 
-		return ec;
-	}
+        return ec;
+    }
 
-	QString filename = QString::fromLatin1(buffer2, szName);
+    QString filename = QString::fromLatin1(buffer2, szName);
 
-	ZipEntryP* h = new ZipEntryP;
-	h->compMethod = compMethod;
+    ZipEntryP* h = new ZipEntryP;
+    h->compMethod = compMethod;
 
-	h->gpFlag[0] = buffer1[UNZIP_CD_OFF_GPFLAG];
-	h->gpFlag[1] = buffer1[UNZIP_CD_OFF_GPFLAG + 1];
+    h->gpFlag[0] = buffer1[UNZIP_CD_OFF_GPFLAG];
+    h->gpFlag[1] = buffer1[UNZIP_CD_OFF_GPFLAG + 1];
 
-	h->modTime[0] = buffer1[UNZIP_CD_OFF_MODT];
-	h->modTime[1] = buffer1[UNZIP_CD_OFF_MODT + 1];
+    h->modTime[0] = buffer1[UNZIP_CD_OFF_MODT];
+    h->modTime[1] = buffer1[UNZIP_CD_OFF_MODT + 1];
 
-	h->modDate[0] = buffer1[UNZIP_CD_OFF_MODD];
-	h->modDate[1] = buffer1[UNZIP_CD_OFF_MODD + 1];
+    h->modDate[0] = buffer1[UNZIP_CD_OFF_MODD];
+    h->modDate[1] = buffer1[UNZIP_CD_OFF_MODD + 1];
 
-	h->crc = getULong(uBuffer, UNZIP_CD_OFF_CRC32);
-	h->szComp = getULong(uBuffer, UNZIP_CD_OFF_CSIZE);
-	h->szUncomp = getULong(uBuffer, UNZIP_CD_OFF_USIZE);
+    h->crc = getULong(uBuffer, UNZIP_CD_OFF_CRC32);
+    h->szComp = getULong(uBuffer, UNZIP_CD_OFF_CSIZE);
+    h->szUncomp = getULong(uBuffer, UNZIP_CD_OFF_USIZE);
 
-	// Skip extra field (if any)
-	if (szExtra != 0)
-	{
-		if (!device->seek( device->pos() + szExtra ))
-		{
-			delete h;
-			return UnZip::SeekFailed;
-		}
-	}
+    // Skip extra field (if any)
+    if (szExtra != 0)
+    {
+        if (!device->seek( device->pos() + szExtra ))
+        {
+            delete h;
+            return UnZip::SeekFailed;
+        }
+    }
 
-	// Read comment field (if any)
-	if (szComment != 0)
-	{
-		if (device->read(buffer2, szComment) != szComment)
-		{
-			delete h;
-			return UnZip::ReadFailed;
-		}
+    // Read comment field (if any)
+    if (szComment != 0)
+    {
+        if (device->read(buffer2, szComment) != szComment)
+        {
+            delete h;
+            return UnZip::ReadFailed;
+        }
 
-		h->comment = QString::fromLatin1(buffer2, szComment);
-	}
+        h->comment = QString::fromLatin1(buffer2, szComment);
+    }
 
-	h->lhOffset = getULong(uBuffer, UNZIP_CD_OFF_LHOFFSET);
+    h->lhOffset = getULong(uBuffer, UNZIP_CD_OFF_LHOFFSET);
 
-	if (headers == 0)
-		headers = new QMap<QString, ZipEntryP*>();
-	headers->insert(filename, h);
+    if (headers == 0)
+        headers = new QMap<QString, ZipEntryP*>();
+    headers->insert(filename, h);
 
-	return UnZip::Ok;
+    return UnZip::Ok;
 }
 
 //! \internal Closes the archive and resets the internal status.
 void UnzipPrivate::closeArchive()
 {
-	if (device == 0)
-		return;
+    if (device == 0)
+        return;
 
-	skipAllEncrypted = false;
+    skipAllEncrypted = false;
 
-	if (headers != 0)
-	{
-		qDeleteAll(*headers);
-		delete headers;
-		headers = 0;
-	}
+    if (headers != 0)
+    {
+        qDeleteAll(*headers);
+        delete headers;
+        headers = 0;
+    }
 
-	delete device; device = 0;
+    delete device; device = 0;
 
-	cdOffset = eocdOffset = 0;
-	cdEntryCount = 0;
-	unsupportedEntryCount = 0;
+    cdOffset = eocdOffset = 0;
+    cdEntryCount = 0;
+    unsupportedEntryCount = 0;
 
-	comment.clear();
+    comment.clear();
 }
 
 //! \internal
 UnZip::ErrorCode UnzipPrivate::extractFile(const QString& path, ZipEntryP& entry, const QDir& dir, UnZip::ExtractionOptions options)
 {
-	QString name(path);
-	QString dirname;
-	QString directory;
+    QString name(path);
+    QString dirname;
+    QString directory;
 
-	int pos = name.lastIndexOf('/');
+    int pos = name.lastIndexOf('/');
 
-	// This entry is for a directory
-	if (pos == name.length() - 1)
-	{
-		if (options.testFlag(UnZip::SkipPaths))
-			return UnZip::Ok;
+    // This entry is for a directory
+    if (pos == name.length() - 1)
+    {
+        if (options.testFlag(UnZip::SkipPaths))
+            return UnZip::Ok;
 
-		directory = QString("%1/%2").arg(dir.absolutePath()).arg(QDir::cleanPath(name));
-		if (!createDirectory(directory))
-		{
-			qDebug() << QString("Unable to create directory: %1").arg(directory);
-			return UnZip::CreateDirFailed;
-		}
+        directory = QString("%1/%2").arg(dir.absolutePath()).arg(QDir::cleanPath(name));
+        if (!createDirectory(directory))
+        {
+            qDebug() << QString("Unable to create directory: %1").arg(directory);
+            return UnZip::CreateDirFailed;
+        }
 
-		return UnZip::Ok;
-	}
+        return UnZip::Ok;
+    }
 
-	// Extract path from entry
-	if (pos > 0)
-	{
-		// get directory part
-		dirname = name.left(pos);
-		if (options.testFlag(UnZip::SkipPaths))
-		{
-			directory = dir.absolutePath();
-		}
-		else
-		{
-			directory = QString("%1/%2").arg(dir.absolutePath()).arg(QDir::cleanPath(dirname));
-			if (!createDirectory(directory))
-			{
-				qDebug() << QString("Unable to create directory: %1").arg(directory);
-				return UnZip::CreateDirFailed;
-			}
-		}
-		name = name.right(name.length() - pos - 1);
-	} else directory = dir.absolutePath();
+    // Extract path from entry
+    if (pos > 0)
+    {
+        // get directory part
+        dirname = name.left(pos);
+        if (options.testFlag(UnZip::SkipPaths))
+        {
+            directory = dir.absolutePath();
+        }
+        else
+        {
+            directory = QString("%1/%2").arg(dir.absolutePath()).arg(QDir::cleanPath(dirname));
+            if (!createDirectory(directory))
+            {
+                qDebug() << QString("Unable to create directory: %1").arg(directory);
+                return UnZip::CreateDirFailed;
+            }
+        }
+        name = name.right(name.length() - pos - 1);
+    } else directory = dir.absolutePath();
 
-	name = QString("%1/%2").arg(directory).arg(name);
+    name = QString("%1/%2").arg(directory).arg(name);
 
-	QFile outFile(name);
+    QFile outFile(name);
 
-	if (!outFile.open(QIODevice::WriteOnly))
-	{
-		qDebug() << QString("Unable to open %1 for writing").arg(name);
-		return UnZip::OpenFailed;
-	}
+    if (!outFile.open(QIODevice::WriteOnly))
+    {
+        qDebug() << QString("Unable to open %1 for writing").arg(name);
+        return UnZip::OpenFailed;
+    }
 
-	//! \todo Set creation/last_modified date/time
+    //! \todo Set creation/last_modified date/time
 
-	UnZip::ErrorCode ec = extractFile(path, entry, &outFile, options);
+    UnZip::ErrorCode ec = extractFile(path, entry, &outFile, options);
 
-	outFile.close();
+    outFile.close();
 
-	if (ec != UnZip::Ok)
-	{
-		if (!outFile.remove())
-			qDebug() << QString("Unable to remove corrupted file: %1").arg(name);
-	}
+    if (ec != UnZip::Ok)
+    {
+        if (!outFile.remove())
+            qDebug() << QString("Unable to remove corrupted file: %1").arg(name);
+    }
 
-	return ec;
+    return ec;
 }
 
 //! \internal
 UnZip::ErrorCode UnzipPrivate::extractFile(const QString& path, ZipEntryP& entry, QIODevice* dev, UnZip::ExtractionOptions options)
 {
-	Q_UNUSED(options);
-	Q_ASSERT(dev != 0);
+    Q_UNUSED(options);
+    Q_ASSERT(dev != 0);
 
-	if (!entry.lhEntryChecked)
-	{
-		UnZip::ErrorCode ec = parseLocalHeaderRecord(path, entry);
-		entry.lhEntryChecked = true;
+    if (!entry.lhEntryChecked)
+    {
+        UnZip::ErrorCode ec = parseLocalHeaderRecord(path, entry);
+        entry.lhEntryChecked = true;
 
-		if (ec != UnZip::Ok)
-			return ec;
-	}
+        if (ec != UnZip::Ok)
+            return ec;
+    }
 
-	if (!device->seek(entry.dataOffset))
-		return UnZip::SeekFailed;
+    if (!device->seek(entry.dataOffset))
+        return UnZip::SeekFailed;
 
-	// Encryption keys
-	quint32 keys[3];
+    // Encryption keys
+    quint32 keys[3];
 
-	if (entry.isEncrypted())
-	{
-		UnZip::ErrorCode e = testPassword(keys, path, entry);
-		if (e != UnZip::Ok)
-		{
-			qDebug() << QString("Unable to decrypt %1").arg(path);
-			return e;
-		}//! Encryption header size
-		entry.szComp -= UNZIP_LOCAL_ENC_HEADER_SIZE; // remove encryption header size
-	}
+    if (entry.isEncrypted())
+    {
+        UnZip::ErrorCode e = testPassword(keys, path, entry);
+        if (e != UnZip::Ok)
+        {
+            qDebug() << QString("Unable to decrypt %1").arg(path);
+            return e;
+        }//! Encryption header size
+        entry.szComp -= UNZIP_LOCAL_ENC_HEADER_SIZE; // remove encryption header size
+    }
 
-	if (entry.szComp == 0)
-	{
-		if (entry.crc != 0)
-			return UnZip::Corrupted;
+    if (entry.szComp == 0)
+    {
+        if (entry.crc != 0)
+            return UnZip::Corrupted;
 
-		return UnZip::Ok;
-	}
+        return UnZip::Ok;
+    }
 
-	uInt rep = entry.szComp / UNZIP_READ_BUFFER;
-	uInt rem = entry.szComp % UNZIP_READ_BUFFER;
-	uInt cur = 0;
+    uInt rep = entry.szComp / UNZIP_READ_BUFFER;
+    uInt rem = entry.szComp % UNZIP_READ_BUFFER;
+    uInt cur = 0;
 
-	// extract data
-	qint64 read;
-	quint64 tot = 0;
+    // extract data
+    qint64 read;
+    quint64 tot = 0;
 
-	quint32 myCRC = crc32(0L, Z_NULL, 0);
+    quint32 myCRC = crc32(0L, Z_NULL, 0);
 
-	if (entry.compMethod == 0)
-	{
-		while ( (read = device->read(buffer1, cur < rep ? UNZIP_READ_BUFFER : rem)) > 0 )
-		{
-			if (entry.isEncrypted())
-				decryptBytes(keys, buffer1, read);
+    if (entry.compMethod == 0)
+    {
+        while ( (read = device->read(buffer1, cur < rep ? UNZIP_READ_BUFFER : rem)) > 0 )
+        {
+            if (entry.isEncrypted())
+                decryptBytes(keys, buffer1, read);
 
-			myCRC = crc32(myCRC, uBuffer, read);
+            myCRC = crc32(myCRC, uBuffer, read);
 
-			if (dev->write(buffer1, read) != read)
-				return UnZip::WriteFailed;
+            if (dev->write(buffer1, read) != read)
+                return UnZip::WriteFailed;
 
-			cur++;
-			tot += read;
+            cur++;
+            tot += read;
 
-			if (tot == entry.szComp)
-				break;
-		}
+            if (tot == entry.szComp)
+                break;
+        }
 
-		if (read < 0)
-			return UnZip::ReadFailed;
-	}
-	else if (entry.compMethod == 8)
-	{
-		/* Allocate inflate state */
-		z_stream zstr;
-		zstr.zalloc = Z_NULL;
-		zstr.zfree = Z_NULL;
-		zstr.opaque = Z_NULL;
-		zstr.next_in = Z_NULL;
-		zstr.avail_in = 0;
+        if (read < 0)
+            return UnZip::ReadFailed;
+    }
+    else if (entry.compMethod == 8)
+    {
+        /* Allocate inflate state */
+        z_stream zstr;
+        zstr.zalloc = Z_NULL;
+        zstr.zfree = Z_NULL;
+        zstr.opaque = Z_NULL;
+        zstr.next_in = Z_NULL;
+        zstr.avail_in = 0;
 
-		int zret;
+        int zret;
 
-		// Use inflateInit2 with negative windowBits to get raw decompression
-		if ( (zret = inflateInit2_(&zstr, -MAX_WBITS, ZLIB_VERSION, sizeof(z_stream))) != Z_OK )
-			return UnZip::ZlibError;
+        // Use inflateInit2 with negative windowBits to get raw decompression
+        if ( (zret = inflateInit2_(&zstr, -MAX_WBITS, ZLIB_VERSION, sizeof(z_stream))) != Z_OK )
+            return UnZip::ZlibError;
 
-		int szDecomp;
+        int szDecomp;
 
-		// Decompress until deflate stream ends or end of file
-		do
-		{
-			read = device->read(buffer1, cur < rep ? UNZIP_READ_BUFFER : rem);
-			if (read == 0)
-				break;
-			if (read < 0)
-			{
-				(void)inflateEnd(&zstr);
-				return UnZip::ReadFailed;
-			}
+        // Decompress until deflate stream ends or end of file
+        do
+        {
+            read = device->read(buffer1, cur < rep ? UNZIP_READ_BUFFER : rem);
+            if (read == 0)
+                break;
+            if (read < 0)
+            {
+                (void)inflateEnd(&zstr);
+                return UnZip::ReadFailed;
+            }
 
-			if (entry.isEncrypted())
-				decryptBytes(keys, buffer1, read);
+            if (entry.isEncrypted())
+                decryptBytes(keys, buffer1, read);
 
-			cur++;
-			tot += read;
+            cur++;
+            tot += read;
 
-			zstr.avail_in = (uInt) read;
-			zstr.next_in = (Bytef*) buffer1;
+            zstr.avail_in = (uInt) read;
+            zstr.next_in = (Bytef*) buffer1;
 
 
-			// Run inflate() on input until output buffer not full
-			do {
-				zstr.avail_out = UNZIP_READ_BUFFER;
-				zstr.next_out = (Bytef*) buffer2;;
+            // Run inflate() on input until output buffer not full
+            do {
+                zstr.avail_out = UNZIP_READ_BUFFER;
+                zstr.next_out = (Bytef*) buffer2;;
 
-				zret = inflate(&zstr, Z_NO_FLUSH);
+                zret = inflate(&zstr, Z_NO_FLUSH);
 
-				switch (zret) {
-					case Z_NEED_DICT:
-					case Z_DATA_ERROR:
-					case Z_MEM_ERROR:
-						inflateEnd(&zstr);
-						return UnZip::WriteFailed;
-					default:
-						;
-				}
+                switch (zret) {
+                    case Z_NEED_DICT:
+                    case Z_DATA_ERROR:
+                    case Z_MEM_ERROR:
+                        inflateEnd(&zstr);
+                        return UnZip::WriteFailed;
+                    default:
+                        ;
+                }
 
-				szDecomp = UNZIP_READ_BUFFER - zstr.avail_out;
-				if (dev->write(buffer2, szDecomp) != szDecomp)
-				{
-					inflateEnd(&zstr);
-					return UnZip::ZlibError;
-				}
+                szDecomp = UNZIP_READ_BUFFER - zstr.avail_out;
+                if (dev->write(buffer2, szDecomp) != szDecomp)
+                {
+                    inflateEnd(&zstr);
+                    return UnZip::ZlibError;
+                }
 
-				myCRC = crc32(myCRC, (const Bytef*) buffer2, szDecomp);
+                myCRC = crc32(myCRC, (const Bytef*) buffer2, szDecomp);
 
-			} while (zstr.avail_out == 0);
+            } while (zstr.avail_out == 0);
 
-		}
-		while (zret != Z_STREAM_END);
+        }
+        while (zret != Z_STREAM_END);
 
-		inflateEnd(&zstr);
-	}
+        inflateEnd(&zstr);
+    }
 
-	if (myCRC != entry.crc)
-		return UnZip::Corrupted;
+    if (myCRC != entry.crc)
+        return UnZip::Corrupted;
 
-	return UnZip::Ok;
+    return UnZip::Ok;
 }
 
 //! \internal Creates a new directory and all the needed parent directories.
 bool UnzipPrivate::createDirectory(const QString& path)
 {
-	QDir d(path);
-	if (!d.exists())
-	{
-		int sep = path.lastIndexOf("/");
-		if (sep <= 0) return true;
+    QDir d(path);
+    if (!d.exists())
+    {
+        int sep = path.lastIndexOf("/");
+        if (sep <= 0) return true;
 
-		if (!createDirectory(path.left(sep)))
-			return false;
+        if (!createDirectory(path.left(sep)))
+            return false;
 
-		if (!d.mkdir(path))
-		{
-			qDebug() << QString("Unable to create directory: %1").arg(path);
-			return false;
-		}
-	}
+        if (!d.mkdir(path))
+        {
+            qDebug() << QString("Unable to create directory: %1").arg(path);
+            return false;
+        }
+    }
 
-	return true;
+    return true;
 }
 
 /*!
-	\internal Reads an quint32 (4 bytes) from a byte array starting at given offset.
+    \internal Reads an quint32 (4 bytes) from a byte array starting at given offset.
 */
 quint32 UnzipPrivate::getULong(const unsigned char* data, quint32 offset) const
 {
-	quint32 res = (quint32) data[offset];
-	res |= (((quint32)data[offset+1]) << 8);
-	res |= (((quint32)data[offset+2]) << 16);
-	res |= (((quint32)data[offset+3]) << 24);
+    quint32 res = (quint32) data[offset];
+    res |= (((quint32)data[offset+1]) << 8);
+    res |= (((quint32)data[offset+2]) << 16);
+    res |= (((quint32)data[offset+3]) << 24);
 
-	return res;
+    return res;
 }
 
 /*!
-	\internal Reads an quint64 (8 bytes) from a byte array starting at given offset.
+    \internal Reads an quint64 (8 bytes) from a byte array starting at given offset.
 */
 quint64 UnzipPrivate::getULLong(const unsigned char* data, quint32 offset) const
 {
-	quint64 res = (quint64) data[offset];
-	res |= (((quint64)data[offset+1]) << 8);
-	res |= (((quint64)data[offset+2]) << 16);
-	res |= (((quint64)data[offset+3]) << 24);
-	res |= (((quint64)data[offset+1]) << 32);
-	res |= (((quint64)data[offset+2]) << 40);
-	res |= (((quint64)data[offset+3]) << 48);
-	res |= (((quint64)data[offset+3]) << 56);
+    quint64 res = (quint64) data[offset];
+    res |= (((quint64)data[offset+1]) << 8);
+    res |= (((quint64)data[offset+2]) << 16);
+    res |= (((quint64)data[offset+3]) << 24);
+    res |= (((quint64)data[offset+1]) << 32);
+    res |= (((quint64)data[offset+2]) << 40);
+    res |= (((quint64)data[offset+3]) << 48);
+    res |= (((quint64)data[offset+3]) << 56);
 
-	return res;
+    return res;
 }
 
 /*!
-	\internal Reads an quint16 (2 bytes) from a byte array starting at given offset.
+    \internal Reads an quint16 (2 bytes) from a byte array starting at given offset.
 */
 quint16 UnzipPrivate::getUShort(const unsigned char* data, quint32 offset) const
 {
-	return (quint16) data[offset] | (((quint16)data[offset+1]) << 8);
+    return (quint16) data[offset] | (((quint16)data[offset+1]) << 8);
 }
 
 /*!
-	\internal Return the next byte in the pseudo-random sequence
+    \internal Return the next byte in the pseudo-random sequence
  */
 int UnzipPrivate::decryptByte(quint32 key2) const
 {
-	quint16 temp = ((quint16)(key2) & 0xffff) | 2;
-	return (int)(((temp * (temp ^ 1)) >> 8) & 0xff);
+    quint16 temp = ((quint16)(key2) & 0xffff) | 2;
+    return (int)(((temp * (temp ^ 1)) >> 8) & 0xff);
 }
 
 /*!
-	\internal Update the encryption keys with the next byte of plain text
+    \internal Update the encryption keys with the next byte of plain text
  */
 void UnzipPrivate::updateKeys(quint32* keys, int c) const
 {
-	keys[0] = CRC32(keys[0], c);
-	keys[1] += keys[0] & 0xff;
-	keys[1] = keys[1] * 134775813L + 1;
-	keys[2] = CRC32(keys[2], ((int)keys[1]) >> 24);
+    keys[0] = CRC32(keys[0], c);
+    keys[1] += keys[0] & 0xff;
+    keys[1] = keys[1] * 134775813L + 1;
+    keys[2] = CRC32(keys[2], ((int)keys[1]) >> 24);
 }
 
 /*!
-	\internal Initialize the encryption keys and the random header according to
-	the given password.
+    \internal Initialize the encryption keys and the random header according to
+    the given password.
  */
 void UnzipPrivate::initKeys(const QString& pwd, quint32* keys) const
 {
-	keys[0] = 305419896L;
-	keys[1] = 591751049L;
-	keys[2] = 878082192L;
+    keys[0] = 305419896L;
+    keys[1] = 591751049L;
+    keys[2] = 878082192L;
 
-	QByteArray pwdBytes = pwd.toLatin1();
-	int sz = pwdBytes.size();
-	const char* ascii = pwdBytes.data();
+    QByteArray pwdBytes = pwd.toLatin1();
+    int sz = pwdBytes.size();
+    const char* ascii = pwdBytes.data();
 
-	for (int i=0; i<sz; ++i)
-		updateKeys(keys, (int)ascii[i]);
+    for (int i=0; i<sz; ++i)
+        updateKeys(keys, (int)ascii[i]);
 }
 
 /*!
-	\internal Attempts to test a password without actually extracting a file.
-	The \p file parameter can be used in the user interface or for debugging purposes
-	as it is the name of the encrypted file for wich the password is being tested.
+    \internal Attempts to test a password without actually extracting a file.
+    The \p file parameter can be used in the user interface or for debugging purposes
+    as it is the name of the encrypted file for wich the password is being tested.
 */
 UnZip::ErrorCode UnzipPrivate::testPassword(quint32* keys, const QString& file, const ZipEntryP& header)
 {
-	Q_UNUSED(file);
+    Q_UNUSED(file);
 
-	// read encryption keys
-	if (device->read(buffer1, 12) != 12)
-		return UnZip::Corrupted;
+    // read encryption keys
+    if (device->read(buffer1, 12) != 12)
+        return UnZip::Corrupted;
 
-	// Replace this code if you want to i.e. call some dialog and ask the user for a password
-	initKeys(password, keys);
-	if (testKeys(header, keys))
-		return UnZip::Ok;
+    // Replace this code if you want to i.e. call some dialog and ask the user for a password
+    initKeys(password, keys);
+    if (testKeys(header, keys))
+        return UnZip::Ok;
 
-	return UnZip::Skip;
+    return UnZip::Skip;
 }
 
 /*!
-	\internal Tests a set of keys on the encryption header.
+    \internal Tests a set of keys on the encryption header.
 */
 bool UnzipPrivate::testKeys(const ZipEntryP& header, quint32* keys)
 {
-	char lastByte;
+    char lastByte;
 
-	// decrypt encryption header
-	for (int i=0; i<11; ++i)
-		updateKeys(keys, lastByte = buffer1[i] ^ decryptByte(keys[2]));
-	updateKeys(keys, lastByte = buffer1[11] ^ decryptByte(keys[2]));
+    // decrypt encryption header
+    for (int i=0; i<11; ++i)
+        updateKeys(keys, lastByte = buffer1[i] ^ decryptByte(keys[2]));
+    updateKeys(keys, lastByte = buffer1[11] ^ decryptByte(keys[2]));
 
-	// if there is an extended header (bit in the gp flag) buffer[11] is a byte from the file time
-	// with no extended header we have to check the crc high-order byte
-	char c = ((header.gpFlag[0] & 0x08) == 8) ? header.modTime[1] : header.crc >> 24;
+    // if there is an extended header (bit in the gp flag) buffer[11] is a byte from the file time
+    // with no extended header we have to check the crc high-order byte
+    char c = ((header.gpFlag[0] & 0x08) == 8) ? header.modTime[1] : header.crc >> 24;
 
-	return (lastByte == c);
+    return (lastByte == c);
 }
 
 /*!
-	\internal Decrypts an array of bytes long \p read.
+    \internal Decrypts an array of bytes long \p read.
 */
 void UnzipPrivate::decryptBytes(quint32* keys, char* buffer, qint64 read)
 {
-	for (int i=0; i<(int)read; ++i)
-		updateKeys(keys, buffer[i] ^= decryptByte(keys[2]));
+    for (int i=0; i<(int)read; ++i)
+        updateKeys(keys, buffer[i] ^= decryptByte(keys[2]));
 }
 
 /*!
-	\internal Converts date and time values from ZIP format to a QDateTime object.
+    \internal Converts date and time values from ZIP format to a QDateTime object.
 */
 QDateTime UnzipPrivate::convertDateTime(const unsigned char date[2], const unsigned char time[2]) const
 {
-	QDateTime dt;
+    QDateTime dt;
 
-	// Usual PKZip low-byte to high-byte order
+    // Usual PKZip low-byte to high-byte order
 
-	// Date: 7 bits = years from 1980, 4 bits = month, 5 bits = day
-	quint16 year = (date[1] >> 1) & 127;
-	quint16 month = ((date[1] << 3) & 14) | ((date[0] >> 5) & 7);
-	quint16 day = date[0] & 31;
+    // Date: 7 bits = years from 1980, 4 bits = month, 5 bits = day
+    quint16 year = (date[1] >> 1) & 127;
+    quint16 month = ((date[1] << 3) & 14) | ((date[0] >> 5) & 7);
+    quint16 day = date[0] & 31;
 
-	// Time: 5 bits hour, 6 bits minutes, 5 bits seconds with a 2sec precision
-	quint16 hour = (time[1] >> 3) & 31;
-	quint16 minutes = ((time[1] << 3) & 56) | ((time[0] >> 5) & 7);
-	quint16 seconds = (time[0] & 31) * 2;
+    // Time: 5 bits hour, 6 bits minutes, 5 bits seconds with a 2sec precision
+    quint16 hour = (time[1] >> 3) & 31;
+    quint16 minutes = ((time[1] << 3) & 56) | ((time[0] >> 5) & 7);
+    quint16 seconds = (time[0] & 31) * 2;
 
-	dt = QDateTime(QDate(1980 + year, month, day),
+    dt = QDateTime(QDate(1980 + year, month, day),
                 QTime(hour, minutes, seconds), Qt::UTC);
-	return dt;
+    return dt;
 }

--- a/mythtv/libs/libmythbase/verbosedefs.h
+++ b/mythtv/libs/libmythbase/verbosedefs.h
@@ -178,6 +178,10 @@ VERBOSE_MAP(VB_REFCOUNT,  0x20000000000ULL, true,
             "Reference Count messages")
 VERBOSE_MAP(VB_HTTP,  0x40000000000ULL, true,
             "HTTP Server messages")
+VERBOSE_MAP(VB_DVBSICACHE, 0x80000000000ULL, true,
+            "DVB SI table section cache related messages")
+VERBOSE_MAP(VB_TEMPDEBUG, 0x100000000000ULL, true,
+            "Temporary debugging")
 VERBOSE_MAP(VB_NONE,      0x00000000, false,
             "NO debug output")
 VERBOSE_POSTAMBLE
@@ -204,14 +208,25 @@ typedef struct {
     bool        additive;
     QString     helpText;
 } VerboseDef;
-typedef QMap<QString, VerboseDef *> VerboseMap;
+
+typedef struct VMap : public QMap<QString, VerboseDef *>
+{
+    // Tidy up for heap debugging
+    ~VMap() { for (iterator i = begin(); i != end(); i++) delete *i; }
+} VerboseMap;
 
 typedef struct {
     int         value;
     QString     name;
     char        shortname;
 } LoglevelDef;
-typedef QMap<int, LoglevelDef *> LoglevelMap;
+
+typedef struct LLMap : public QMap<int, LoglevelDef *>
+{
+    // Tidy up for heap debugging
+    ~LLMap() { for (iterator i = begin(); i != end(); i++) delete *i; }
+} LoglevelMap;
+
 typedef QMap<uint64_t, LogLevel_t> ComponentLogLevelMap;
 
 extern VerboseMap verboseMap;

--- a/mythtv/libs/libmythfreemheg/Engine.cpp
+++ b/mythtv/libs/libmythfreemheg/Engine.cpp
@@ -1377,7 +1377,7 @@ bool MHEngine::GetEngineSupport(const MHOctetString &feature)
         // 'The Space' on Freeview checks this...
         if (strings[1] == "PANT11001")
             return true;
-	// Irish DTT expects "1285". From ETSI ES 202 184: UEP(1285) means the receiver has been verified as fully conformant.
+        // Irish DTT expects "1285". From ETSI ES 202 184: UEP(1285) means the receiver has been verified as fully conformant.
         if (strings[1] == "1285")
             return true;
         

--- a/mythtv/libs/libmythfreemheg/Text.cpp
+++ b/mythtv/libs/libmythfreemheg/Text.cpp
@@ -330,7 +330,7 @@ void MHText::Preparation(MHEngine *engine)
 
     if (m_pDisplay == NULL)
     {
-	    m_pDisplay = engine->GetContext()->CreateText();
+        m_pDisplay = engine->GetContext()->CreateText();
     }
 
     m_pDisplay->SetSize(m_nBoxWidth, m_nBoxHeight);

--- a/mythtv/libs/libmythprotoserver/requesthandler/basehandler.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/basehandler.cpp
@@ -101,8 +101,8 @@ bool BaseRequestHandler::HandleQueryLoad(SocketHandler *sock)
                 << QString::number(loads[1])
                 << QString::number(loads[2]);
 #else
-	strlist << "ERROR";
-	strlist << "getloadavg() not supported on Windows";
+    strlist << "ERROR";
+    strlist << "getloadavg() not supported on Windows";
 #endif
 
     sock->WriteStringList(strlist);

--- a/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.cpp
@@ -159,8 +159,8 @@ void FileServerHandler::RunDeleteThread(void)
 {
     if (deletethread != NULL)
     {
-		if (deletethread->isRunning())
-			return;
+        if (deletethread->isRunning())
+            return;
 
         delete deletethread;
         deletethread = NULL;

--- a/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
@@ -706,7 +706,7 @@ void ChannelScanSM::UpdateScanTransports(const NetworkInformationTable *nit)
                 case DescriptorID::satellite_delivery_system:
                 {
                     const SatelliteDeliverySystemDescriptor cd(desc);
-                    frequency = cd.FrequencyHz()/1000;
+                    frequency = cd.FrequencyKHz();
                     tt = DTVTunerType::kTunerTypeDVBS1;
                     break;
                 }

--- a/mythtv/libs/libmythtv/channelscan/channelscanner.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner.cpp
@@ -34,7 +34,6 @@ using namespace std;
 #include "iptvchannelfetcher.h"
 #include "dvbsignalmonitor.h"
 #include "scanwizardconfig.h"
-#include "channelscan_sm.h"
 #include "channelscanner.h"
 #include "hdhrchannel.h"
 #include "scanmonitor.h"

--- a/mythtv/libs/libmythtv/channelscan/channelscanner.h
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner.h
@@ -39,6 +39,7 @@
 #include "iptvchannelfetcher.h"
 #include "scanmonitor.h"
 #include "channelscantypes.h"
+#include "channelscan_sm.h"
 
 #ifdef USING_VBOX
 #include "vboxchannelfetcher.h"
@@ -126,6 +127,7 @@ class MTV_PUBLIC ChannelScanner
 
     /// Services desired post scan
     ServiceRequirements serviceRequirements;
+
 };
 
 #endif // _CHANNEL_SCANNER_H_

--- a/mythtv/libs/libmythtv/channelutil.cpp
+++ b/mythtv/libs/libmythtv/channelutil.cpp
@@ -329,7 +329,7 @@ static void handle_transport_desc(vector<uint> &muxes,
 
         uint mux = ChannelUtil::CreateMultiplex(
             sourceid,             "dvb",
-            cd.FrequencyKHz(),     cd.ModulationString(),
+            cd.FrequencyHz(),     cd.ModulationString(),
             // DVB specific
             tsid,                 netid,
             cd.SymbolRateHz(),    -1,

--- a/mythtv/libs/libmythtv/channelutil.cpp
+++ b/mythtv/libs/libmythtv/channelutil.cpp
@@ -329,7 +329,7 @@ static void handle_transport_desc(vector<uint> &muxes,
 
         uint mux = ChannelUtil::CreateMultiplex(
             sourceid,             "dvb",
-            cd.FrequencyHz(),     cd.ModulationString(),
+            cd.FrequencyKHz(),     cd.ModulationString(),
             // DVB specific
             tsid,                 netid,
             cd.SymbolRateHz(),    -1,

--- a/mythtv/libs/libmythtv/dbcheck.cpp
+++ b/mythtv/libs/libmythtv/dbcheck.cpp
@@ -3392,19 +3392,6 @@ NULL
             return false;
     }
 
-    if (dbver == "1347")
-    {
-        const char *updates[] = {
-            "ALTER TABLE record MODIFY COLUMN startdate DATE DEFAULT NULL",
-            "ALTER TABLE record MODIFY COLUMN enddate DATE DEFAULT NULL",
-            "ALTER TABLE record MODIFY COLUMN starttime TIME DEFAULT NULL",
-            "ALTER TABLE record MODIFY COLUMN endtime TIME DEFAULT NULL",
-            NULL
-        };
-        if (!performActualUpdate(updates, "1348", dbver))
-            return false;
-    }
-
     return true;
 }
 

--- a/mythtv/libs/libmythtv/dtvmultiplex.cpp
+++ b/mythtv/libs/libmythtv/dtvmultiplex.cpp
@@ -477,7 +477,7 @@ bool DTVMultiplex::FillFromDeliverySystemDesc(DTVTunerType type,
                 }
 
                 return ParseDVB_S_and_C(
-                    QString::number(cd.FrequencyHz()),  "a",
+                    QString::number(cd.FrequencyKHz()),  "a",
                     QString::number(cd.SymbolRateHz()), cd.FECInnerString(),
                     cd.ModulationString(),
                     cd.PolarizationString());
@@ -486,7 +486,7 @@ bool DTVMultiplex::FillFromDeliverySystemDesc(DTVTunerType type,
             if (type == DTVTunerType::kTunerTypeDVBS2)
             {
                 return ParseDVB_S2(
-                    QString::number(cd.FrequencyHz()),  "a",
+                    QString::number(cd.FrequencyKHz()),  "a",
                     QString::number(cd.SymbolRateHz()), cd.FECInnerString(),
                     cd.ModulationString(),
                     cd.PolarizationString(),

--- a/mythtv/libs/libmythtv/dtvmultiplex.cpp
+++ b/mythtv/libs/libmythtv/dtvmultiplex.cpp
@@ -477,7 +477,7 @@ bool DTVMultiplex::FillFromDeliverySystemDesc(DTVTunerType type,
                 }
 
                 return ParseDVB_S_and_C(
-                    QString::number(cd.FrequencyKHz()),  "a",
+                    QString::number(cd.FrequencyHz()),  "a",
                     QString::number(cd.SymbolRateHz()), cd.FECInnerString(),
                     cd.ModulationString(),
                     cd.PolarizationString());
@@ -486,7 +486,7 @@ bool DTVMultiplex::FillFromDeliverySystemDesc(DTVTunerType type,
             if (type == DTVTunerType::kTunerTypeDVBS2)
             {
                 return ParseDVB_S2(
-                    QString::number(cd.FrequencyKHz()),  "a",
+                    QString::number(cd.FrequencyHz()),  "a",
                     QString::number(cd.SymbolRateHz()), cd.FECInnerString(),
                     cd.ModulationString(),
                     cd.PolarizationString(),

--- a/mythtv/libs/libmythtv/eitcache.cpp
+++ b/mythtv/libs/libmythtv/eitcache.cpp
@@ -367,7 +367,10 @@ bool EITCache::IsNewEIT(uint chanid,  uint tableid,   uint version,
     {
         if (extract_table_id(*it) > tableid)
         {
-            // EIT from lower (ie. better) table number
+            // EIT from lower table number. The event is getting
+            // nearer to the present time.
+            // If the event is for the current day it might
+            // Already be in the past
             tblChgCnt++;
         }
         else if ((extract_table_id(*it) == tableid) &&

--- a/mythtv/libs/libmythtv/eitfixup.cpp
+++ b/mythtv/libs/libmythtv/eitfixup.cpp
@@ -864,7 +864,7 @@ void EITFixUp::FixUK(DBEventEIT &event) const
     event.description = event.description.remove(m_ukAllNew);
 
     // Removal of 'Also in HD' text
- 	event.description = event.description.remove(m_ukAlsoInHD);
+    event.description = event.description.remove(m_ukAlsoInHD);
 
     // Remove [AD,S] etc.
     bool    ccMatched = false;
@@ -947,8 +947,8 @@ void EITFixUp::FixUK(DBEventEIT &event) const
                 .arg(event.title, event.description));
 
             if (position2 == 0)
-     		    // Remove from the start of the description.
-		        // Otherwise it ends up in the subtitle.
+                // Remove from the start of the description.
+                // Otherwise it ends up in the subtitle.
                 event.description.remove(tmpSeries.cap(form));
         }
     }
@@ -1878,7 +1878,7 @@ void EITFixUp::FixDisneyChannel(DBEventEIT &event) const
         {
             event.airdate = tmp.cap(3).toUInt();
         }
-	event.subtitle.replace(tmp, "");
+    event.subtitle.replace(tmp, "");
     }
     tmp = QRegExp("\\s[^\\s]+-(Serie)");
     pos = tmp.indexIn(event.subtitle);

--- a/mythtv/libs/libmythtv/eithelper.cpp
+++ b/mythtv/libs/libmythtv/eithelper.cpp
@@ -351,352 +351,411 @@ static inline void parse_dvb_component_descriptors(desc_list_t list,
     }
 }
 
-void EITHelper::AddEIT(const DVBEventInformationTable *eit)
+void EITHelper::AddEIT(eit_sections_cache_const_t& EventInformationTable)
 {
     uint chanid = 0;
-    if ((eit->TableID() == TableID::PF_EIT) ||
-        ((eit->TableID() >= TableID::SC_EITbeg) && (eit->TableID() <= TableID::SC_EITend)))
+
+    eit_sections_cache_const_t::const_iterator eit_section_ptr = EventInformationTable.begin();
+
+    if (eit_section_ptr != EventInformationTable.end())
     {
-        // EITa(ctive)
-        chanid = GetChanID(eit->ServiceID());
-    }
-    else
-    {
-        // EITo(ther)
-        chanid = GetChanID(eit->ServiceID(), eit->OriginalNetworkID(), eit->TSID());
-        // do not reschedule if its only present+following
-        if (eit->TableID() != TableID::PF_EITo)
+        if (((*eit_section_ptr)->TableID() == TableID::PF_EIT) ||
+                (((*eit_section_ptr)->TableID() >= TableID::SC_EITbeg) && ((*eit_section_ptr)->TableID() <= TableID::SC_EITend)))
         {
-            seenEITother = true;
-        }
-    }
-    if (!chanid)
-        return;
-
-    uint descCompression = (eit->TableID() > 0x80) ? 2 : 1;
-    FixupValue fix = fixup.value((FixupKey)eit->OriginalNetworkID() << 16);
-    fix |= fixup.value((((FixupKey)eit->TSID()) << 32) |
-                 ((FixupKey)eit->OriginalNetworkID() << 16));
-    fix |= fixup.value(((FixupKey)eit->OriginalNetworkID() << 16) |
-                 (FixupKey)eit->ServiceID());
-    fix |= fixup.value((((FixupKey)eit->TSID()) << 32) |
-                 ((FixupKey)eit->OriginalNetworkID() << 16) |
-                  (FixupKey)eit->ServiceID());
-    fix |= EITFixUp::kFixGenericDVB;
-
-    uint tableid   = eit->TableID();
-    uint version   = eit->Version();
-    for (uint i = 0; i < eit->EventCount(); i++)
-    {
-        // Skip event if we have already processed it before...
-        if (!eitcache->IsNewEIT(chanid, tableid, version, eit->EventID(i),
-                              eit->EndTimeUnixUTC(i)))
-        {
-            continue;
-        }
-
-        QString title         = QString("");
-        QString subtitle      = QString("");
-        QString description   = QString("");
-        QString category      = QString("");
-        ProgramInfo::CategoryType category_type = ProgramInfo::kCategoryNone;
-        unsigned char subtitle_type=0, audio_props=0, video_props=0;
-        uint season = 0, episode = 0, totalepisodes = 0;
-        QMap<QString,QString> items;
-
-        // Parse descriptors
-        desc_list_t list = MPEGDescriptor::Parse(
-            eit->Descriptors(i), eit->DescriptorsLength(i));
-
-        const unsigned char *dish_event_name = NULL;
-        if (EITFixUp::kFixDish & fix)
-        {
-            dish_event_name = MPEGDescriptor::Find(
-                    list, PrivateDescriptorID::dish_event_name);
-        }
-
-        if (dish_event_name)
-        {
-            DishEventNameDescriptor dend(dish_event_name);
-            if (dend.HasName())
-                title = dend.Name(descCompression);
-
-            const unsigned char *dish_event_description =
-                MPEGDescriptor::Find(
-                    list, PrivateDescriptorID::dish_event_description);
-            if (dish_event_description)
-            {
-                DishEventDescriptionDescriptor dedd(dish_event_description);
-                if (dedd.HasDescription())
-                    description = dedd.Description(descCompression);
-            }
+            // EITa(ctive)
+            chanid = GetChanID((*eit_section_ptr)->ServiceID());
+            LOG(VB_TEMPDEBUG, LOG_DEBUG, QString("actual - tableid 0x%1(%2) chanid 0x%3(%4) serviceid 0x%5(%6) "
+                                                "onid 0x%7(%8) tsid 0x%9(%10) pid 0x%11(%12) sourceid %13")
+                                                .arg((*eit_section_ptr)->TableID(), 0, 16)
+                                                .arg((*eit_section_ptr)->TableID())
+                                                .arg(chanid, 0, 16)
+                                                .arg(chanid)
+                                                .arg((*eit_section_ptr)->ServiceID(), 0, 16)
+                                                .arg((*eit_section_ptr)->ServiceID())
+                                                .arg((*eit_section_ptr)->OriginalNetworkID(), 0, 16)
+                                                .arg((*eit_section_ptr)->OriginalNetworkID())
+                                                .arg((*eit_section_ptr)->TSID(), 0, 16)
+                                                .arg((*eit_section_ptr)->TSID())
+                                                .arg((*eit_section_ptr)->GetPID(), 0, 16)
+                                                .arg((*eit_section_ptr)->GetPID())
+                                                .arg(sourceid));
         }
         else
         {
-            parse_dvb_event_descriptors(list, fix, languagePreferences,
-                                        title, subtitle, description, items);
-        }
-
-        parse_dvb_component_descriptors(list, subtitle_type, audio_props,
-                                        video_props);
-
-        QString programId = QString("");
-        QString seriesId  = QString("");
-        QString rating    = QString("");
-        QString rating_system = QString("");
-        QString advisory = QString("");
-        float stars = 0.0;
-        QDate originalairdate;
-
-        if (EITFixUp::kFixDish & fix)
-        {
-            const unsigned char *mpaa_data = MPEGDescriptor::Find(
-                list, PrivateDescriptorID::dish_event_mpaa);
-            if (mpaa_data)
+            // EITo(ther)
+            chanid = GetChanID((*eit_section_ptr)->ServiceID(), (*eit_section_ptr)->OriginalNetworkID(), (*eit_section_ptr)->TSID());
+            LOG(VB_TEMPDEBUG, LOG_DEBUG, QString("other - tableid 0x%1(%2) chanid 0x%3(%4) serviceid 0x%5(%6) "
+                                                "onid 0x%7(%8) tsid 0x%9(%10) pid 0x%11(%12) sourceid %13")
+                                                .arg((*eit_section_ptr)->TableID(), 0, 16)
+                                                .arg((*eit_section_ptr)->TableID())
+                                                .arg(chanid, 0, 16)
+                                                .arg(chanid)
+                                                .arg((*eit_section_ptr)->ServiceID(), 0, 16)
+                                                .arg((*eit_section_ptr)->ServiceID())
+                                                .arg((*eit_section_ptr)->OriginalNetworkID(), 0, 16)
+                                                .arg((*eit_section_ptr)->OriginalNetworkID())
+                                                .arg((*eit_section_ptr)->TSID(), 0, 16)
+                                                .arg((*eit_section_ptr)->TSID())
+                                                .arg((*eit_section_ptr)->GetPID(), 0, 16)
+                                                .arg((*eit_section_ptr)->GetPID())
+                                                .arg(sourceid));
+           // do not reschedule if its only present+following
+           if ((*eit_section_ptr)->TableID() != TableID::PF_EITo)
             {
-                DishEventMPAADescriptor mpaa(mpaa_data);
-                stars = mpaa.stars();
-
-                if (stars) // Only movies for now
-                {
-                    rating = mpaa.rating();
-                    rating_system = "MPAA";
-                    advisory = mpaa.advisory();
-                }
-            }
-
-            if (!stars) // Not MPAA rated, check VCHIP
-            {
-                const unsigned char *vchip_data = MPEGDescriptor::Find(
-                    list, PrivateDescriptorID::dish_event_vchip);
-                if (vchip_data)
-                {
-                    DishEventVCHIPDescriptor vchip(vchip_data);
-                    rating = vchip.rating();
-                    rating_system = "VCHIP";
-                    advisory = vchip.advisory();
-                }
-            }
-
-            if (!advisory.isEmpty() && !rating.isEmpty())
-                rating += ", " + advisory;
-            else if (!advisory.isEmpty())
-            {
-                rating = advisory;
-                rating_system = "advisory";
-            }
-
-            const unsigned char *tags_data = MPEGDescriptor::Find(
-                list, PrivateDescriptorID::dish_event_tags);
-            if (tags_data)
-            {
-                DishEventTagsDescriptor tags(tags_data);
-                seriesId  = tags.seriesid();
-                programId = tags.programid();
-                originalairdate = tags.originalairdate(); // future use
-
-                if (programId.startsWith("MV") || programId.startsWith("SP"))
-                    seriesId = "";
-            }
-
-            const unsigned char *properties_data = MPEGDescriptor::Find(
-                list, PrivateDescriptorID::dish_event_properties);
-            if (properties_data)
-            {
-                DishEventPropertiesDescriptor properties(properties_data);
-                subtitle_type |= properties.SubtitleProperties(descCompression);
-                audio_props   |= properties.AudioProperties(descCompression);
+                LOG(VB_TEMPDEBUG, LOG_DEBUG, "other not PF set seenEITother");
+                seenEITother = true;
             }
         }
-
-        const unsigned char *content_data =
-            MPEGDescriptor::Find(list, DescriptorID::content);
-        if (content_data)
+        if (!chanid)
         {
-            if ((EITFixUp::kFixDish & fix) || (EITFixUp::kFixBell & fix))
+            LOG(VB_TEMPDEBUG, LOG_DEBUG, "Ditching an eit section chanid not found");
+            return;
+        }
+
+        for(; eit_section_ptr != EventInformationTable.end(); ++eit_section_ptr)
+        {
+            uint descCompression = ((*eit_section_ptr)->TableID() > 0x80) ? 2 : 1;
+            FixupValue fix = fixup.value((FixupKey)(*eit_section_ptr)->OriginalNetworkID() << 16);
+            fix |= fixup.value((((FixupKey)(*eit_section_ptr)->TSID()) << 32) |
+                         ((FixupKey)(*eit_section_ptr)->OriginalNetworkID() << 16));
+            fix |= fixup.value(((FixupKey)(*eit_section_ptr)->OriginalNetworkID() << 16) |
+                         (FixupKey)(*eit_section_ptr)->ServiceID());
+            fix |= fixup.value((((FixupKey)(*eit_section_ptr)->TSID()) << 32) |
+                         ((FixupKey)(*eit_section_ptr)->OriginalNetworkID() << 16) |
+                          (FixupKey)(*eit_section_ptr)->ServiceID());
+            fix |= EITFixUp::kFixGenericDVB;
+
+            uint tableid   = (*eit_section_ptr)->TableID();
+            uint version   = (*eit_section_ptr)->Version();
+            for (uint i = 0; i < (*eit_section_ptr)->EventCount(); i++)
             {
-                DishContentDescriptor content(content_data);
-                switch (content.GetTheme())
+                // Skip event if we have already processed it before...
+                if (!eitcache->IsNewEIT(chanid, tableid, version, (*eit_section_ptr)->EventID(i),
+                                      (*eit_section_ptr)->EndTimeUnixUTC(i)))
                 {
-                    case kThemeMovie :
-                        category_type = ProgramInfo::kCategoryMovie;
-                        break;
-                    case kThemeSeries :
-                        category_type = ProgramInfo::kCategorySeries;
-                        break;
-                    case kThemeSports :
-                        category_type = ProgramInfo::kCategorySports;
-                        break;
-                    default :
-                        category_type = ProgramInfo::kCategoryNone;
+                    continue;
                 }
+
+                QString title         = QString("");
+                QString subtitle      = QString("");
+                QString description   = QString("");
+                QString category      = QString("");
+                ProgramInfo::CategoryType category_type = ProgramInfo::kCategoryNone;
+                unsigned char subtitle_type=0, audio_props=0, video_props=0;
+                uint season = 0, episode = 0, totalepisodes = 0;
+                QMap<QString,QString> items;
+
+                // Parse descriptors
+                desc_list_t list = MPEGDescriptor::Parse(
+                    (*eit_section_ptr)->Descriptors(i), (*eit_section_ptr)->DescriptorsLength(i));
+
+                const unsigned char *dish_event_name = NULL;
                 if (EITFixUp::kFixDish & fix)
-                    category  = content.GetCategory();
-            }
-            else if (EITFixUp::kFixAUDescription & fix)//AU Freeview assigned genres
-            {
-                ContentDescriptor content(content_data);
-                switch (content.Nibble1(0))
                 {
-                    case 0x01:
-                        category = "Movie";
-                        break;
-                    case 0x02:
-                        category = "News";
-                        break;
-                    case 0x03:
-                        category = "Entertainment";
-                        break;
-                    case 0x04:
-                        category = "Sport";
-                        break;
-                    case 0x05:
-                        category = "Children";
-                        break;
-                    case 0x06:
-                        category = "Music";
-                        break;
-                    case 0x07:
-                        category = "Arts/Culture";
-                        break;
-                    case 0x08:
-                        category = "Current Affairs";
-                        break;
-                    case 0x09:
-                        category = "Education";
-                        break;
-                    case 0x0A:
-                        category = "Infotainment";
-                        break;
-                    case 0x0B:
-                        category = "Special";
-                        break;
-                    case 0x0C:
-                        category = "Comedy";
-                        break;
-                    case 0x0D:
-                        category = "Drama";
-                        break;
-                    case 0x0E:
-                        category = "Documentary";
-                        break;
-                    default:
-                        category = "";
-                        break;
+                    dish_event_name = MPEGDescriptor::Find(
+                            list, PrivateDescriptorID::dish_event_name);
                 }
-                category_type = content.GetMythCategory(0);
-            }
-            else if (EITFixUp::kFixGreekEIT & fix)//Greek
-            {
-                ContentDescriptor content(content_data);
-                switch (content.Nibble2(0))
-                {
-                    case 0x01:
-                        category = "Ταινία";       // confirmed
-                        break;
-                    case 0x02:
-                        category = "Ενημερωτικό";  // confirmed
-                        break;
-                    case 0x04:
-                        category = "Αθλητικό";     // confirmed
-                        break;
-                    case 0x05:
-                        category = "Παιδικό";      // confirmed
-                        break;
-                    case 0x09:
-                        category = "Ντοκιμαντέρ";  // confirmed
-                        break;
-                    default:
-                        category = "";
-                        break;
-                }
-                category_type = content.GetMythCategory(2);
-            }
-            else
-            {
-                ContentDescriptor content(content_data);
-                category      = content.GetDescription(0);
-#if 0 /* there is no category_type in DVB EIT */
-                category_type = content.GetMythCategory(0);
-#endif
-            }
-        }
 
-        desc_list_t contentIds =
-            MPEGDescriptor::FindAll(list, DescriptorID::dvb_content_identifier);
-        for (uint j = 0; j < contentIds.size(); j++)
-        {
-            DVBContentIdentifierDescriptor desc(contentIds[j]);
-            for (uint k = 0; k < desc.CRIDCount(); k++)
-            {
-                if (desc.ContentEncoding(k) == 0)
+                if (dish_event_name)
                 {
-                    // The CRID is a URI.  It could contain UTF8 sequences encoded
-                    // as %XX but there's no advantage in decoding them.
-                    // The BBC currently uses private types 0x31 and 0x32.
-                    // IDs from the authority eventis.nl are not fit for our scheduler
-                    if (desc.ContentType(k) == 0x01 || desc.ContentType(k) == 0x31)
+                    DishEventNameDescriptor dend(dish_event_name);
+                    if (dend.HasName())
+                        title = dend.Name(descCompression);
+
+                    const unsigned char *dish_event_description =
+                        MPEGDescriptor::Find(
+                            list, PrivateDescriptorID::dish_event_description);
+                    if (dish_event_description)
                     {
-                        if (!desc.ContentId(k).startsWith ("eventis.nl/"))
-                        {
-                            programId = desc.ContentId(k);
-                        }
-                    }
-                    else if (desc.ContentType(k) == 0x02 || desc.ContentType(k) == 0x32)
-                    {
-                        if (!desc.ContentId(k).startsWith ("eventis.nl/"))
-                        {
-                            seriesId = desc.ContentId(k);
-                        }
-                        category_type = ProgramInfo::kCategorySeries;
+                        DishEventDescriptionDescriptor dedd(dish_event_description);
+                        if (dedd.HasDescription())
+                            description = dedd.Description(descCompression);
                     }
                 }
+                else
+                {
+                    parse_dvb_event_descriptors(list, fix, languagePreferences,
+                                                title, subtitle, description, items);
+                }
+
+                parse_dvb_component_descriptors(list, subtitle_type, audio_props,
+                                                video_props);
+
+                QString programId = QString("");
+                QString seriesId  = QString("");
+                QString rating    = QString("");
+                QString rating_system = QString("");
+                QString advisory = QString("");
+                float stars = 0.0;
+                QDate originalairdate;
+
+                if (EITFixUp::kFixDish & fix)
+                {
+                    const unsigned char *mpaa_data = MPEGDescriptor::Find(
+                        list, PrivateDescriptorID::dish_event_mpaa);
+                    if (mpaa_data)
+                    {
+                        DishEventMPAADescriptor mpaa(mpaa_data);
+                        stars = mpaa.stars();
+
+                        if (stars) // Only movies for now
+                        {
+                            rating = mpaa.rating();
+                            rating_system = "MPAA";
+                            advisory = mpaa.advisory();
+                        }
+                    }
+
+                    if (!stars) // Not MPAA rated, check VCHIP
+                    {
+                        const unsigned char *vchip_data = MPEGDescriptor::Find(
+                            list, PrivateDescriptorID::dish_event_vchip);
+                        if (vchip_data)
+                        {
+                            DishEventVCHIPDescriptor vchip(vchip_data);
+                            rating = vchip.rating();
+                            rating_system = "VCHIP";
+                            advisory = vchip.advisory();
+                        }
+                    }
+
+                    if (!advisory.isEmpty() && !rating.isEmpty())
+                        rating += ", " + advisory;
+                    else if (!advisory.isEmpty())
+                    {
+                        rating = advisory;
+                        rating_system = "advisory";
+                    }
+
+                    const unsigned char *tags_data = MPEGDescriptor::Find(
+                        list, PrivateDescriptorID::dish_event_tags);
+                    if (tags_data)
+                    {
+                        DishEventTagsDescriptor tags(tags_data);
+                        seriesId  = tags.seriesid();
+                        programId = tags.programid();
+                        originalairdate = tags.originalairdate(); // future use
+
+                        if (programId.startsWith("MV") || programId.startsWith("SP"))
+                            seriesId = "";
+                    }
+
+                    const unsigned char *properties_data = MPEGDescriptor::Find(
+                        list, PrivateDescriptorID::dish_event_properties);
+                    if (properties_data)
+                    {
+                        DishEventPropertiesDescriptor properties(properties_data);
+                        subtitle_type |= properties.SubtitleProperties(descCompression);
+                        audio_props   |= properties.AudioProperties(descCompression);
+                    }
+                }
+
+                const unsigned char *content_data =
+                    MPEGDescriptor::Find(list, DescriptorID::content);
+                if (content_data)
+                {
+                    if ((EITFixUp::kFixDish & fix) || (EITFixUp::kFixBell & fix))
+                    {
+                        DishContentDescriptor content(content_data);
+                        switch (content.GetTheme())
+                        {
+                            case kThemeMovie :
+                                category_type = ProgramInfo::kCategoryMovie;
+                                break;
+                            case kThemeSeries :
+                                category_type = ProgramInfo::kCategorySeries;
+                                break;
+                            case kThemeSports :
+                                category_type = ProgramInfo::kCategorySports;
+                                break;
+                            default :
+                                category_type = ProgramInfo::kCategoryNone;
+                        }
+                        if (EITFixUp::kFixDish & fix)
+                            category  = content.GetCategory();
+                    }
+                    else if (EITFixUp::kFixAUDescription & fix)//AU Freeview assigned genres
+                    {
+                        ContentDescriptor content(content_data);
+                        switch (content.Nibble1(0))
+                        {
+                            case 0x01:
+                                category = "Movie";
+                                break;
+                            case 0x02:
+                                category = "News";
+                                break;
+                            case 0x03:
+                                category = "Entertainment";
+                                break;
+                            case 0x04:
+                                category = "Sport";
+                                break;
+                            case 0x05:
+                                category = "Children";
+                                break;
+                            case 0x06:
+                                category = "Music";
+                                break;
+                            case 0x07:
+                                category = "Arts/Culture";
+                                break;
+                            case 0x08:
+                                category = "Current Affairs";
+                                break;
+                            case 0x09:
+                                category = "Education";
+                                break;
+                            case 0x0A:
+                                category = "Infotainment";
+                                break;
+                            case 0x0B:
+                                category = "Special";
+                                break;
+                            case 0x0C:
+                                category = "Comedy";
+                                break;
+                            case 0x0D:
+                                category = "Drama";
+                                break;
+                            case 0x0E:
+                                category = "Documentary";
+                                break;
+                            default:
+                                category = "";
+                                break;
+                        }
+                        category_type = content.GetMythCategory(0);
+                    }
+                    else if (EITFixUp::kFixGreekEIT & fix)//Greek
+                    {
+                        ContentDescriptor content(content_data);
+                        switch (content.Nibble2(0))
+                        {
+                            case 0x01:
+                                category = "Ταινία";       // confirmed
+                                break;
+                            case 0x02:
+                                category = "Ενημερωτικό";  // confirmed
+                                break;
+                            case 0x04:
+                                category = "Αθλητικό";     // confirmed
+                                break;
+                            case 0x05:
+                                category = "Παιδικό";      // confirmed
+                                break;
+                            case 0x09:
+                                category = "Ντοκιμαντέρ";  // confirmed
+                                break;
+                            default:
+                                category = "";
+                                break;
+                        }
+                        category_type = content.GetMythCategory(2);
+                    }
+                    else
+                    {
+                        ContentDescriptor content(content_data);
+                        category      = content.GetDescription(0);
+        #if 0 /* there is no category_type in DVB EIT */
+                        category_type = content.GetMythCategory(0);
+        #endif
+                    }
+                }
+
+                desc_list_t contentIds =
+                    MPEGDescriptor::FindAll(list, DescriptorID::dvb_content_identifier);
+                for (uint j = 0; j < contentIds.size(); j++)
+                {
+                    DVBContentIdentifierDescriptor desc(contentIds[j]);
+                    for (uint k = 0; k < desc.CRIDCount(); k++)
+                    {
+                        if (desc.ContentEncoding(k) == 0)
+                        {
+                            // The CRID is a URI.  It could contain UTF8 sequences encoded
+                            // as %XX but there's no advantage in decoding them.
+                            // The BBC currently uses private types 0x31 and 0x32.
+                            // IDs from the authority eventis.nl are not fit for our scheduler
+                            if (desc.ContentType(k) == 0x01 || desc.ContentType(k) == 0x31)
+                            {
+                                if (!desc.ContentId(k).startsWith ("eventis.nl/"))
+                                {
+                                    programId = desc.ContentId(k);
+                                }
+                            }
+                            else if (desc.ContentType(k) == 0x02 || desc.ContentType(k) == 0x32)
+                            {
+                                if (!desc.ContentId(k).startsWith ("eventis.nl/"))
+                                {
+                                    seriesId = desc.ContentId(k);
+                                }
+                                category_type = ProgramInfo::kCategorySeries;
+                            }
+                        }
+                    }
+                }
+
+                /* if we don't have a subtitle, try to parse one from private descriptors */
+                if (subtitle.isEmpty()) {
+                    bool isUPC = false;
+                    /* is this event carrying UPC private data? */
+                    desc_list_t private_data_specifiers = MPEGDescriptor::FindAll(list, DescriptorID::private_data_specifier);
+                    for (uint j = 0; j < private_data_specifiers.size(); j++) {
+                        PrivateDataSpecifierDescriptor desc(private_data_specifiers[j]);
+                        if (desc.PrivateDataSpecifier() == PrivateDataSpecifierID::UPC1) {
+                            isUPC = true;
+                        }
+                    }
+
+                    if (isUPC) {
+                        desc_list_t subtitles = MPEGDescriptor::FindAll(list, PrivateDescriptorID::upc_event_episode_title);
+                        for (uint j = 0; j < subtitles.size(); j++) {
+                            PrivateUPCCablecomEpisodeTitleDescriptor desc(subtitles[j]);
+
+                            subtitle = desc.Text();
+                        }
+                    }
+                }
+
+                QDateTime starttime = (*eit_section_ptr)->StartTimeUTC(i);
+                // fix starttime only if the duration is a multiple of a minute
+                uint total_duration = (*eit_section_ptr)->DurationInSeconds(i);
+                if (!(total_duration % 60))
+                    EITFixUp::TimeFix(starttime);
+                QDateTime endtime   = starttime.addSecs((*eit_section_ptr)->DurationInSeconds(i));
+
+                // Make an ETSI TS 102 851 compliant event URL
+                uint duration_hours = total_duration / 3600;
+                uint duration_mins = (total_duration - (duration_hours * 3600)) / 60;
+                uint duration_secs = total_duration % 60;
+                QString etsiEventUrl(QString("dvb://%1.%2.%3;%4~%5Z--PT%6H%7M%8S")
+                                        .arg((*eit_section_ptr)->OriginalNetworkID(),0,16)
+                                        .arg((*eit_section_ptr)->TSID(),0,16)
+                                        .arg((*eit_section_ptr)->ServiceID(),0,16)
+                                        .arg((*eit_section_ptr)->EventID(i),0,16)
+                                        .arg(starttime.toString(QString("yyyyMMdd'T'hhmmss")))
+                                        .arg(duration_hours,2,10,QChar('0'))
+                                        .arg(duration_mins,2,10,QChar('0'))
+                                        .arg(duration_secs,2,10,QChar('0')));
+
+                DBEventEIT *event = new DBEventEIT(
+                    chanid,
+                    title,     subtitle,      description,
+                    category,  category_type,
+                    starttime, endtime,       fix,
+                    subtitle_type,
+                    audio_props,
+                    video_props, stars,
+                    seriesId,  programId,
+                    season, episode, totalepisodes);
+                event->items = items;
+
+                db_events.enqueue(event);
             }
         }
-
-        /* if we don't have a subtitle, try to parse one from private descriptors */
-        if (subtitle.isEmpty()) {
-            bool isUPC = false;
-            /* is this event carrying UPC private data? */
-            desc_list_t private_data_specifiers = MPEGDescriptor::FindAll(list, DescriptorID::private_data_specifier);
-            for (uint j = 0; j < private_data_specifiers.size(); j++) {
-                PrivateDataSpecifierDescriptor desc(private_data_specifiers[j]);
-                if (desc.PrivateDataSpecifier() == PrivateDataSpecifierID::UPC1) {
-                    isUPC = true;
-                }
-            }
-
-            if (isUPC) {
-                desc_list_t subtitles = MPEGDescriptor::FindAll(list, PrivateDescriptorID::upc_event_episode_title);
-                for (uint j = 0; j < subtitles.size(); j++) {
-                    PrivateUPCCablecomEpisodeTitleDescriptor desc(subtitles[j]);
-
-                    subtitle = desc.Text();
-                }
-            }
-        }
-
-
-        QDateTime starttime = eit->StartTimeUTC(i);
-        // fix starttime only if the duration is a multiple of a minute
-        if (!(eit->DurationInSeconds(i) % 60))
-            EITFixUp::TimeFix(starttime);
-        QDateTime endtime   = starttime.addSecs(eit->DurationInSeconds(i));
-
-        DBEventEIT *event = new DBEventEIT(
-            chanid,
-            title,     subtitle,      description,
-            category,  category_type,
-            starttime, endtime,       fix,
-            subtitle_type,
-            audio_props,
-            video_props, stars,
-            seriesId,  programId,
-            season, episode, totalepisodes);
-        event->items = items;
-
-        db_events.enqueue(event);
     }
+    else
+        LOG(VB_TEMPDEBUG, LOG_DEBUG, "EIT table with no sections encountered");
 }
 
 // This function gets special EIT data from the German provider Premiere
@@ -959,6 +1018,14 @@ static uint get_chan_id_from_db_dvb(uint sourceid, uint serviceid,
     query.bindValue(":NETWORKID",   networkid);
     query.bindValue(":TRANSPORTID", transportid);
 
+    LOG(VB_TEMPDEBUG, LOG_INFO, QString("get_chan_id_from_db_dvb serviceid 0x%1(%4) networkid 0x%2(%5) transportid 0x%3(%6)")
+                        .arg(serviceid, 0, 16)
+                        .arg(networkid, 0, 16)
+                        .arg(transportid, 0, 16)
+                        .arg(serviceid)
+                        .arg(networkid)
+                        .arg(transportid));
+
     if (!query.exec() || !query.isActive())
         MythDB::DBError("Looking up chanID", query);
 
@@ -979,9 +1046,21 @@ static uint get_chan_id_from_db_dvb(uint sourceid, uint serviceid,
             MythDB::DBError("Looking up chanID in fuzzy mode", query);
     }
 
+    LOG(VB_TEMPDEBUG, LOG_INFO, QString("get_chan_id_from_db_dvb fuzzy serviceid 0x%1(%3) networkid 0x%2(%4)")
+                        .arg(serviceid, 0, 16)
+                        .arg(networkid, 0, 16)
+                        .arg(serviceid)
+                        .arg(networkid));
+
     while (query.next())
     {
         // Check to see if we are interested in this channel
+        LOG(VB_TEMPDEBUG, LOG_INFO, QString("get_chan_id_from_db_dvb fuzzy sourceid %1 query.chanid %2 query.useOnAirGuide %3 query.sourceid %4")
+                        .arg(sourceid)
+                        .arg(query.value(0).toUInt())
+                        .arg(query.value(1).toBool())
+                        .arg(query.value(2).toUInt()));
+
         chanid        = query.value(0).toUInt();
         useOnAirGuide = query.value(1).toBool();
         if (sourceid == query.value(2).toUInt())
@@ -990,8 +1069,8 @@ static uint get_chan_id_from_db_dvb(uint sourceid, uint serviceid,
 
     if (query.size() > 1)
     {
-        LOG(VB_EIT, LOG_INFO,
-            LOC + QString("found %1 channels for networdid %2, "
+        LOG(VB_TEMPDEBUG, LOG_INFO,
+            LOC + QString("found %1 channels for networkid %2, "
                           "transportid %3, serviceid %4 but none "
                           "for current sourceid %5.")
                 .arg(query.size()).arg(networkid).arg(transportid)

--- a/mythtv/libs/libmythtv/eithelper.h
+++ b/mythtv/libs/libmythtv/eithelper.h
@@ -16,6 +16,7 @@
 
 // MythTV includes
 #include "mythdeque.h"
+#include "dvbstreamdata.h"
 
 class MSqlQuery;
 
@@ -84,7 +85,7 @@ class EITCache;
 
 class EventInformationTable;
 class ExtendedTextTable;
-class DVBEventInformationTable;
+class DVBEventInformationTableSection;
 class PremiereContentInformationTable;
 
 class EITHelper
@@ -111,12 +112,12 @@ class EITHelper
                 const EventInformationTable *eit);
     void AddETT(uint atsc_major, uint atsc_minor,
                 const ExtendedTextTable     *ett);
-    void AddEIT(const DVBEventInformationTable *eit);
+    void AddEIT(eit_sections_cache_const_t& EventInformationTable);
     void AddEIT(const PremiereContentInformationTable *eit);
 #else // if !USING_BACKEND
     void AddEIT(uint, uint, const EventInformationTable*) {}
     void AddETT(uint, uint, const ExtendedTextTable*) {}
-    void AddEIT(const DVBEventInformationTable*) {}
+    void AddEIT(eit_sections_cache_const_t& EventInformationTable) {}
     void AddEIT(const PremiereContentInformationTable*) {}
 #endif // !USING_BACKEND
 

--- a/mythtv/libs/libmythtv/eitscanner.h
+++ b/mythtv/libs/libmythtv/eitscanner.h
@@ -46,7 +46,8 @@ class EITScanner : public QRunnable
   private:
     void TeardownAll(void);
     static void *SpawnEventLoop(void*);
-           void  RescheduleRecordings(void);
+    void  RescheduleRecordings(void);
+    bool HasIncompleteEITTables();
 
     QMutex           lock;
     ChannelBase     *channel;
@@ -65,14 +66,18 @@ class EITScanner : public QRunnable
     uint             activeScanTrigTime;
     QStringList      activeScanChannels;
     QStringList::iterator activeScanNextChan;
+    uint             secondsWaitedForIncompleteEITScheduleTables;
 
     uint             cardnum;
 
     static QMutex    resched_lock;
     static QDateTime resched_next_time;
 
-    /// Minumum number of seconds between reschedules.
-    static const uint kMinRescheduleInterval;
+    /// Incremental extra time to wait if any EIT Schedule tables are incomplete
+    /// after the normal per channel scan period has expired in an active scan.
+    static const uint kExtraSecondsToWaitForIncompleteEITScheduleTables;
+    /// Maximum extra time to wait if any EIT Schedule tables are incomplete.
+    static const uint kMaxExtraSecondsToWaitForIncompleteEITScheduleTables;
 };
 
 #endif // EITSCANNER_H

--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -208,6 +208,7 @@ HEADERS += mpeg/iso6937tables.h
 HEADERS += mpeg/tsstats.h           mpeg/streamlisteners.h
 HEADERS += mpeg/H264Parser.h
 HEADERS += mpeg/tablestatus.h
+HEADERS += mepg/sicachetypes.h
 
 SOURCES += mpeg/tspacket.cpp        mpeg/pespacket.cpp
 SOURCES += mpeg/mpegtables.cpp      mpeg/atsctables.cpp

--- a/mythtv/libs/libmythtv/mpeg/atscstreamdata.h
+++ b/mythtv/libs/libmythtv/mpeg/atscstreamdata.h
@@ -30,7 +30,7 @@ class MTV_PUBLIC ATSCStreamData : virtual public MPEGStreamData
   public:
     ATSCStreamData(int desiredMajorChannel,
                    int desiredMinorChannel,
-                   int cardnum, bool cacheTables = false);
+                   int cardnum, bool cacheTableSections = false);
     virtual ~ATSCStreamData();
 
     void Reset(void) { Reset(-1, -1); }
@@ -40,7 +40,7 @@ class MTV_PUBLIC ATSCStreamData : virtual public MPEGStreamData
 
     // Table processing
     virtual bool HandleTables(uint pid, const PSIPTable &psip);
-    virtual bool IsRedundant(uint, const PSIPTable&) const;
+    virtual bool IsRedundant(uint, const PSIPTable&);
 
     /// Current UTC to GPS time offset in seconds
     uint GPSOffset(void) const { return _GPS_UTC_offset; }
@@ -121,7 +121,7 @@ class MTV_PUBLIC ATSCStreamData : virtual public MPEGStreamData
     void CacheTVCT(uint pid, TerrestrialVirtualChannelTable*);
     void CacheCVCT(uint pid, CableVirtualChannelTable*);
   protected:
-    virtual bool DeleteCachedTable(PSIPTable *psip) const;
+    virtual bool DeleteCachedTableSection(PSIPTable *psip) const;
 
   private:
     uint                      _GPS_UTC_offset;

--- a/mythtv/libs/libmythtv/mpeg/dvbdescriptors.cpp
+++ b/mythtv/libs/libmythtv/mpeg/dvbdescriptors.cpp
@@ -558,7 +558,7 @@ QString SatelliteDeliverySystemDescriptor::toString() const
 {
     QString str = QString("SatelliteDeliverySystemDescriptor: ");
 
-    str.append(QString("Frequency: %1KHz, Type: %2\n").arg(FrequencyKHz())
+    str.append(QString("Frequency: %1, Type: %2\n").arg(FrequencyHz())
         .arg(ModulationSystemString()));
     str.append(QString("      Mod=%1, SymbR=%2, FECInner=%3, Orbit=%4, Pol=%5")
         .arg(ModulationString())

--- a/mythtv/libs/libmythtv/mpeg/dvbdescriptors.cpp
+++ b/mythtv/libs/libmythtv/mpeg/dvbdescriptors.cpp
@@ -558,7 +558,7 @@ QString SatelliteDeliverySystemDescriptor::toString() const
 {
     QString str = QString("SatelliteDeliverySystemDescriptor: ");
 
-    str.append(QString("Frequency: %1, Type: %2\n").arg(FrequencyHz())
+    str.append(QString("Frequency: %1KHz, Type: %2\n").arg(FrequencyKHz())
         .arg(ModulationSystemString()));
     str.append(QString("      Mod=%1, SymbR=%2, FECInner=%3, Orbit=%4, Pol=%5")
         .arg(ModulationString())

--- a/mythtv/libs/libmythtv/mpeg/dvbdescriptors.h
+++ b/mythtv/libs/libmythtv/mpeg/dvbdescriptors.h
@@ -803,7 +803,7 @@ class SatelliteDeliverySystemDescriptor : public MPEGDescriptor
         return ((_data[2]<<24) | (_data[3]<<16) |
                 (_data[4]<<8)  | (_data[5]));
     }
-    unsigned long long FrequencyHz(void) const
+    unsigned long long FrequencyKHz(void) const
     {
         return byte4BCD2int(_data[2], _data[3], _data[4], _data[5]) * 10;
     }

--- a/mythtv/libs/libmythtv/mpeg/dvbdescriptors.h
+++ b/mythtv/libs/libmythtv/mpeg/dvbdescriptors.h
@@ -803,7 +803,7 @@ class SatelliteDeliverySystemDescriptor : public MPEGDescriptor
         return ((_data[2]<<24) | (_data[3]<<16) |
                 (_data[4]<<8)  | (_data[5]));
     }
-    unsigned long long FrequencyKHz(void) const
+    unsigned long long FrequencyHz(void) const
     {
         return byte4BCD2int(_data[2], _data[3], _data[4], _data[5]) * 10;
     }

--- a/mythtv/libs/libmythtv/mpeg/dvbstreamdata.h
+++ b/mythtv/libs/libmythtv/mpeg/dvbstreamdata.h
@@ -3,20 +3,18 @@
 #ifndef DVBSTREAMDATA_H_
 #define DVBSTREAMDATA_H_
 
+/// \file dvbstreamdata.h
+
 #include "mpegstreamdata.h"
 #include "mythtvexp.h"
 #include "tablestatus.h"
+#include "qdatetime.h"
 
-typedef NetworkInformationTable* nit_ptr_t;
-typedef NetworkInformationTable const* nit_const_ptr_t;
-typedef vector<const NetworkInformationTable*>  nit_vec_t;
-typedef QMap<uint, nit_ptr_t>    nit_cache_t; // section->sdts
+#include "sicachetypes.h"
 
-typedef ServiceDescriptionTable* sdt_ptr_t;
-typedef ServiceDescriptionTable const* sdt_const_ptr_t;
-typedef vector<const ServiceDescriptionTable*>  sdt_vec_t;
-typedef QMap<uint, sdt_ptr_t>    sdt_cache_t; // tsid+section->sdts
-typedef QMap<uint, sdt_vec_t>    sdt_map_t;   // tsid->sdts
+class DVBMainStreamListener;
+class DVBOtherStreamListener;
+class DVBEITStreamListener;
 
 typedef vector<DVBMainStreamListener*>   dvb_main_listener_vec_t;
 typedef vector<DVBOtherStreamListener*>  dvb_other_listener_vec_t;
@@ -24,26 +22,31 @@ typedef vector<DVBEITStreamListener*>    dvb_eit_listener_vec_t;
 
 typedef QMap<uint, bool>                 dvb_has_eit_t;
 
+/** \class DVBStreamData
+ *  \brief Methods for managing a DVB stream
+*/
 class MTV_PUBLIC DVBStreamData : virtual public MPEGStreamData
 {
   public:
-    DVBStreamData(uint desired_netid, uint desired_tsid,
-                  int desired_program, int cardnum, bool cacheTables = false);
+    DVBStreamData(uint desired_onid, uint desired_tsid,
+                  int desired_program, int cardnum, bool cacheTableSections = false);
     virtual ~DVBStreamData();
 
     using MPEGStreamData::Reset;
     void Reset(void) { Reset(0, 0, -1); }
-    void Reset(uint desired_netid, uint desired_tsid, int desired_sid);
+    void Reset(uint original_network_id, uint transport_id, int service_id);
 
     // DVB table monitoring
-    void SetDesiredService(uint netid, uint tsid, int serviceid);
-    uint DesiredNetworkID(void)   const { return _desired_netid; }
+    void SetDesiredService(uint original_network_id, uint transport_id, int service_id);
+    uint DesiredNetworkID(void)   const { return _desired_onid; }
     uint DesiredTransportID(void) const { return _desired_tsid;  }
 
     // Table processing
     bool HandleTables(uint pid, const PSIPTable&);
-    bool IsRedundant(uint pid, const PSIPTable&) const;
-    void ProcessSDT(uint tsid, const ServiceDescriptionTable*);
+    void CheckStaleEIT(const DVBEventInformationTableSection& eit, uint onid, uint tsid, uint sid, uint tid) const;
+    void CheckStaleSDT(const ServiceDescriptionTableSection& sdt, uint onid, uint tsid, uint tid) const;
+    bool IsRedundant(uint pid, const PSIPTable&);
+    void ProcessSDTSection(sdt_section_ptr_t);
 
     // NIT for broken providers
     inline void SetRealNetworkID(int);
@@ -58,43 +61,56 @@ class MTV_PUBLIC DVBStreamData : virtual public MPEGStreamData
                           uint_vec_t &del_pids) const;
 
     // Table versions
-    void SetVersionSDT(uint tsid, int version, uint last_section)
+    /** \fn static uint InternalOriginalNetworkID(uint transport_stream_id)
+     *  \brief Generates a unique original network ID in the locally allocated range
+     *  at the moment this only applies to UK onids.
+     */
+    static uint InternalOriginalNetworkID(uint onid, uint tsid)
     {
-        _sdt_status.SetVersion(tsid, version, last_section);
+        switch (onid)
+        {
+        case 0x233a:
+        {
+            // Convert United Kingdom DTT id to temporary temporary local range
+            uint mux_id = (tsid & 0x3f000) >> 12;
+            if (mux_id > 0xb)
+                mux_id = 0;
+            if ((mux_id == 0x7) && ((tsid & 0xfff) < 0x3ff))
+                mux_id = 0xc;
+            // Shift id to private temporary use range
+            return 0xff01  + mux_id;
+        }
+
+        default:
+            return onid;
+        }
     }
 
-    void SetVersionSDTo(uint tsid, int version, uint last_section)
-    {
-        _sdto_status.SetVersion(tsid, version, last_section);
-    }
-
-    // Sections seen
+   // Sections seen
     bool HasAllNITSections(void) const;
 
     bool HasAllNIToSections(void) const;
 
-    bool HasAllSDTSections(uint tsid) const;
+    void SetEITSectionSeen(DVBEventInformationTableSection& eit_section);
+    bool EITSectionSeen(const DVBEventInformationTableSection& eit_section) const;
+    bool HasAllEITSections(const DVBEventInformationTableSection& eit_section) const;
+    int MissingEITSections(const DVBEventInformationTableSection& eit_section) const;
+    bool HasIncompleteEITTables(uint original_network_id, uint transport_stream_id);
 
-    bool HasAllSDToSections(uint tsid) const;
+
+    void SetSDTSectionSeen(ServiceDescriptionTableSection& sdt_section);
+    bool SDTSectionSeen(const ServiceDescriptionTableSection& sdt_section) const;
+    bool HasAllSDTSections(const ServiceDescriptionTableSection& sdt_section) const;
+    void RequestReplayOfCachedSDTs();
+
 
     bool HasAllBATSections(uint bid) const;
 
     // Caching
     bool HasCachedAnyNIT(bool current = true) const;
     bool HasCachedAllNIT(bool current = true) const;
-    bool HasCachedAnySDT(uint tsid, bool current = true) const;
-    bool HasCachedAllSDT(uint tsid, bool current = true) const;
-    bool HasCachedSDT(bool current = true) const;
-    bool HasCachedAnySDTs(bool current = true) const;
-    bool HasCachedAllSDTs(bool current = true) const;
-
     nit_const_ptr_t GetCachedNIT(uint section_num, bool current = true) const;
-    nit_vec_t GetCachedNIT(bool current = true) const;
-    sdt_const_ptr_t GetCachedSDT(uint tsid, uint section_num,
-                           bool current = true) const;
-    sdt_vec_t GetCachedSDTs(bool current = true) const;
-
-    void ReturnCachedSDTTables(sdt_vec_t&) const;
+    nit_const_vec_t GetCachedNIT(bool current = true) const;
 
     void AddDVBMainListener(DVBMainStreamListener*);
     void AddDVBOtherListener(DVBOtherStreamListener*);
@@ -103,18 +119,46 @@ class MTV_PUBLIC DVBStreamData : virtual public MPEGStreamData
     void RemoveDVBMainListener(DVBMainStreamListener*);
     void RemoveDVBOtherListener(DVBOtherStreamListener*);
     void RemoveDVBEITListener(DVBEITStreamListener*);
+    static void LogSICache();
+
+    bool HasCurrentTSID(uint& onid, uint& tsid)
+    {
+        if (((int)_current_onid < 0) || ((int)_current_tsid < 0))
+            return false;
+        else
+        {
+            onid = _current_onid;
+            tsid = _current_tsid;
+            return true;
+        }
+    }
 
   private:
     // Caching
-    void CacheNIT(NetworkInformationTable*);
-    void CacheSDT(ServiceDescriptionTable*);
+    class RecursiveMutex : public QMutex
+    {
+    public:
+        RecursiveMutex() : QMutex(QMutex::Recursive) {}
+    };
+
+    void CacheNIT(nit_ptr_t);
+    void ReplayCachedSDTa();
+    void ReplayCachedSDTos();
+
   protected:
-    virtual bool DeleteCachedTable(PSIPTable *psip) const;
+    /** \fn virtual bool DeleteCachedTableSection(PSIPTable *psip) const
+     *  \brief Deletes the PESPacket containing this teable section. Because
+     *  the destructor is virtual any derived class oblects will be deleted as well.
+     */
+   virtual bool DeleteCachedTableSection(PSIPTable *psip) const;
 
   private:
     /// DVB table monitoring
-    uint                      _desired_netid;
+    uint                      _desired_onid;
     uint                      _desired_tsid;
+
+    uint                      _current_onid;
+    uint                      _current_tsid;
 
     // Real network ID for broken providers
     int                       _dvb_real_network_id;
@@ -131,17 +175,26 @@ class MTV_PUBLIC DVBStreamData : virtual public MPEGStreamData
 
     // Table versions
     TableStatus               _nit_status;
-    TableStatusMap            _sdt_status;
-    TableStatusMap            _eit_status;
-    TableStatusMap            _cit_status;
-
     TableStatus               _nito_status;
-    TableStatusMap            _sdto_status;
+    TableStatusMap            _cit_status;
     TableStatusMap            _bat_status;
 
     // Caching
-    mutable nit_cache_t       _cached_nit;  // section -> sdt
-    mutable sdt_cache_t       _cached_sdts; // tsid+section -> sdt
+    mutable nit_cache_t       _cached_nit;  // NIT sections cached within transport stream ID
+
+    // Static shared caches
+    static sdt_tsn_cache_t    _cached_sdts; // SDT sections cached within transport stream ID
+                                            // within original network ID
+    static RecursiveMutex     _cached_sdts_lock;
+    bool _replay_cached_sdta;
+    bool _replay_cached_sdtos;
+    static eit_tssn_cache_t   _cached_eits; // EIT sections cached within table ID within
+                                            // service ID within transport stream ID within
+                                            // original network ID
+    static RecursiveMutex      _cached_eits_lock;
+
+    static qint64 EIT_STALE_TIME;
+    static qint64 SDT_STALE_TIME;
 };
 
 inline void DVBStreamData::SetDishNetEIT(bool use_dishnet_eit)

--- a/mythtv/libs/libmythtv/mpeg/dvbtables.h
+++ b/mythtv/libs/libmythtv/mpeg/dvbtables.h
@@ -94,25 +94,27 @@ class MTV_PUBLIC NetworkInformationTable : public PSIPTable
     mutable vector<const unsigned char*> _ptrs; // used to parse
 };
 
-/** \class ServiceDescriptionTable
+/** \class ServiceDescriptionTableSection
  *  \brief This table tells the decoder on which PIDs to find A/V data.
  *  \todo This is just a stub.
  */
-class MTV_PUBLIC ServiceDescriptionTable : public PSIPTable
+class MTV_PUBLIC ServiceDescriptionTableSection : public PSIPTable
 {
   public:
-    ServiceDescriptionTable(const ServiceDescriptionTable& table)
+    ServiceDescriptionTableSection() {}
+    ServiceDescriptionTableSection(const ServiceDescriptionTableSection& table)
         : PSIPTable(table)
     {
         assert(TableID::SDT == TableID() || TableID::SDTo == TableID());
         Parse();
     }
-    explicit ServiceDescriptionTable(const PSIPTable& table) : PSIPTable(table)
+    
+    explicit ServiceDescriptionTableSection(const PSIPTable& table) : PSIPTable(table)
     {
         assert(TableID::SDT == TableID() || TableID::SDTo == TableID());
         Parse();
     }
-    ~ServiceDescriptionTable() { ; }
+    ~ServiceDescriptionTableSection() { ; }
 
     // table_id                 8   0.0       0x42/0x46
     // section_syntax_indicator 1   1.0          1
@@ -282,24 +284,13 @@ class MTV_PUBLIC SelectionInformationTable : public PSIPTable
     // CRC_32 32 rpchof
 };
 
-class MTV_PUBLIC DVBEventInformationTable : public PSIPTable
+class MTV_PUBLIC DVBEventInformationTableSection : public PSIPTable
 {
   public:
-    explicit DVBEventInformationTable(const PSIPTable& table) : PSIPTable(table)
-    {
-    // table_id                 8   0.0       0xC7
-        assert(IsEIT(TableID()));
-    // section_syntax_indicator 1   1.0          1
-    // private_indicator        1   1.1          1
-    // reserved                 2   1.2          3
-    // section_length          12   1.4
-    // reserved                 2   5.0          3
-    // version_number           5   5.2
-    // current_next_indicator   1   5.7          1
-    // section_number           8   6.0
-    // last_section_number      8   7.0
-        Parse();
-    }
+    DVBEventInformationTableSection() {}
+    explicit DVBEventInformationTableSection(const PSIPTable& table);
+
+    ~DVBEventInformationTableSection();
 
     // service_id              16   3.0
     uint ServiceID(void) const { return TableIDExtension(); }

--- a/mythtv/libs/libmythtv/mpeg/mpegstreamdata.h
+++ b/mythtv/libs/libmythtv/mpeg/mpegstreamdata.h
@@ -11,7 +11,7 @@
 using namespace std;
 
 // Qt
-#include <QMap>
+#include "qmap.h"
 
 #include "tspacket.h"
 #include "mythtimer.h"
@@ -92,10 +92,10 @@ typedef QMap<uint, PIDPriority> pid_map_t;
 class MTV_PUBLIC MPEGStreamData : public EITSource
 {
   public:
-    MPEGStreamData(int desiredProgram, int cardnum, bool cacheTables);
+    MPEGStreamData(int desiredProgram, int cardnum, bool cacheTableSections);
     virtual ~MPEGStreamData();
 
-    void SetCaching(bool cacheTables) { _cache_tables = cacheTables; }
+    void SetCaching(bool cacheTableSections) { _cache_tables = cacheTableSections; }
     void SetListeningDisabled(bool lt) { _listening_disabled = lt; }
 
     virtual void Reset(void) { Reset(-1); }
@@ -116,7 +116,7 @@ class MTV_PUBLIC MPEGStreamData : public EITSource
 
     // Table processin
     void SetIgnoreCRC(bool haveCRCbug) { _have_CRC_bug = haveCRCbug; }
-    virtual bool IsRedundant(uint pid, const PSIPTable&) const;
+    virtual bool IsRedundant(uint pid, const PSIPTable&);
     virtual bool HandleTables(uint pid, const PSIPTable &psip);
     virtual void HandleTSTables(const TSPacket* tspacket);
     virtual bool ProcessTSPacket(const TSPacket& tspacket);
@@ -166,6 +166,7 @@ class MTV_PUBLIC MPEGStreamData : public EITSource
     {
         _pat_status.SetVersion(tsid, version, last_section);
     }
+
     void SetVersionPMT(uint pnum, int version, uint last_section)
     {
         _pmt_status.SetVersion(pnum, version, last_section);
@@ -307,7 +308,7 @@ class MTV_PUBLIC MPEGStreamData : public EITSource
 
     // Caching
     void IncrementRefCnt(const PSIPTable *psip) const;
-    virtual bool DeleteCachedTable(PSIPTable *psip) const;
+    virtual bool DeleteCachedTableSection(PSIPTable *psip) const;
     void CachePAT(const ProgramAssociationTable *pat);
     void CacheCAT(const ConditionalAccessTable *pat);
     void CachePMT(const ProgramMapTable *pmt);

--- a/mythtv/libs/libmythtv/mpeg/mpegtables.cpp
+++ b/mythtv/libs/libmythtv/mpeg/mpegtables.cpp
@@ -327,6 +327,17 @@ bool PSIPTable::VerifyPSIP(bool verify_crc) const
     return true;
 }
 
+void PSIPTable::CloneAndShrink(const PSIPTable& table, uint pid)
+{
+    // Shrink the data down to just the PES data
+    // plus enough space to save the current pid
+    _pesdataSize = _allocSize = table.Length();
+    _pesdata = _fullbuffer = (unsigned char*)malloc(_allocSize + sizeof(uint));
+    _isLongTermCopy = true;
+    memcpy(_fullbuffer, table.pesdata(), _allocSize);
+    *(uint*)(_fullbuffer + _allocSize) = pid;
+}
+
 ProgramAssociationTable* ProgramAssociationTable::CreateBlank(bool smallPacket)
 {
     (void) smallPacket; // currently always a small packet..

--- a/mythtv/libs/libmythtv/mpeg/mpegtables.h
+++ b/mythtv/libs/libmythtv/mpeg/mpegtables.h
@@ -393,6 +393,9 @@ class MTV_PUBLIC PSIPTable : public PESPacket
     }
 
   protected:
+    // default
+    PSIPTable() {}
+
     // does not create it's own data
     PSIPTable(const TSPacket& tspacket, bool)
         : PESPacket()
@@ -506,6 +509,10 @@ class MTV_PUBLIC PSIPTable : public PESPacket
     // if 0 this table is not yet valid, but will be the next psip
     // table with the same sectionNumber(), tableIDExtension() and
     // tableID() to become valid.
+    // For DVB usage see ETSI ETR 211 section 4.1.9. The value of this
+    // field in transmitted (broadcast) sections shall always have the
+    // value 1.
+    
     bool IsCurrent(void) const { return bool(pesdata()[5]&1); }
 
     // section_number       8       6.0      48
@@ -552,6 +559,8 @@ class MTV_PUBLIC PSIPTable : public PESPacket
     virtual QString toString(void) const;
     virtual QString toStringXML(uint indent_level) const;
 
+    void CloneAndShrink(const PSIPTable& table, uint pid = 0);
+    uint GetPID() { return *(uint*)(_fullbuffer + _allocSize); } // N.B. must only be used on CloneAndShrink tables
     static const uint PSIP_OFFSET = 8; // general PSIP header offset
 
   protected:

--- a/mythtv/libs/libmythtv/mpeg/pespacket.h
+++ b/mythtv/libs/libmythtv/mpeg/pespacket.h
@@ -28,7 +28,8 @@ class MTV_PUBLIC PESPacket
     /** noop constructor, only for use by derived classes */
     PESPacket()
         : _pesdata(NULL), _fullbuffer(NULL),  _psiOffset(0),
-          _ccLast(255), _pesdataSize(0), _allocSize(0), _badPacket(false)
+          _ccLast(255), _pesdataSize(0), _allocSize(0),
+          _badPacket(false), _isLongTermCopy(false)
     { ; }
 
   public:
@@ -36,7 +37,8 @@ class MTV_PUBLIC PESPacket
     explicit PESPacket(const unsigned char *pesdata)
         : _pesdata(const_cast<unsigned char*>(pesdata)),
           _fullbuffer(const_cast<unsigned char*>(pesdata)),
-          _psiOffset(0), _ccLast(255), _allocSize(0)
+          _psiOffset(0), _ccLast(255), _allocSize(0),
+          _isLongTermCopy(false)
     {
         _badPacket = !VerifyCRC();
         _pesdataSize = max(((int)Length())-1 + (HasCRC() ? 4 : 0), (int)0);
@@ -54,12 +56,16 @@ class MTV_PUBLIC PESPacket
           _ccLast(pkt._ccLast),
           _pesdataSize(pkt._pesdataSize),
           _allocSize(pkt._allocSize),
-          _badPacket(pkt._badPacket)
+          _badPacket(pkt._badPacket),
+          _isLongTermCopy(pkt._isLongTermCopy)
     { // clone
         if (!_allocSize)
             _allocSize = pkt._pesdataSize + (pkt._pesdata - pkt._fullbuffer);
 
-        _fullbuffer = pes_alloc(_allocSize);
+        if (_isLongTermCopy)
+            _fullbuffer = (unsigned char *)malloc(_allocSize);
+        else
+            _fullbuffer = pes_alloc(_allocSize);
         memcpy(_fullbuffer, pkt._fullbuffer, _allocSize);
         _pesdata = _fullbuffer + (pkt._pesdata - pkt._fullbuffer);
     }
@@ -72,8 +78,11 @@ class MTV_PUBLIC PESPacket
 
     virtual ~PESPacket()
     {
-        if (IsClone())
-            pes_free(_fullbuffer);
+        if (_isLongTermCopy)
+            free(_fullbuffer);
+        else
+            if (IsClone())
+                pes_free(_fullbuffer);
 
         _fullbuffer = NULL;
         _pesdata    = NULL;
@@ -93,7 +102,13 @@ class MTV_PUBLIC PESPacket
 
     void GetAsTSPackets(vector<TSPacket> &pkts, uint cc) const;
 
+    // PES Packet structure
+    // Start code 3 bytes
+    // ==================
     // _pesdata[-3] == 0, _pesdata[-2] == 0, _pesdata[-1] == 1
+
+    // PES Header  Fixed part  bytes
+    // ==============================
     uint StreamID()   const { return _pesdata[0]; }
     uint Length()     const
         { return (_pesdata[1] & 0x0f) << 8 | _pesdata[2]; }
@@ -129,7 +144,12 @@ class MTV_PUBLIC PESPacket
     virtual bool HasCRC()     const { return (_pesdata[4] & 0x2) >> 1; }
     /// 1 bit  Extension flags are present
     bool HasExtensionFlags()  const { return _pesdata[4] & 0x1; }
+    // Header fields length 1 byte
+    // _pesdata[5]
 
+    // PES Header Fields - variable length
+    // Ordered the same as the flag bits
+    // ===================================
     /// Presentation Time Stamp, present if HasPTS() is true
     uint64_t PTS(void) const
     {
@@ -226,6 +246,9 @@ class MTV_PUBLIC PESPacket
     // FIXME re-read the specs and follow all negations to find out the
     // initial value of the CRC function when its being returned
     static const uint kTheMagicNoCRCCRC = 0xFFFFFFFF;
+
+    // This is a long term copy that is allocated via malloc
+    bool _isLongTermCopy;
 };
 
 class SequenceHeader

--- a/mythtv/libs/libmythtv/mpeg/scanstreamdata.cpp
+++ b/mythtv/libs/libmythtv/mpeg/scanstreamdata.cpp
@@ -17,10 +17,10 @@ ScanStreamData::ScanStreamData(bool no_default_pid) :
 
 ScanStreamData::~ScanStreamData() { ; }
 
-/** \fn ScanStreamData::IsRedundant(uint,const PSIPTable&) const
+/** \fn ScanStreamData::IsRedundant(uint,const PSIPTable&)
  *  \brief Returns true if table already seen.
  */
-bool ScanStreamData::IsRedundant(uint pid, const PSIPTable &psip) const
+bool ScanStreamData::IsRedundant(uint pid, const PSIPTable &psip)
 {
     // Treat BAT and SDTo as redundant unless they are on the FREESAT_SI_PID
     if (dvb_uk_freesat_si &&
@@ -98,13 +98,13 @@ QString ScanStreamData::GetSIStandard(QString guess) const
 }
 
 
-bool ScanStreamData::DeleteCachedTable(PSIPTable *psip) const
+bool ScanStreamData::DeleteCachedTableSection(PSIPTable *psip) const
 {
     if (!psip)
         return false;
 
-    if (ATSCStreamData::DeleteCachedTable(psip))
+    if (ATSCStreamData::DeleteCachedTableSection(psip))
         return true;
     else
-        return DVBStreamData::DeleteCachedTable(psip);
+        return DVBStreamData::DeleteCachedTableSection(psip);
 }

--- a/mythtv/libs/libmythtv/mpeg/scanstreamdata.h
+++ b/mythtv/libs/libmythtv/mpeg/scanstreamdata.h
@@ -16,7 +16,7 @@ class MTV_PUBLIC ScanStreamData :
     explicit ScanStreamData(bool no_default_pid = false);
     virtual ~ScanStreamData();
 
-    bool IsRedundant(uint pid, const PSIPTable&) const;
+    bool IsRedundant(uint pid, const PSIPTable&);
     bool HandleTables(uint pid, const PSIPTable &psip);
 
     using DVBStreamData::Reset;
@@ -33,8 +33,8 @@ class MTV_PUBLIC ScanStreamData :
     void SetFreesatAdditionalSI(bool freesat_si);
 
   private:
-    virtual bool DeleteCachedTable(PSIPTable *psip) const;
-    /// listen for addiotional Freesat service information
+    virtual bool DeleteCachedTableSection(PSIPTable *psip) const;
+    /// listen for additional Freesat service information
     int dvb_uk_freesat_si;
     bool m_no_default_pid;
 };

--- a/mythtv/libs/libmythtv/mpeg/sicachetypes.h
+++ b/mythtv/libs/libmythtv/mpeg/sicachetypes.h
@@ -1,0 +1,130 @@
+// -*- Mode: c++ -*-
+#ifndef SICACHETYPES_H_
+#define SICACHETYPES_H_
+
+#include "tablestatus.h"
+
+/// \file sicachetypes.h
+/// \brief Externally visible types for the DVB System Information caches
+///
+///The ETSI DVB standard defines a subtable as collection of sections with
+///the same value of table_id and:
+///- for a NIT: the same table_id_extension (network_id) and version_number;
+///- for a BAT: the same table_id_extension (bouquet_id) and version_number;
+///-for a SDT: the same table_id_extension (transport_stream_id), the same original_network_id and
+///version_number
+///- for a EIT: the same table_id_extension (service_id), the same transport_stream_id, the same
+///original_network_id and version_number.
+///
+
+class NetworkInformationTable;
+class ServiceDescriptionTableSection;
+class DVBEventInformationTableSection;
+
+// Network Information Table (NIT)
+
+// Network information table
+/// Pointer to non const NIT section
+typedef NetworkInformationTable* nit_ptr_t;
+/// Pointer to const NIT section
+typedef NetworkInformationTable const * nit_const_ptr_t;
+/// Vector of pointers to non const NIT sections
+typedef vector<nit_ptr_t>  nit_vec_t;
+/// Vector of pointers to const NIT sections
+typedef vector<nit_const_ptr_t>  nit_const_vec_t;
+/// Map of non const pointers to NIT sections indexed by section number
+typedef QMap<uint, nit_ptr_t>    nit_cache_t;
+
+// Service Description Table (SDT)
+
+/// Pointer to non const SDT section
+typedef ServiceDescriptionTableSection* sdt_section_ptr_t;
+/// Pointer to const SDT section
+typedef ServiceDescriptionTableSection const * sdt_section_const_ptr_t;
+/// Vector of pointers to non const SDT sections
+typedef vector<sdt_section_ptr_t>  sdt_section_vec_t;
+/// Vector of pointers to const SDT sections
+typedef vector<sdt_section_const_ptr_t>  sdt_section_const_vec_t;
+/// Non const SDT section level cache
+typedef QMap<uint16_t, sdt_section_ptr_t> sdt_sections_cache_t;
+/// const SDT Section level cache
+typedef QMap<uint16_t, sdt_section_ptr_t> const sdt_sections_cache_const_t;
+/// SDT sections cache and status information
+typedef struct SdtSectionsAndStatus
+{
+    /// Constructor initialises status info
+    SdtSectionsAndStatus(){ status.SetVersion(-1,0); }
+    /// Cache of the sections of this table
+    sdt_sections_cache_t sections;
+    /// Status of the this table
+    TableStatus status;
+    /// Time status was last modified or re-verified
+    QDateTime timestamp;
+    /// Map of MD5 hashes of table contents
+    QMap<uint16_t, QByteArray> hashes;
+} sdt_sections_cache_wrapper_t;
+/// SDT table level cache
+typedef QMap<uint16_t,sdt_sections_cache_wrapper_t>
+        sdt_t_cache_t;
+/// SDT transport stream level cache
+typedef QMap<uint16_t,sdt_t_cache_t>
+        sdt_ts_cache_t;
+
+/// Service description tables cache
+///
+/// SDT table sections are held in a cache that is indexed by
+/// section number within table ID within transport stream ID within
+/// original network ID. Per table status information is held at the table
+/// ID level.
+typedef struct SdtCache : public QMap<uint16_t,sdt_ts_cache_t>
+{
+    ~SdtCache();
+}        sdt_tsn_cache_t;
+
+// Event Information Table (EIT)
+
+/// Pointer to non const EIT section
+typedef DVBEventInformationTableSection* eit_section_ptr_t;
+/// Pointer to const EIT section
+typedef DVBEventInformationTableSection const * eit_section_const_ptr_t;
+/// Vector of pointers to non const EIT sections
+typedef vector<eit_section_ptr_t>  eit_section_vec_t;
+/// Vector of pointers to const EIT sections
+typedef vector<eit_section_const_ptr_t>  eit_section_const_vec_t;
+/// Non const EIT section level cache
+typedef QMap<uint16_t, eit_section_ptr_t> eit_sections_cache_t;
+/// const EIT section level cache
+typedef QMap<uint16_t, eit_section_ptr_t> const eit_sections_cache_const_t;
+/// EIT sections cache and status information
+typedef struct EitSectionsAndStatus
+{
+    /// Constructor initialises status info
+    EitSectionsAndStatus(){ status.SetVersion(-1,0); }
+    /// Cache of the sections of this table
+    eit_sections_cache_t sections;
+    /// Status of the this table
+    TableStatus status;
+    /// Time status was last modified or re-verified
+    QDateTime timestamp;
+    /// Map of MD5 hashes of table contents
+    QMap<uint16_t, QByteArray> hashes;
+} eit_sections_cache_wrapper_t;
+/// Table level cache
+typedef QMap<uint16_t, eit_sections_cache_wrapper_t> eit_t_cache_t;
+/// Service level cache
+typedef QMap<uint16_t,eit_t_cache_t> eit_ts_cache_t;
+/// Transport stream level cache
+typedef QMap<uint16_t,eit_ts_cache_t> eit_tss_cache_t;
+
+/// Event Information Tables cache
+///
+/// EIT table sections are held in a cache that is indexed by
+/// section number within table ID within service ID within transport stream
+/// ID within original network ID.
+typedef struct EitCache : public QMap<uint16_t,eit_tss_cache_t>
+{
+    ~EitCache();
+} eit_tssn_cache_t;
+
+#endif // SICACHETYPES_H_
+

--- a/mythtv/libs/libmythtv/mpeg/streamlisteners.h
+++ b/mythtv/libs/libmythtv/mpeg/streamlisteners.h
@@ -4,6 +4,7 @@
 
 #include "tspacket.h"
 #include "mythdate.h"
+#include "sicachetypes.h"
 
 class TSPacket;
 class TSPacket_nonconst;
@@ -44,9 +45,9 @@ class AggregateDataEventTable;
 
 class NetworkInformationTable;
 class BouquetAssociationTable;
-class ServiceDescriptionTable;
+class ServiceDescriptionTableSection;
 class TimeDateTable;
-class DVBEventInformationTable;
+class DVBEventInformationTableSection;
 class PremiereContentInformationTable;
 
 class TSDataListener
@@ -176,7 +177,7 @@ class DVBMainStreamListener
   public:
     virtual void HandleTDT(const TimeDateTable*) = 0;
     virtual void HandleNIT(const NetworkInformationTable*) = 0;
-    virtual void HandleSDT(uint tsid, const ServiceDescriptionTable*) = 0;
+    virtual void HandleSDT(const sdt_sections_cache_const_t&) = 0;
 };
 
 class DVBOtherStreamListener
@@ -185,7 +186,7 @@ class DVBOtherStreamListener
     virtual ~DVBOtherStreamListener() {}
   public:
     virtual void HandleNITo(const NetworkInformationTable*) = 0;
-    virtual void HandleSDTo(uint tsid, const ServiceDescriptionTable*) = 0;
+    virtual void HandleSDTo(const sdt_sections_cache_const_t&) = 0;
     virtual void HandleBAT(const BouquetAssociationTable*) = 0;
 };
 
@@ -194,7 +195,7 @@ class DVBEITStreamListener
   protected:
     virtual ~DVBEITStreamListener() {}
   public:
-    virtual void HandleEIT(const DVBEventInformationTable*) = 0;
+    virtual void HandleEIT(const DVBEventInformationTableSection*) = 0;
     virtual void HandleEIT(const PremiereContentInformationTable*) = 0;
 };
 

--- a/mythtv/libs/libmythtv/mpeg/tablestatus.cpp
+++ b/mythtv/libs/libmythtv/mpeg/tablestatus.cpp
@@ -54,6 +54,16 @@ bool TableStatus::HasAllSections() const
     return true;
 }
 
+int TableStatus::MissingSections() const
+{
+    // Let the compiler optimise this :-)
+    int missing = 0;
+    for (uint32_t i = 0; i < 32; i++)
+        for (uint j = 0; j < 8; j++)
+            if (0 == (m_sections[i] & (1 << j)))
+                missing++;
+    return missing;
+}
 
 void TableStatusMap::SetVersion(uint32_t key, int32_t version, uint32_t last_section)
 {
@@ -85,5 +95,14 @@ bool TableStatusMap::HasAllSections(uint32_t key) const
         return false;
 
     return it->HasAllSections();
+}
+
+int TableStatusMap::MissingSections(uint32_t key) const
+{
+    const_iterator it = this->find(key);
+    if (it == this->end())
+        return -1;
+
+    return it->MissingSections();
 }
 

--- a/mythtv/libs/libmythtv/mpeg/tablestatus.h
+++ b/mythtv/libs/libmythtv/mpeg/tablestatus.h
@@ -20,11 +20,13 @@ public:
     static void InitSections(sections_t &sect, uint32_t last_section);
 
     TableStatus() : m_version(-2) {}
+    ~TableStatus() { m_sections.clear(); }
     void SetVersion(int32_t version, uint32_t last_section);
     void SetSectionSeen(int32_t version, uint32_t section,
                         uint32_t last_section, uint32_t segment_last_section = 0xffff);
     bool IsSectionSeen(int32_t version, uint32_t section) const;
     bool HasAllSections() const;
+    int MissingSections() const;
 
     int32_t     m_version;
     sections_t  m_sections;
@@ -42,6 +44,7 @@ public:
                         uint32_t last_section, uint32_t segment_last_section = 0xffff);
     bool IsSectionSeen(uint32_t key, int32_t version, uint32_t section) const;
     bool HasAllSections(uint32_t key) const;
+    int MissingSections(uint32_t key) const;
 };
 
 #endif // TABLESTATUS_H_

--- a/mythtv/libs/libmythtv/privatedecoder_omx.cpp
+++ b/mythtv/libs/libmythtv/privatedecoder_omx.cpp
@@ -92,6 +92,9 @@ void PrivateDecoderOMX::GetDecoders(render_opts &opts)
 PrivateDecoderOMX::PrivateDecoderOMX() :
     m_videc(gCoreContext->GetSetting("OMXVideoDecode", VIDEO_DECODE), *this),
     m_filter(0), m_bStartTime(false),
+#ifdef USING_BROADCOM
+    m_eMode(OMX_InterlaceFieldsInterleavedUpperFirst), m_bRepeatFirstField(false),
+#endif
     m_avctx(0),
     m_lock(QMutex::Recursive), m_bSettingsChanged(false),
     m_bSettingsHaveChanged(false)
@@ -885,7 +888,6 @@ int PrivateDecoderOMX::GetBufferedFrame(AVStream *stream, AVFrame *picture)
     OMX_BUFFERHEADERTYPE *hdr = m_obufs.takeFirst();
     m_lock.unlock();
 
-    OMX_U32 nFlags = hdr->nFlags;
     if (hdr->nFlags & ~OMX_BUFFERFLAG_ENDOFFRAME)
         LOG(VB_PLAYBACK, LOG_DEBUG, LOC +
             QString("Decoded frame flags=%1").arg(HeaderFlags(hdr->nFlags)) );
@@ -1017,15 +1019,39 @@ int PrivateDecoderOMX::GetBufferedFrame(AVStream *stream, AVFrame *picture)
         if (ret)
         {
 #ifdef USING_BROADCOM
-            if (nFlags & OMX_BUFFERFLAG_INTERLACED)
-                picture->interlaced_frame = 1;
-            else
+            switch (m_eMode)
+            {
+              case OMX_InterlaceProgressive:
                 picture->interlaced_frame = 0;
-            if (nFlags & OMX_BUFFERFLAG_TOP_FIELD_FIRST)
-                picture->top_field_first = 1;
-            else
                 picture->top_field_first = 0;
-            picture->repeat_pict = 0;
+                break;
+              case OMX_InterlaceFieldSingleUpperFirst:
+                /* The data is interlaced, fields sent
+                 * separately in temporal order, with upper field first */
+                picture->interlaced_frame = 1;
+                picture->top_field_first = 1;
+                break;
+              case OMX_InterlaceFieldSingleLowerFirst:
+                picture->interlaced_frame = 1;
+                picture->top_field_first = 0;
+                break;
+              case OMX_InterlaceFieldsInterleavedUpperFirst:
+                /* The data is interlaced, two fields sent together line
+                 * interleaved, with the upper field temporally earlier */
+                picture->interlaced_frame = 1;
+                picture->top_field_first = 1;
+                break;
+              case OMX_InterlaceFieldsInterleavedLowerFirst:
+                picture->interlaced_frame = 1;
+                picture->top_field_first = 0;
+                break;
+              case OMX_InterlaceMixed:
+                /* The stream may contain a mixture of progressive
+                 * and interlaced frames */
+                picture->interlaced_frame = 1;
+                break;
+            }
+            picture->repeat_pict = m_bRepeatFirstField;
 #endif // USING_BROADCOM
 
             if (!frame)
@@ -1100,6 +1126,55 @@ OMX_ERRORTYPE PrivateDecoderOMX::SettingsChanged(AVCodecContext *avctx)
         LOG(VB_PLAYBACK, LOG_ERR, LOC + QString(
                 "SetParameter IndexParamVideoPortFormat error %1")
             .arg(Error2String(e)));
+
+#ifdef USING_BROADCOM
+    OMX_CONFIG_INTERLACETYPE inter;
+    e = GetInterlace(inter, index);
+    if (e == OMX_ErrorNone)
+    {
+        LOG(VB_PLAYBACK, LOG_INFO, LOC + QString("%1%2")
+            .arg(Interlace2String(inter.eMode))
+            .arg(inter.bRepeatFirstField ? " rpt 1st" : "") );
+
+        m_bRepeatFirstField = inter.bRepeatFirstField;
+        m_eMode = inter.eMode;
+#if 0 // Can't change interlacing setting, at least not on RPi
+        switch (inter.eMode)
+        {
+          case OMX_InterlaceProgressive:
+            break;
+
+          case OMX_InterlaceFieldSingleUpperFirst:
+          case OMX_InterlaceFieldSingleLowerFirst:
+            break;
+
+          case OMX_InterlaceFieldsInterleavedUpperFirst:
+            /* The data is interlaced, two fields sent together line
+             * interleaved, with the upper field temporally earlier */
+            inter.eMode = OMX_InterlaceFieldSingleUpperFirst;
+            break;
+          case OMX_InterlaceFieldsInterleavedLowerFirst:
+            inter.eMode = OMX_InterlaceFieldSingleLowerFirst;
+            break;
+
+          case OMX_InterlaceMixed:
+            inter.eMode = OMX_InterlaceFieldSingleUpperFirst;
+            break;
+        }
+
+        if (m_eMode != inter.eMode)
+        {
+            e = m_videc.SetConfig(OMX_IndexConfigCommonInterlace, &inter);
+            if (e == OMX_ErrorNone)
+                m_eMode = inter.eMode;
+            else
+                LOG(VB_PLAYBACK, LOG_ERR, LOC + QString(
+                        "Set ConfigCommonInterlace error %1")
+                    .arg(Error2String(e)));
+        }
+#endif
+    }
+#endif // USING_BROADCOM
 
 #ifdef USING_BROADCOM
     if (VERBOSE_LEVEL_CHECK(VB_PLAYBACK, LOG_INFO))

--- a/mythtv/libs/libmythtv/privatedecoder_omx.h
+++ b/mythtv/libs/libmythtv/privatedecoder_omx.h
@@ -70,6 +70,10 @@ class PrivateDecoderOMX : public PrivateDecoder, private OMXComponentCtx
     OMXComponent m_videc;
     AVBitStreamFilterContext *m_filter;
     bool m_bStartTime;
+#ifdef USING_BROADCOM
+    OMX_INTERLACETYPE m_eMode;
+    bool m_bRepeatFirstField;
+#endif
     AVCodecContext *m_avctx;
 
     QMutex mutable m_lock;      // Protects data following

--- a/mythtv/libs/libmythtv/recorders/dtvrecorder.h
+++ b/mythtv/libs/libmythtv/recorders/dtvrecorder.h
@@ -78,7 +78,7 @@ class DTVRecorder :
     // DVBMainStreamListener
     void HandleTDT(const TimeDateTable*) { UpdateCAMTimeOffset(); }
     void HandleNIT(const NetworkInformationTable*) {}
-    void HandleSDT(uint /*tsid*/, const ServiceDescriptionTable*) {}
+    void HandleSDT(const sdt_sections_cache_const_t&) {}
 
     // TSPacketListener
     bool ProcessTSPacket(const TSPacket &tspacket);

--- a/mythtv/libs/libmythtv/recorders/dtvsignalmonitor.cpp
+++ b/mythtv/libs/libmythtv/recorders/dtvsignalmonitor.cpp
@@ -66,6 +66,7 @@ DTVSignalMonitor::DTVSignalMonitor(int db_cardnum,
       detectedNetworkID(0), detectedTransportID(0),
       programNumber(-1),
       ignore_encrypted(false)
+//      ,old_flags(0)
 {
 }
 
@@ -232,14 +233,14 @@ void DTVSignalMonitor::SetProgramNumber(int progNum)
     }
 }
 
-void DTVSignalMonitor::SetDVBService(uint netid, uint tsid, int serviceid)
+void DTVSignalMonitor::SetDVBService(uint original_network_id, uint transport_id, int service_id)
 {
-    DBG_SM(QString("SetDVBService(transport_id: %1, network_id: %2, "
-                   "service_id: %3)").arg(tsid).arg(netid).arg(serviceid), "");
+    DBG_SM(QString("SetDVBService(transport_id: %1, original_network_id: %2, "
+                   "service_id: %3)").arg(transport_id).arg(original_network_id).arg(service_id), "");
     seen_table_crc.clear();
 
-    if (netid == networkID && tsid == transportID &&
-        serviceid == programNumber)
+    if (original_network_id == networkID && transport_id == transportID &&
+        service_id == programNumber)
     {
         return;
     }
@@ -248,15 +249,17 @@ void DTVSignalMonitor::SetDVBService(uint netid, uint tsid, int serviceid)
                 kDTVSigMon_SDTSeen   | kDTVSigMon_SDTMatch |
                 kDTVSigMon_CryptSeen | kDTVSigMon_CryptMatch);
 
-    transportID   = tsid;
-    networkID     = netid;
-    programNumber = serviceid;
+    transportID   = transport_id;
+    networkID     = original_network_id;
+    programNumber = service_id;
 
-    if (GetDVBStreamData())
+    DVBStreamData* streamdata = GetDVBStreamData();
+    if (streamdata)
     {
-        GetDVBStreamData()->SetDesiredService(netid, tsid, programNumber);
+        streamdata->SetDesiredService(original_network_id, transport_id, service_id);
         AddFlags(kDTVSigMon_WaitForPMT | kDTVSigMon_WaitForSDT);
-        GetDVBStreamData()->AddListeningPID(DVB_SDT_PID);
+        streamdata->AddListeningPID(DVB_SDT_PID);
+        streamdata->RequestReplayOfCachedSDTs();
     }
 }
 
@@ -490,34 +493,57 @@ void DTVSignalMonitor::HandleNIT(const NetworkInformationTable *nit)
         return;
 }
 
-void DTVSignalMonitor::HandleSDT(uint, const ServiceDescriptionTable *sdt)
+void DTVSignalMonitor::HandleSDT(const sdt_sections_cache_const_t& sections)
 {
     AddFlags(kDTVSigMon_SDTSeen);
 
-    detectedNetworkID = sdt->OriginalNetworkID();
-    detectedTransportID = sdt->TSID();
+    sdt_sections_cache_const_t::const_iterator section = sections.begin();
 
-    // if the multiplex is not properly configured with ONID and TSID then take
-    // whatever SDT we see first
-    if ((networkID == 0) && (transportID == 0))
+    if (section != sections.end())
     {
-        networkID = detectedNetworkID;
-        transportID = detectedTransportID;
+        detectedNetworkID = (*section)->OriginalNetworkID();
+        detectedTransportID = (*section)->TSID();
 
-        // FIXME assert if TableID == SDTo
-    }
+        // if the multiplex is not properly configured with ONID and TSID then take
+        // whatever SDT we see first
+        if ((networkID == 0) && (transportID == 0))
+        {
+            networkID = detectedNetworkID;
+            transportID = detectedTransportID;
+        }
 
-    if (sdt->OriginalNetworkID() != networkID || sdt->TSID() != transportID)
-    {
-        GetDVBStreamData()->SetVersionSDT(sdt->TSID(), -1, 0);
+        if (detectedNetworkID == networkID && detectedTransportID == transportID)
+        {
+            AddFlags(kDTVSigMon_SDTMatch);
+            RemoveFlags(kDVBSigMon_WaitForPos);
+        }
+        else
+        {
+        }
     }
     else
+        LOG(VB_GENERAL, LOG_ERR, "SDTa with no sections encountered");
+}
+
+void DTVSignalMonitor::HandleSDTo(const sdt_sections_cache_const_t& sections)
+{
+    sdt_sections_cache_const_t::const_iterator section = sections.begin();
+
+    if (section != sections.end())
     {
-        DBG_SM("SetSDT()", QString("tsid = %1 orig_net_id = %2")
-               .arg(sdt->TSID()).arg(sdt->OriginalNetworkID()));
-        AddFlags(kDTVSigMon_SDTMatch);
-        RemoveFlags(kDVBSigMon_WaitForPos);
+        detectedNetworkID = (*section)->OriginalNetworkID();
+        detectedTransportID = (*section)->TSID();
+
+        if (detectedNetworkID == networkID && detectedTransportID == transportID)
+        {
+            // Looks like I am on a non standard system that transmit SDT as SDTo
+            AddFlags(kDTVSigMon_SDTSeen);
+            AddFlags(kDTVSigMon_SDTMatch);
+            RemoveFlags(kDVBSigMon_WaitForPos);
+        }
     }
+    else
+        LOG(VB_GENERAL, LOG_ERR, "SDTo with no sections encountered");
 }
 
 void DTVSignalMonitor::HandleEncryptionStatus(uint, bool enc_status)
@@ -560,6 +586,7 @@ const ScanStreamData *DTVSignalMonitor::GetScanStreamData() const
 bool DTVSignalMonitor::IsAllGood(void) const
 {
     QMutexLocker locker(&statusLock);
+
     if (!SignalMonitor::IsAllGood())
         return false;
     if ((flags & kDTVSigMon_WaitForPAT) && !matchingPAT.IsGood())

--- a/mythtv/libs/libmythtv/recorders/dtvsignalmonitor.h
+++ b/mythtv/libs/libmythtv/recorders/dtvsignalmonitor.h
@@ -16,7 +16,8 @@ class DTVSignalMonitor : public SignalMonitor,
                          public MPEGStreamListener,
                          public ATSCMainStreamListener,
                          public ATSCAuxStreamListener,
-                         public DVBMainStreamListener
+                         public DVBMainStreamListener,
+                         public DVBOtherStreamListener
 {
   public:
     DTVSignalMonitor(int db_cardnum,
@@ -34,7 +35,7 @@ class DTVSignalMonitor : public SignalMonitor,
     void SetProgramNumber(int progNum);
     int  GetProgramNumber() const { return programNumber; }
 
-    void SetDVBService(uint network_id, uint transport_id, int service_id);
+    void SetDVBService(uint original_network_id, uint transport_id, int service_id);
     uint GetTransportID(void) const { return transportID;   }
     uint GetNetworkID(void)   const { return networkID;     }
     int  GetServiceID(void)   const { return programNumber; }
@@ -97,7 +98,12 @@ class DTVSignalMonitor : public SignalMonitor,
     // DVB Main
     void HandleTDT(const TimeDateTable*);
     void HandleNIT(const NetworkInformationTable*);
-    void HandleSDT(uint, const ServiceDescriptionTable*);
+    void HandleSDT(const sdt_sections_cache_const_t&);
+
+    // DVB Other
+    void HandleNITo(const NetworkInformationTable*) {}
+    void HandleSDTo(const sdt_sections_cache_const_t&);
+    void HandleBAT(const BouquetAssociationTable*) {}
 
     void IgnoreEncrypted(bool ignore) { ignore_encrypted = ignore; }
 
@@ -139,6 +145,7 @@ class DTVSignalMonitor : public SignalMonitor,
     QList<uint64_t>    seen_table_crc;
 
     bool ignore_encrypted;
+//    volatile mutable uint64_t old_flags;
 };
 
 #endif // DTVSIGNALMONITOR_H

--- a/mythtv/libs/libmythtv/recorders/dvbchannel.cpp
+++ b/mythtv/libs/libmythtv/recorders/dvbchannel.cpp
@@ -88,6 +88,7 @@ DVBChannel::DVBChannel(const QString &aDevice, TVRec *parent)
     if (m_pParent)
         key += QString(":%1")
             .arg(CardUtil::GetSourceID(m_pParent->GetInputId()));
+            
     master_map[key].push_back(this); // == RegisterForMaster
     DVBChannel *master = static_cast<DVBChannel*>(master_map[key].front());
     if (master == this)
@@ -114,7 +115,15 @@ DVBChannel::~DVBChannel()
     if (m_pParent)
         key += QString(":%1")
             .arg(CardUtil::GetSourceID(m_pParent->GetInputId()));
-    DVBChannel *master = static_cast<DVBChannel*>(master_map[key].front());
+
+    DVBChannel *master = NULL;
+
+    // If the database has gone away the key string may be incorrect    
+    if ((!master_map.contains(key)) || (master_map[key].isEmpty()))
+          return;
+
+    master = static_cast<DVBChannel*>(master_map[key].front());
+
     if (master == this)
     {
         master_map[key].pop_front();
@@ -125,9 +134,8 @@ DVBChannel::~DVBChannel()
             new_master->is_open = master->is_open;
     }
     else
-    {
         master_map[key].removeAll(this);
-    }
+
     master_map_lock.unlock();
 
     Close();

--- a/mythtv/libs/libmythtv/recorders/firewiresignalmonitor.cpp
+++ b/mythtv/libs/libmythtv/recorders/firewiresignalmonitor.cpp
@@ -126,7 +126,7 @@ void FirewireSignalMonitor::HandlePMT(uint pnum, const ProgramMapTable *pmt)
 
     if (!HasFlags(kDTVSigMon_PATMatch))
     {
-        GetStreamData()->SetVersionPMT(pnum, -1,0);
+        GetStreamData()->SetVersionPMT(pnum, -1, 0);
         LOG(VB_CHANNEL, LOG_INFO, LOC + "HandlePMT() ignoring PMT");
         return;
     }

--- a/mythtv/libs/libmythtv/tv_rec.cpp
+++ b/mythtv/libs/libmythtv/tv_rec.cpp
@@ -1301,7 +1301,8 @@ void TVRec::run(void)
     {
         scanner = new EITScanner(inputid);
         eitScanStartTime = eitScanStartTime.addSecs(
-            eitCrawlIdleStart + eit_start_rand(inputid, eitTransportTimeout));
+                                eitCrawlIdleStart
+                                + eit_start_rand(inputid, eitTransportTimeout));
     }
     else
         eitScanStartTime = eitScanStartTime.addYears(1);

--- a/mythtv/libs/libmythtv/tv_rec.h
+++ b/mythtv/libs/libmythtv/tv_rec.h
@@ -249,6 +249,8 @@ class MTV_PUBLIC TVRec : public SignalMonitorListener, public QRunnable
 
     static TVRec *GetTVRec(uint inputid);
 
+    DTVSignalMonitor *GetDTVSignalMonitor(void);
+
     virtual void AllGood(void) { WakeEventLoop(); }
     virtual void StatusChannelTuned(const SignalMonitorValue&) { }
     virtual void StatusSignalLock(const SignalMonitorValue&) { }
@@ -284,7 +286,6 @@ class MTV_PUBLIC TVRec : public SignalMonitorListener, public QRunnable
         bool enable_table_monitoring, bool EITscan, bool notify);
     bool SetupDTVSignalMonitor(bool EITscan);
     void TeardownSignalMonitor(void);
-    DTVSignalMonitor *GetDTVSignalMonitor(void);
 
     bool HasFlags(uint f) const { return (stateFlags & f) == f; }
     void SetFlags(uint f, const QString & file, int line);

--- a/mythtv/libs/libmythtv/videoout_omx.cpp
+++ b/mythtv/libs/libmythtv/videoout_omx.cpp
@@ -877,10 +877,6 @@ void VideoOutputOMX::Show(FrameScanType scan)
 
     hdr->nFilledLen = frame->offsets[2] + (frame->offsets[1] >> 2);
     hdr->nFlags = OMX_BUFFERFLAG_ENDOFFRAME;
-    if (frame->interlaced_frame)
-        hdr->nFlags |= OMX_BUFFERFLAG_INTERLACED;
-    if (frame->top_field_first)
-        hdr->nFlags |= OMX_BUFFERFLAG_TOP_FIELD_FIRST;
     OMXComponent &cmpnt = m_imagefx.IsValid() ? m_imagefx : m_render;
     OMX_ERRORTYPE e = OMX_EmptyThisBuffer(cmpnt.Handle(), hdr);
     if (e != OMX_ErrorNone)

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -39,6 +39,7 @@ using namespace std;
 #include "channelutil.h"
 #include "frequencies.h"
 #include "diseqcsettings.h"
+#include "dvbstreamdata.h"
 #include "firewiredevice.h"
 #include "compat.h"
 #include "mythdb.h"

--- a/mythtv/libs/libmythui/mythpainter.cpp
+++ b/mythtv/libs/libmythui/mythpainter.cpp
@@ -14,7 +14,7 @@
 // libmythui headers
 #include "mythfontproperties.h"
 #include "mythimage.h"
-#include "mythuianimation.h"	// UIEffects
+#include "mythuianimation.h" // UIEffects
 
 // Own header
 #include "mythpainter.h"

--- a/mythtv/libs/libmythupnp/mmembuf.cpp
+++ b/mythtv/libs/libmythupnp/mmembuf.cpp
@@ -83,7 +83,7 @@ bool MMembuf::consumeBytes(quint64 nbytes, char *sink)
             }
             nbytes -= len;
             buf.removeFirst();
-	    delete a;
+            delete a;
             _index = 0;
             if (nbytes == 0)
                 break;

--- a/mythtv/libs/libmythupnp/wsdl.cpp
+++ b/mythtv/libs/libmythupnp/wsdl.cpp
@@ -262,7 +262,7 @@ bool Wsdl::GetWSDL( HTTPRequest *pRequest )
         // ------------------------------------------------------------------
         // Create all needed includes
         //
-        //	<xs:import schemaLocation="<path to dependant schema" namespace="http://mythtv.org"/>
+        // <xs:import schemaLocation="<path to dependant schema" namespace="http://mythtv.org"/>
         // ------------------------------------------------------------------
 
         QString sBaseUri = "http://" + pRequest->m_mapHeaders[ "host" ] + pRequest->m_sBaseUrl + "/xsd";

--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -78,6 +78,7 @@ using namespace std;
 #include "musicmetadata.h"
 #include "imagemanager.h"
 #include "cardutil.h"
+#include "dvbstreamdata.h"
 
 // mythbackend headers
 #include "backendcontext.h"
@@ -1427,6 +1428,9 @@ void MainServer::customEvent(QEvent *e)
 
         if (me->Message() == "CLEAR_SETTINGS_CACHE")
             gCoreContext->ClearSettingsCache();
+
+        if (me->Message() == "LOG_SI_CACHE")
+            DVBStreamData::LogSICache();
 
         if (me->Message().startsWith("RESET_IDLETIME") && m_sched)
             m_sched->ResetIdleTime();

--- a/mythtv/programs/mythtv-setup/main.cpp
+++ b/mythtv/programs/mythtv-setup/main.cpp
@@ -312,7 +312,12 @@ int main(int argc, char *argv[])
     // of the MythPushButton widgets, and they don't use the themed background.
     QApplication::setDesktopSettingsAware(false);
 #endif
-    new QApplication(argc, argv, use_display);
+
+    if (use_display)
+        new QApplication(argc, argv);
+    else
+        new QCoreApplication(argc, argv);
+
     QCoreApplication::setApplicationName(MYTH_APPNAME_MYTHTV_SETUP);
 
 #ifndef _WIN32

--- a/mythtv/programs/mythutil/backendutils.cpp
+++ b/mythtv/programs/mythutil/backendutils.cpp
@@ -104,6 +104,20 @@ static int ParseVideoFilename(const MythUtilCommandLineParser &cmdline)
     return GENERIC_EXIT_OK;
 }
 
+static int LogSICache(const MythUtilCommandLineParser &cmdline)
+{
+    if (gCoreContext->ConnectToMasterServer(false, false))
+    {
+        gCoreContext->SendMessage("LOG_SI_CACHE");
+        LOG(VB_GENERAL, LOG_INFO, "Sent LOG_SI_CACHE message");
+        return GENERIC_EXIT_OK;
+    }
+
+    LOG(VB_GENERAL, LOG_ERR, "Unable to connect to backend, settings "
+        "SI cache will not be logged.");
+    return GENERIC_EXIT_CONNECT_ERROR;
+}
+
 void registerBackendUtils(UtilMap &utilMap)
 {
     utilMap["clearcache"]           = &ClearSettingsCache;
@@ -112,6 +126,7 @@ void registerBackendUtils(UtilMap &utilMap)
     utilMap["scanvideos"]           = &ScanVideos;
     utilMap["systemevent"]          = &SendSystemEvent;
     utilMap["parsevideo"]           = &ParseVideoFilename;
+    utilMap["logsicache"]           = &LogSICache;
 }
 
 /* vim: set expandtab tabstop=4 shiftwidth=4: */

--- a/mythtv/programs/mythutil/commandlineparser.cpp
+++ b/mythtv/programs/mythutil/commandlineparser.cpp
@@ -89,6 +89,13 @@ void MythUtilCommandLineParser::LoadArguments(void)
                 ->SetParentOf(ChanidStartimeVideo)
 
         // backendutils.cpp
+        << add("--logsicache", "logsicache", false,
+                "Trigger a print of the current DVB SI cache on the existing "
+                "master backend.",
+                "This command will connect to the master backend and trigger "
+                "a print of the current DVB SI cache to the log. The call "
+                "will return immediately.")
+                ->SetGroup("Backend")
         << add("--resched", "resched", false,
                 "Trigger a run of the recording scheduler on the existing "
                 "master backend.",

--- a/mythtv/programs/mythutil/mpegutils.cpp
+++ b/mythtv/programs/mythutil/mpegutils.cpp
@@ -666,9 +666,12 @@ class PrintDVBMainStreamListener :
         Output(nit);
     }
 
-    virtual void HandleSDT(uint tsid, const ServiceDescriptionTable *sdt)
+    virtual void HandleSDT(const sdt_sections_cache_const_t& sections)
     {
-        Output(sdt);
+        for (sdt_sections_cache_const_t::const_iterator section = sections.begin();
+                section != sections.end();
+                ++section)
+            Output(*section);
     }
 
 };
@@ -685,9 +688,12 @@ class PrintDVBOtherStreamListener :
         Output(nit);
     }
 
-    virtual void HandleSDTo(uint tsid, const ServiceDescriptionTable *sdt)
+    virtual void HandleSDTo(const sdt_sections_cache_const_t& sections)
     {
-        Output(sdt);
+        for (sdt_sections_cache_const_t::const_iterator section = sections.begin();
+                section != sections.end();
+                ++section)
+            Output(*section);
     }
 
     virtual void HandleBAT(const BouquetAssociationTable *bat)
@@ -704,7 +710,7 @@ class PrintDVBEITStreamListener :
     PrintDVBEITStreamListener(RingBuffer *out, bool use_xml) :
         PrintOutput(out, use_xml) { }
 
-    virtual void HandleEIT(const DVBEventInformationTable *eit)
+    virtual void HandleEIT(const DVBEventInformationTableSection *eit)
     {
         Output(eit);
     }

--- a/mythtv/settings.pro
+++ b/mythtv/settings.pro
@@ -270,15 +270,17 @@ win32 {
 # Globals in static libraries need special treatment on OS X
 macx:QMAKE_CFLAGS_STATIC_LIB += -fno-common
 
-# figure out compile flags based on qmake info
+# figure out compile and link flags based on qmake info
 # qmake 4.8.2 & 4.8.3 messes up OSX "-arch i386 -arch x86_64"
 # clang 3.0 on Linux does not like duplicate arguments.
 macx {
     QMAKE_CFLAGS   += $$CPPFLAGS   $$CFLAGS
     QMAKE_CXXFLAGS += $$CXXPPFLAGS $$ECXXFLAGS
+    QMAKE_LFLAGS += $$LDFLAGS
 } else {
     QMAKE_CFLAGS   *= $$CPPFLAGS   $$CFLAGS
     QMAKE_CXXFLAGS *= $$CXXPPFLAGS $$ECXXFLAGS
+    QMAKE_LFLAGS *= $$LDFLAGS
 }
 
 profile:!win32:!macx:CONFIG += debug


### PR DESCRIPTION
Change name of SatelliteDeliverySystemDescriptor::FrequencyHz()  to FrequencyKHz and fix the places where the return value is incorrectly treated. This fixes the a problem with fully tuned scans of satellite delivery systems which would fail to tune any new muliplexes found due to incorrectly dividing the frequency got from the the descriptor by 1000.

Also dvbsi changes as a consolidated patch.