### PR TITLE
Fix QObject related compile warnings in trunk

### DIFF
--- a/mythtv/libs/libmythservicecontracts/datacontracthelper.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracthelper.h
@@ -140,7 +140,7 @@ void CopyListContents( QObject *pParent, QVariantList &dst, const QVariantList &
             {
                 QObject *pNew = new T( pParent );
 
-                ((T *)pNew)->Copy( (const T &)(*pObject) );
+                ((T *)pNew)->Copy( (const T *)pObject );
 
                 dst.append( QVariant::fromValue<QObject *>( pNew ));
             }

--- a/mythtv/libs/libmythservicecontracts/datacontracts/artworkInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/artworkInfo.h
@@ -38,41 +38,23 @@ class SERVICE_PUBLIC ArtworkInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ArtworkInfo(QObject *parent = 0)
             : QObject         ( parent )
         {
         }
 
-        ArtworkInfo( const ArtworkInfo &src )
+        void Copy( const ArtworkInfo *src )
         {
-            Copy( src );
+            m_URL           = src->m_URL           ;
+            m_FileName      = src->m_FileName      ;
+            m_StorageGroup  = src->m_StorageGroup  ;
+            m_Type          = src->m_Type          ;
         }
 
-        void Copy( const ArtworkInfo &src )
-        {
-            m_URL           = src.m_URL           ;
-            m_FileName      = src.m_FileName      ;
-            m_StorageGroup  = src.m_StorageGroup  ;
-            m_Type          = src.m_Type          ;
-        }
+    private:
+        Q_DISABLE_COPY(ArtworkInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ArtworkInfo  )
-Q_DECLARE_METATYPE( DTC::ArtworkInfo* )
-
-namespace DTC
-{
-inline void ArtworkInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< ArtworkInfo  >();
-    qRegisterMetaType< ArtworkInfo* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/artworkInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/artworkInfoList.h
@@ -38,23 +38,14 @@ class SERVICE_PUBLIC ArtworkInfoList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ArtworkInfoList(QObject *parent = 0)
             : QObject         ( parent )
         {
         }
 
-        ArtworkInfoList( const ArtworkInfoList &src )
+        void Copy( const ArtworkInfoList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const ArtworkInfoList &src )
-        {
-            CopyListContents< ArtworkInfo >( this, m_ArtworkInfos, src.m_ArtworkInfos );
+            CopyListContents< ArtworkInfo >( this, m_ArtworkInfos, src->m_ArtworkInfos );
         }
 
         ArtworkInfo *AddNewArtworkInfo()
@@ -68,22 +59,10 @@ class SERVICE_PUBLIC ArtworkInfoList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(ArtworkInfoList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ArtworkInfoList  )
-Q_DECLARE_METATYPE( DTC::ArtworkInfoList* )
-
-namespace DTC
-{
-inline void ArtworkInfoList::InitializeCustomTypes()
-{
-    qRegisterMetaType< ArtworkInfoList  >();
-    qRegisterMetaType< ArtworkInfoList* >();
-
-    ArtworkInfo::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/backendInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/backendInfo.h
@@ -37,10 +37,6 @@ class SERVICE_PUBLIC BackendInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         BackendInfo(QObject *parent = 0)
             : QObject   ( parent ),
               m_Build   ( NULL   ),
@@ -49,49 +45,28 @@ class SERVICE_PUBLIC BackendInfo : public QObject
         {
         }
 
-        BackendInfo( const BackendInfo &src )
-            : m_Build  ( NULL ),
-              m_Env    ( NULL ),
-              m_Log    ( NULL )
-        {
-            Copy( src );
-        }
-
-        void Copy( const BackendInfo &src )
+        void Copy( const BackendInfo *src )
         {
             // We always need to make sure the child object is
             // created with the correct parent *
 
-            if (src.m_Build)
-                Build()->Copy( src.m_Build );
+            if (src->m_Build)
+                Build()->Copy( src->m_Build );
 
-            if (src.m_Env)
-                Env()->Copy( src.m_Env  );
+            if (src->m_Env)
+                Env()->Copy( src->m_Env  );
 
-            if (src.m_Log)
-                Log()->Copy( src.m_Log  );
+            if (src->m_Log)
+                Log()->Copy( src->m_Log  );
 
         }
+
+    private:
+        Q_DISABLE_COPY(BackendInfo);
 };
 
 typedef BackendInfo* BackendInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::BackendInfo  )
-Q_DECLARE_METATYPE( DTC::BackendInfo* )
-
-namespace DTC
-{
-inline void BackendInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< BackendInfo  >();
-    qRegisterMetaType< BackendInfo* >();
-
-    BuildInfo::InitializeCustomTypes();
-    EnvInfo  ::InitializeCustomTypes();
-    LogInfo  ::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/blurayInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/blurayInfo.h
@@ -70,10 +70,6 @@ class SERVICE_PUBLIC BlurayInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         BlurayInfo(QObject *parent = 0)
                  : QObject                ( parent    ),
                    m_Path                 ( QString() ),
@@ -99,48 +95,34 @@ class SERVICE_PUBLIC BlurayInfo : public QObject
         {
         }
 
-        BlurayInfo( const BlurayInfo &src )
+        void Copy( const BlurayInfo *src )
         {
-            Copy( src );
+            m_Path                 = src->m_Path                 ;
+            m_Title                = src->m_Title                ;
+            m_AltTitle             = src->m_AltTitle             ;
+            m_DiscLang             = src->m_DiscLang             ;
+            m_DiscNum              = src->m_DiscNum              ;
+            m_TotalDiscNum         = src->m_TotalDiscNum         ;
+            m_TitleCount           = src->m_TitleCount           ;
+            m_ThumbCount           = src->m_ThumbCount           ;
+            m_ThumbPath            = src->m_ThumbPath            ;
+            m_TopMenuSupported     = src->m_TopMenuSupported     ;
+            m_FirstPlaySupported   = src->m_FirstPlaySupported   ;
+            m_NumHDMVTitles        = src->m_NumHDMVTitles        ;
+            m_NumBDJTitles         = src->m_NumBDJTitles         ;
+            m_NumUnsupportedTitles = src->m_NumUnsupportedTitles ;
+            m_AACSDetected         = src->m_AACSDetected         ;
+            m_LibAACSDetected      = src->m_LibAACSDetected      ;
+            m_AACSHandled          = src->m_AACSHandled          ;
+            m_BDPlusDetected       = src->m_BDPlusDetected       ;
+            m_LibBDPlusDetected    = src->m_LibBDPlusDetected    ;
+            m_BDPlusHandled        = src->m_BDPlusHandled        ;
         }
 
-        void Copy( const BlurayInfo &src )
-        {
-            m_Path                 = src.m_Path                 ;
-            m_Title                = src.m_Title                ;
-            m_AltTitle             = src.m_AltTitle             ;
-            m_DiscLang             = src.m_DiscLang             ;
-            m_DiscNum              = src.m_DiscNum              ;
-            m_TotalDiscNum         = src.m_TotalDiscNum         ;
-            m_TitleCount           = src.m_TitleCount           ;
-            m_ThumbCount           = src.m_ThumbCount           ;
-            m_ThumbPath            = src.m_ThumbPath            ;
-            m_TopMenuSupported     = src.m_TopMenuSupported     ;
-            m_FirstPlaySupported   = src.m_FirstPlaySupported   ;
-            m_NumHDMVTitles        = src.m_NumHDMVTitles        ;
-            m_NumBDJTitles         = src.m_NumBDJTitles         ;
-            m_NumUnsupportedTitles = src.m_NumUnsupportedTitles ;
-            m_AACSDetected         = src.m_AACSDetected         ;
-            m_LibAACSDetected      = src.m_LibAACSDetected      ;
-            m_AACSHandled          = src.m_AACSHandled          ;
-            m_BDPlusDetected       = src.m_BDPlusDetected       ;
-            m_LibBDPlusDetected    = src.m_LibBDPlusDetected    ;
-            m_BDPlusHandled        = src.m_BDPlusHandled        ;
-        }
+    private:
+        Q_DISABLE_COPY(BlurayInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::BlurayInfo  )
-Q_DECLARE_METATYPE( DTC::BlurayInfo* )
-
-namespace DTC
-{
-inline void BlurayInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< BlurayInfo  >();
-    qRegisterMetaType< BlurayInfo* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/buildInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/buildInfo.h
@@ -35,10 +35,6 @@ class SERVICE_PUBLIC BuildInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         BuildInfo(QObject *parent = 0)
             : QObject    ( parent ),
               m_Version  ( ""     ),
@@ -47,33 +43,19 @@ class SERVICE_PUBLIC BuildInfo : public QObject
         {
         }
 
-        BuildInfo( const BuildInfo &src )
+        void Copy( const BuildInfo *src )
         {
-            Copy( src );
+            m_Version   = src->m_Version  ;
+            m_LibX264   = src->m_LibX264  ;
+            m_LibDNS_SD = src->m_LibDNS_SD;
         }
 
-        void Copy( const BuildInfo &src )
-        {
-            m_Version   = src.m_Version  ;
-            m_LibX264   = src.m_LibX264  ;
-            m_LibDNS_SD = src.m_LibDNS_SD;
-        }
+    private:
+        Q_DISABLE_COPY(BuildInfo);
 };
 
 typedef BuildInfo* BuildInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::BuildInfo  )
-Q_DECLARE_METATYPE( DTC::BuildInfo* )
-
-namespace DTC
-{
-inline void BuildInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< BuildInfo  >();
-    qRegisterMetaType< BuildInfo* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/captureCard.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/captureCard.h
@@ -80,10 +80,6 @@ class SERVICE_PUBLIC CaptureCard : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         CaptureCard(QObject *parent = 0)
             : QObject         ( parent ), m_CardId(0),
             m_AudioRateLimit(0), m_DVBSWFilter(0),
@@ -97,52 +93,38 @@ class SERVICE_PUBLIC CaptureCard : public QObject
         {
         }
 
-        CaptureCard( const CaptureCard &src )
+        void Copy( const CaptureCard *src )
         {
-            Copy( src );
+            m_CardId             = src->m_CardId;
+            m_VideoDevice        = src->m_VideoDevice;
+            m_AudioDevice        = src->m_AudioDevice;
+            m_CardType           = src->m_CardType;
+            m_AudioRateLimit     = src->m_AudioRateLimit;
+            m_HostName           = src->m_HostName;
+            m_DVBSWFilter        = src->m_DVBSWFilter;
+            m_DVBSatType         = src->m_DVBSatType;
+            m_DVBWaitForSeqStart = src->m_DVBWaitForSeqStart;
+            m_SkipBTAudio        = src->m_SkipBTAudio;
+            m_DVBOnDemand        = src->m_DVBOnDemand;
+            m_DVBDiSEqCType      = src->m_DVBDiSEqCType;
+            m_FirewireSpeed      = src->m_FirewireSpeed;
+            m_FirewireModel      = src->m_FirewireModel;
+            m_FirewireConnection = src->m_FirewireConnection;
+            m_SignalTimeout      = src->m_SignalTimeout;
+            m_ChannelTimeout     = src->m_ChannelTimeout;
+            m_DVBTuningDelay     = src->m_DVBTuningDelay;
+            m_Contrast           = src->m_Contrast;
+            m_Brightness         = src->m_Brightness;
+            m_Colour             = src->m_Colour;
+            m_Hue                = src->m_Hue;
+            m_DiSEqCId           = src->m_DiSEqCId;
+            m_DVBEITScan         = src->m_DVBEITScan;
         }
 
-        void Copy( const CaptureCard &src )
-        {
-            m_CardId             = src.m_CardId;
-            m_VideoDevice        = src.m_VideoDevice;
-            m_AudioDevice        = src.m_AudioDevice;
-            m_CardType           = src.m_CardType;
-            m_AudioRateLimit     = src.m_AudioRateLimit;
-            m_HostName           = src.m_HostName;
-            m_DVBSWFilter        = src.m_DVBSWFilter;
-            m_DVBSatType         = src.m_DVBSatType;
-            m_DVBWaitForSeqStart = src.m_DVBWaitForSeqStart;
-            m_SkipBTAudio        = src.m_SkipBTAudio;
-            m_DVBOnDemand        = src.m_DVBOnDemand;
-            m_DVBDiSEqCType      = src.m_DVBDiSEqCType;
-            m_FirewireSpeed      = src.m_FirewireSpeed;
-            m_FirewireModel      = src.m_FirewireModel;
-            m_FirewireConnection = src.m_FirewireConnection;
-            m_SignalTimeout      = src.m_SignalTimeout;
-            m_ChannelTimeout     = src.m_ChannelTimeout;
-            m_DVBTuningDelay     = src.m_DVBTuningDelay;
-            m_Contrast           = src.m_Contrast;
-            m_Brightness         = src.m_Brightness;
-            m_Colour             = src.m_Colour;
-            m_Hue                = src.m_Hue;
-            m_DiSEqCId           = src.m_DiSEqCId;
-            m_DVBEITScan         = src.m_DVBEITScan;
-        }
+    private:
+        Q_DISABLE_COPY(CaptureCard);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::CaptureCard  )
-Q_DECLARE_METATYPE( DTC::CaptureCard* )
-
-namespace DTC
-{
-inline void CaptureCard::InitializeCustomTypes()
-{
-    qRegisterMetaType< CaptureCard  >();
-    qRegisterMetaType< CaptureCard* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/captureCardList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/captureCardList.h
@@ -37,23 +37,14 @@ class SERVICE_PUBLIC CaptureCardList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         CaptureCardList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        CaptureCardList( const CaptureCardList &src )
+        void Copy( const CaptureCardList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const CaptureCardList &src )
-        {
-            CopyListContents< CaptureCard >( this, m_CaptureCards, src.m_CaptureCards );
+            CopyListContents< CaptureCard >( this, m_CaptureCards, src->m_CaptureCards );
         }
 
         CaptureCard *AddNewCaptureCard()
@@ -67,22 +58,10 @@ class SERVICE_PUBLIC CaptureCardList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(CaptureCardList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::CaptureCardList  )
-Q_DECLARE_METATYPE( DTC::CaptureCardList* )
-
-namespace DTC
-{
-inline void CaptureCardList::InitializeCustomTypes()
-{
-    qRegisterMetaType< CaptureCardList  >();
-    qRegisterMetaType< CaptureCardList* >();
-
-    CaptureCard::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/castMember.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/castMember.h
@@ -40,40 +40,23 @@ class SERVICE_PUBLIC CastMember : public QObject
 
     public:
 
-        static void InitializeCustomTypes();
-
         CastMember(QObject *parent = 0)
             : QObject           ( parent )
         {
         }
 
-        CastMember( const CastMember &src )
+        void Copy( const CastMember *src )
         {
-            Copy( src );
+            m_Name           = src->m_Name          ;
+            m_CharacterName  = src->m_CharacterName ;
+            m_Role           = src->m_Role          ;
+            m_TranslatedRole = src->m_TranslatedRole;
         }
 
-        void Copy( const CastMember &src )
-        {
-            m_Name           = src.m_Name          ;
-            m_CharacterName  = src.m_CharacterName ;
-            m_Role           = src.m_Role          ;
-            m_TranslatedRole = src.m_TranslatedRole;
-        }
-
+    private:
+        Q_DISABLE_COPY(CastMember);
 };
 
-}
-
-Q_DECLARE_METATYPE( DTC::CastMember  )
-Q_DECLARE_METATYPE( DTC::CastMember* )
-
-namespace DTC
-{
-inline void CastMember::InitializeCustomTypes()
-{
-    qRegisterMetaType< CastMember   >();
-    qRegisterMetaType< CastMember*  >();
-}
 }
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/castMemberList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/castMemberList.h
@@ -29,21 +29,14 @@ class SERVICE_PUBLIC CastMemberList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
         CastMemberList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        CastMemberList( const CastMemberList &src )
+        void Copy( const CastMemberList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const CastMemberList &src )
-        {
-            CopyListContents< CastMember >( this, m_CastMembers, src.m_CastMembers );
+            CopyListContents< CastMember >( this, m_CastMembers, src->m_CastMembers );
         }
 
         CastMember *AddNewCastMember()
@@ -57,22 +50,10 @@ class SERVICE_PUBLIC CastMemberList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(CastMemberList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::CastMemberList  )
-Q_DECLARE_METATYPE( DTC::CastMemberList* )
-
-namespace DTC
-{
-inline void CastMemberList::InitializeCustomTypes()
-{
-    qRegisterMetaType< CastMemberList   >();
-    qRegisterMetaType< CastMemberList*  >();
-
-    CastMember::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/channelGroup.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/channelGroup.h
@@ -38,40 +38,23 @@ class SERVICE_PUBLIC ChannelGroup : public QObject
 
     public:
 
-        static void InitializeCustomTypes();
-
         ChannelGroup(QObject *parent = 0)
             : QObject           ( parent ),
               m_GroupId         ( 0      )
         {
         }
 
-        ChannelGroup( const ChannelGroup &src )
+        void Copy( const ChannelGroup *src )
         {
-            Copy( src );
+            m_GroupId      = src->m_GroupId     ;
+            m_Name         = src->m_Name        ;
+            m_Password     = src->m_Password    ;
         }
 
-        void Copy( const ChannelGroup &src )
-        {
-            m_GroupId      = src.m_GroupId     ;
-            m_Name         = src.m_Name        ;
-            m_Password     = src.m_Password    ;
-        }
-
+    private:
+        Q_DISABLE_COPY(ChannelGroup);
 };
 
-}
-
-Q_DECLARE_METATYPE( DTC::ChannelGroup  )
-Q_DECLARE_METATYPE( DTC::ChannelGroup* )
-
-namespace DTC
-{
-inline void ChannelGroup::InitializeCustomTypes()
-{
-    qRegisterMetaType< ChannelGroup   >();
-    qRegisterMetaType< ChannelGroup*  >();
-}
 }
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/channelGroupList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/channelGroupList.h
@@ -29,21 +29,14 @@ class SERVICE_PUBLIC ChannelGroupList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
         ChannelGroupList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        ChannelGroupList( const ChannelGroupList &src )
+        void Copy( const ChannelGroupList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const ChannelGroupList &src )
-        {
-            CopyListContents< ChannelGroup >( this, m_ChannelGroups, src.m_ChannelGroups );
+            CopyListContents< ChannelGroup >( this, m_ChannelGroups, src->m_ChannelGroups );
         }
 
         ChannelGroup *AddNewChannelGroup()
@@ -57,22 +50,10 @@ class SERVICE_PUBLIC ChannelGroupList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(ChannelGroupList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ChannelGroupList  )
-Q_DECLARE_METATYPE( DTC::ChannelGroupList* )
-
-namespace DTC
-{
-inline void ChannelGroupList::InitializeCustomTypes()
-{
-    qRegisterMetaType< ChannelGroupList   >();
-    qRegisterMetaType< ChannelGroupList*  >();
-
-    ChannelGroup::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/channelInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/channelInfoList.h
@@ -46,10 +46,6 @@ class SERVICE_PUBLIC ChannelInfoList : public QObject
 
     public:
 
-        static void InitializeCustomTypes();
-
-    public:
-
         ChannelInfoList(QObject *parent = 0)
             : QObject( parent ),
               m_StartIndex    ( 0      ),
@@ -60,21 +56,16 @@ class SERVICE_PUBLIC ChannelInfoList : public QObject
         {
         }
 
-        ChannelInfoList( const ChannelInfoList &src )
+        void Copy( const ChannelInfoList *src )
         {
-            Copy( src );
-        }
+            m_StartIndex    = src->m_StartIndex     ;
+            m_Count         = src->m_Count          ;
+            m_TotalAvailable= src->m_TotalAvailable ;
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const ChannelInfoList &src )
-        {
-            m_StartIndex    = src.m_StartIndex     ;
-            m_Count         = src.m_Count          ;
-            m_TotalAvailable= src.m_TotalAvailable ;
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< ChannelInfo >( this, m_ChannelInfos, src.m_ChannelInfos );
+            CopyListContents< ChannelInfo >( this, m_ChannelInfos, src->m_ChannelInfos );
         }
 
         ChannelInfo *AddNewChannelInfo()
@@ -88,22 +79,10 @@ class SERVICE_PUBLIC ChannelInfoList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(ChannelInfoList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ChannelInfoList  )
-Q_DECLARE_METATYPE( DTC::ChannelInfoList* )
-
-namespace DTC
-{
-inline void ChannelInfoList::InitializeCustomTypes()
-{
-    qRegisterMetaType< ChannelInfoList   >();
-    qRegisterMetaType< ChannelInfoList*  >();
-
-    ChannelInfo::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/connectionInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/connectionInfo.h
@@ -37,10 +37,6 @@ class SERVICE_PUBLIC ConnectionInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ConnectionInfo(QObject *parent = 0) 
             : QObject        ( parent ),
               m_Version      ( NULL   ),
@@ -48,49 +44,28 @@ class SERVICE_PUBLIC ConnectionInfo : public QObject
               m_WOL          ( NULL   )             
         {
         }
-        
-        ConnectionInfo( const ConnectionInfo &src ) 
-            : m_Version   ( NULL ),
-              m_Database  ( NULL ),
-              m_WOL       ( NULL )                  
-        {
-            Copy( src );
-        }
 
-        void Copy( const ConnectionInfo &src ) 
+        void Copy( const ConnectionInfo *src )
         {
             // We always need to make sure the child object is
             // created with the correct parent *
 
-            if (src.m_Version)
-                Version()->Copy( src.m_Version );
+            if (src->m_Version)
+                Version()->Copy( src->m_Version );
 
-            if (src.m_Database)
-                Database()->Copy( src.m_Database );
+            if (src->m_Database)
+                Database()->Copy( src->m_Database );
 
-            if (src.m_WOL)
-                WOL     ()->Copy( src.m_WOL      );
+            if (src->m_WOL)
+                WOL     ()->Copy( src->m_WOL      );
         }
+
+    private:
+        Q_DISABLE_COPY(ConnectionInfo);
 };
 
 typedef ConnectionInfo* ConnectionInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ConnectionInfo  )
-Q_DECLARE_METATYPE( DTC::ConnectionInfo* )
-
-namespace DTC
-{
-inline void ConnectionInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< ConnectionInfo   >();
-    qRegisterMetaType< ConnectionInfo*  >();
-
-    VersionInfo ::InitializeCustomTypes();
-    DatabaseInfo::InitializeCustomTypes();
-    WOLInfo     ::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/cutList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/cutList.h
@@ -38,23 +38,14 @@ class SERVICE_PUBLIC CutList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         CutList(QObject *parent = 0)
             : QObject         ( parent )
         {
         }
 
-        CutList( const CutList &src )
+        void Copy( const CutList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const CutList &src )
-        {
-            CopyListContents< Cutting >( this, m_Cuttings, src.m_Cuttings );
+            CopyListContents< Cutting >( this, m_Cuttings, src->m_Cuttings );
         }
 
         Cutting *AddNewCutting()
@@ -68,22 +59,10 @@ class SERVICE_PUBLIC CutList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(CutList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::CutList  )
-Q_DECLARE_METATYPE( DTC::CutList* )
-
-namespace DTC
-{
-inline void CutList::InitializeCustomTypes()
-{
-    qRegisterMetaType< CutList  >();
-    qRegisterMetaType< CutList* >();
-
-    Cutting::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/cutting.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/cutting.h
@@ -33,39 +33,21 @@ class SERVICE_PUBLIC Cutting : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         Cutting(QObject *parent = 0)
             : QObject( parent ), m_Mark(0), m_Offset(0)
         {
         }
 
-        Cutting( const Cutting &src )
+        void Copy( const Cutting *src )
         {
-            Copy( src );
+            m_Mark          = src->m_Mark   ;
+            m_Offset        = src->m_Offset ;
         }
 
-        void Copy( const Cutting &src )
-        {
-            m_Mark          = src.m_Mark   ;
-            m_Offset        = src.m_Offset ;
-        }
+    private:
+        Q_DISABLE_COPY(Cutting);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::Cutting  )
-Q_DECLARE_METATYPE( DTC::Cutting* )
-
-namespace DTC
-{
-inline void Cutting::InitializeCustomTypes()
-{
-    qRegisterMetaType< Cutting  >();
-    qRegisterMetaType< Cutting* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/databaseInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/databaseInfo.h
@@ -46,10 +46,6 @@ class SERVICE_PUBLIC DatabaseInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         DatabaseInfo(QObject *parent = 0) 
             : QObject       ( parent ),
               m_Ping        ( false  ),
@@ -57,40 +53,26 @@ class SERVICE_PUBLIC DatabaseInfo : public QObject
               m_LocalEnabled( false  ) 
         {
         }
-        
-        DatabaseInfo( const DatabaseInfo &src ) 
+
+        void Copy( const DatabaseInfo *src )
         {
-            Copy( src );
+            m_Host         = src->m_Host         ;
+            m_Ping         = src->m_Ping         ;
+            m_Port         = src->m_Port         ;
+            m_UserName     = src->m_UserName     ;
+            m_Password     = src->m_Password     ;
+            m_Name         = src->m_Name         ;
+            m_Type         = src->m_Type         ;
+            m_LocalEnabled = src->m_LocalEnabled ;
+            m_LocalHostName= src->m_LocalHostName;
         }
 
-        void Copy( const DatabaseInfo &src ) 
-        {
-            m_Host         = src.m_Host         ;
-            m_Ping         = src.m_Ping         ;
-            m_Port         = src.m_Port         ;
-            m_UserName     = src.m_UserName     ;
-            m_Password     = src.m_Password     ;
-            m_Name         = src.m_Name         ;
-            m_Type         = src.m_Type         ;
-            m_LocalEnabled = src.m_LocalEnabled ;
-            m_LocalHostName= src.m_LocalHostName;
-        }
+    private:
+        Q_DISABLE_COPY(DatabaseInfo);
 };
 
 typedef DatabaseInfo * DatabaseInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::DatabaseInfo  )
-Q_DECLARE_METATYPE( DTC::DatabaseInfo* )
-
-namespace DTC
-{
-inline void DatabaseInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< DatabaseInfo   >();
-    qRegisterMetaType< DatabaseInfo*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/encoder.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/encoder.h
@@ -56,10 +56,6 @@ class SERVICE_PUBLIC Encoder : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         Encoder(QObject *parent = 0) 
             : QObject         ( parent ),
               m_Id            ( 0      ),
@@ -71,27 +67,22 @@ class SERVICE_PUBLIC Encoder : public QObject
               m_Recording     ( NULL   )  
         { 
         }
-        
-        Encoder( const Encoder &src )
-        {
-            Copy( src );
-        }
 
-        void Copy( const Encoder &src )
+        void Copy( const Encoder *src )
         {
-            m_Id            = src.m_Id            ;
-            m_HostName      = src.m_HostName      ;
-            m_Local         = src.m_Local         ;
-            m_Connected     = src.m_Connected     ;
-            m_State         = src.m_State         ;
-            m_SleepStatus   = src.m_SleepStatus   ;
-            m_LowOnFreeSpace= src.m_LowOnFreeSpace;
+            m_Id            = src->m_Id            ;
+            m_HostName      = src->m_HostName      ;
+            m_Local         = src->m_Local         ;
+            m_Connected     = src->m_Connected     ;
+            m_State         = src->m_State         ;
+            m_SleepStatus   = src->m_SleepStatus   ;
+            m_LowOnFreeSpace= src->m_LowOnFreeSpace;
             m_Recording     = NULL                ;
         
-            if ( src.m_Recording != NULL)
-                Recording()->Copy( *(src.m_Recording) );
+            if ( src->m_Recording != NULL)
+                Recording()->Copy( src->m_Recording );
 
-            CopyListContents< Input >( this, m_Inputs, src.m_Inputs );
+            CopyListContents< Input >( this, m_Inputs, src->m_Inputs );
         }
 
         Input *AddNewInput()
@@ -105,23 +96,10 @@ class SERVICE_PUBLIC Encoder : public QObject
             return pObject;
         }
 
-
+    private:
+        Q_DISABLE_COPY(Encoder);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::Encoder  )
-Q_DECLARE_METATYPE( DTC::Encoder* )
-
-namespace DTC
-{
-inline void Encoder::InitializeCustomTypes()
-{
-    qRegisterMetaType< Encoder  >();
-    qRegisterMetaType< Encoder* >();
-
-    Program::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/encoderList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/encoderList.h
@@ -37,23 +37,14 @@ class SERVICE_PUBLIC EncoderList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         EncoderList(QObject *parent = 0) 
             : QObject( parent )               
         {
         }
-        
-        EncoderList( const EncoderList &src ) 
-        {
-            Copy( src );
-        }
 
-        void Copy( const EncoderList &src )
+        void Copy( const EncoderList *src )
         {
-            CopyListContents< Encoder >( this, m_Encoders, src.m_Encoders );
+            CopyListContents< Encoder >( this, m_Encoders, src->m_Encoders );
         }
 
         Encoder *AddNewEncoder()
@@ -67,22 +58,10 @@ class SERVICE_PUBLIC EncoderList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(EncoderList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::EncoderList  )
-Q_DECLARE_METATYPE( DTC::EncoderList* )
-
-namespace DTC
-{
-inline void EncoderList::InitializeCustomTypes()
-{
-    qRegisterMetaType< EncoderList  >();
-    qRegisterMetaType< EncoderList* >();
-
-    Encoder::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/enum.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/enum.h
@@ -40,25 +40,16 @@ class SERVICE_PUBLIC Enum : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         explicit Enum(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        Enum( const Enum &src )
+        void Copy( const Enum *src )
         {
-            Copy( src );
-        }
+            m_Type = src->m_Type;
 
-        void Copy( const Enum &src )
-        {
-            m_Type = src.m_Type;
-
-            CopyListContents< EnumItem >( this, m_EnumItems, src.m_EnumItems );
+            CopyListContents< EnumItem >( this, m_EnumItems, src->m_EnumItems );
         }
 
         EnumItem *AddNewEnum()
@@ -72,22 +63,10 @@ class SERVICE_PUBLIC Enum : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(Enum);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::Enum  )
-Q_DECLARE_METATYPE( DTC::Enum* )
-
-namespace DTC
-{
-inline void Enum::InitializeCustomTypes()
-{
-    qRegisterMetaType< Enum  >();
-    qRegisterMetaType< Enum* >();
-
-    EnumItem::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/enumItem.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/enumItem.h
@@ -32,43 +32,23 @@ class SERVICE_PUBLIC EnumItem : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         explicit EnumItem( QObject *parent = 0)
           : QObject ( parent ),
             m_Value ( 0      )
         {
         }
 
-        EnumItem( const EnumItem &src )
+        void Copy( const EnumItem *src )
         {
-            Copy( src );
+            m_Key           = src->m_Key  ;
+            m_Value         = src->m_Value;
+            m_Desc          = src->m_Desc ;
         }
 
-        void Copy( const EnumItem &src )
-        {
-            m_Key           = src.m_Key  ;
-            m_Value         = src.m_Value;
-            m_Desc          = src.m_Desc ;
-        }
+    private:
+        Q_DISABLE_COPY(EnumItem);
 };
 
 }  // namespace
-
-Q_DECLARE_METATYPE( DTC::EnumItem  )
-Q_DECLARE_METATYPE( DTC::EnumItem* )
-
-namespace DTC
-{
-inline void EnumItem::InitializeCustomTypes()
-{
-    qRegisterMetaType< EnumItem  >();
-    qRegisterMetaType< EnumItem* >();
-}
-}  // namespace
-
-
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/envInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/envInfo.h
@@ -39,10 +39,6 @@ class SERVICE_PUBLIC EnvInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         EnvInfo(QObject *parent = 0)
             : QObject       ( parent ),
               m_LANG        ( ""     ),
@@ -53,35 +49,21 @@ class SERVICE_PUBLIC EnvInfo : public QObject
         {
         }
 
-        EnvInfo( const EnvInfo &src )
+        void Copy( const EnvInfo *src )
         {
-            Copy( src );
+            m_LANG        = src->m_LANG;
+            m_LCALL       = src->m_LCALL;
+            m_LCCTYPE     = src->m_LCCTYPE;
+            m_HOME        = src->m_HOME;
+            m_MYTHCONFDIR = src->m_MYTHCONFDIR;
         }
 
-        void Copy( const EnvInfo &src )
-        {
-            m_LANG        = src.m_LANG;
-            m_LCALL       = src.m_LCALL;
-            m_LCCTYPE     = src.m_LCCTYPE;
-            m_HOME        = src.m_HOME;
-            m_MYTHCONFDIR = src.m_MYTHCONFDIR;
-        }
+    private:
+        Q_DISABLE_COPY(EnvInfo);
 };
 
 typedef EnvInfo* EnvInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::EnvInfo  )
-Q_DECLARE_METATYPE( DTC::EnvInfo* )
-
-namespace DTC
-{
-inline void EnvInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< EnvInfo  >();
-    qRegisterMetaType< EnvInfo* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/frontend.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/frontend.h
@@ -37,9 +37,6 @@ class SERVICE_PUBLIC Frontend : public QObject
     PROPERTYIMP    ( bool       , OnLine          )
 
     public:
-        static inline void InitializeCustomTypes();
-
-    public:
 
         Frontend(QObject *parent = 0)
             : QObject         ( parent ),
@@ -47,32 +44,18 @@ class SERVICE_PUBLIC Frontend : public QObject
         {
         }
 
-        Frontend( const Frontend &src )
+        void Copy( const Frontend *src )
         {
-            Copy( src );
+            m_Name            = src->m_Name;
+            m_IP              = src->m_IP;
+            m_Port            = src->m_Port;
+            m_OnLine          = src->m_OnLine;
         }
 
-        void Copy( const Frontend &src )
-        {
-            m_Name            = src.m_Name;
-            m_IP              = src.m_IP;
-            m_Port            = src.m_Port;
-            m_OnLine          = src.m_OnLine;
-        }
+    private:
+        Q_DISABLE_COPY(Frontend);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::Frontend  )
-Q_DECLARE_METATYPE( DTC::Frontend* )
-
-namespace DTC
-{
-inline void Frontend::InitializeCustomTypes()
-{
-    qRegisterMetaType< Frontend  >();
-    qRegisterMetaType< Frontend* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/frontendActionList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/frontendActionList.h
@@ -18,35 +18,18 @@ namespace DTC
         PROPERTYIMP_RO_REF(QVariantMap, ActionList);
 
       public:
-        static inline void InitializeCustomTypes();
-
-      public:
         explicit FrontendActionList(QObject *parent = 0) : QObject(parent)
         {
         }
 
-        FrontendActionList(const FrontendActionList &src)
+        void Copy( const FrontendActionList *src)
         {
-            Copy(src);
+            m_ActionList = src->m_ActionList;
         }
 
-        void Copy(const FrontendActionList &src)
-        {
-            m_ActionList = src.m_ActionList;
-        }
+        private:
+        Q_DISABLE_COPY(FrontendActionList);
     };
 };
-
-Q_DECLARE_METATYPE(DTC::FrontendActionList)
-Q_DECLARE_METATYPE(DTC::FrontendActionList*)
-
-namespace DTC
-{
-inline void FrontendActionList::InitializeCustomTypes()
-{
-    qRegisterMetaType<FrontendActionList>();
-    qRegisterMetaType<FrontendActionList*>();
-}
-}
 
 #endif // FRONTENDACTIONLIST_H

--- a/mythtv/libs/libmythservicecontracts/datacontracts/frontendList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/frontendList.h
@@ -37,23 +37,14 @@ class SERVICE_PUBLIC FrontendList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         FrontendList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        FrontendList( const FrontendList &src )
+        void Copy( const FrontendList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const FrontendList &src )
-        {
-            CopyListContents< Frontend >( this, m_Frontends, src.m_Frontends );
+            CopyListContents< Frontend >( this, m_Frontends, src->m_Frontends );
         }
 
         Frontend *AddNewFrontend()
@@ -67,22 +58,10 @@ class SERVICE_PUBLIC FrontendList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(FrontendList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::FrontendList  )
-Q_DECLARE_METATYPE( DTC::FrontendList* )
-
-namespace DTC
-{
-inline void FrontendList::InitializeCustomTypes()
-{
-    qRegisterMetaType< FrontendList  >();
-    qRegisterMetaType< FrontendList* >();
-
-    Frontend::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/frontendStatus.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/frontendStatus.h
@@ -31,26 +31,18 @@ namespace DTC
         PROPERTYIMP_RO_REF(QVariantMap, AudioTracks)
 
       public:
-        static inline void InitializeCustomTypes();
-
-      public:
         explicit FrontendStatus(QObject *parent = 0) : QObject(parent)
         {
         }
 
-        FrontendStatus(const FrontendStatus &src)
+        void Copy( const FrontendStatus *src)
         {
-            Copy(src);
-        }
-
-        void Copy(const FrontendStatus &src)
-        {
-            m_Name           = src.m_Name;
-            m_Version        = src.m_Version;
-            m_State          = src.m_State;
-            m_ChapterTimes   = src.m_ChapterTimes;
-            m_SubtitleTracks = src.m_SubtitleTracks;
-            m_AudioTracks    = src.m_AudioTracks;
+            m_Name           = src->m_Name;
+            m_Version        = src->m_Version;
+            m_State          = src->m_State;
+            m_ChapterTimes   = src->m_ChapterTimes;
+            m_SubtitleTracks = src->m_SubtitleTracks;
+            m_AudioTracks    = src->m_AudioTracks;
         }
 
         void Process(void)
@@ -76,19 +68,10 @@ namespace DTC
                 m_State.remove("audiotracks");
             }
         }
+
+    private:
+        Q_DISABLE_COPY(FrontendStatus);
     };
 };
-
-Q_DECLARE_METATYPE(DTC::FrontendStatus)
-Q_DECLARE_METATYPE(DTC::FrontendStatus*)
-
-namespace DTC
-{
-inline void FrontendStatus::InitializeCustomTypes()
-{
-    qRegisterMetaType<FrontendStatus>();
-    qRegisterMetaType<FrontendStatus*>();
-}
-}
 
 #endif // FRONTENDSTATUS_H

--- a/mythtv/libs/libmythservicecontracts/datacontracts/genre.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/genre.h
@@ -32,38 +32,20 @@ class SERVICE_PUBLIC Genre : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         Genre(QObject *parent = 0)
             : QObject         ( parent )
         {
         }
 
-        Genre( const Genre &src )
+        void Copy( const Genre *src )
         {
-            Copy( src );
+            m_Name          = src->m_Name          ;
         }
 
-        void Copy( const Genre &src )
-        {
-            m_Name          = src.m_Name          ;
-        }
+    private:
+        Q_DISABLE_COPY(Genre);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::Genre  )
-Q_DECLARE_METATYPE( DTC::Genre* )
-
-namespace DTC
-{
-inline void Genre::InitializeCustomTypes()
-{
-    qRegisterMetaType< Genre  >();
-    qRegisterMetaType< Genre* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/genreList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/genreList.h
@@ -38,23 +38,14 @@ class SERVICE_PUBLIC GenreList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         GenreList(QObject *parent = 0)
             : QObject         ( parent )
         {
         }
 
-        GenreList( const GenreList &src )
+        void Copy( const GenreList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const GenreList &src )
-        {
-            CopyListContents< Genre >( this, m_Genres, src.m_Genres );
+            CopyListContents< Genre >( this, m_Genres, src->m_Genres );
         }
 
         Genre *AddNewGenre()
@@ -68,22 +59,10 @@ class SERVICE_PUBLIC GenreList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(GenreList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::GenreList  )
-Q_DECLARE_METATYPE( DTC::GenreList* )
-
-namespace DTC
-{
-inline void GenreList::InitializeCustomTypes()
-{
-    qRegisterMetaType< GenreList  >();
-    qRegisterMetaType< GenreList* >();
-
-    Genre::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/imageMetadataInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/imageMetadataInfo.h
@@ -28,42 +28,24 @@ class SERVICE_PUBLIC ImageMetadataInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ImageMetadataInfo(QObject *parent = 0)
                         : QObject         ( parent ),
                           m_Number        ( 0      )
         {
         }
 
-        ImageMetadataInfo( const ImageMetadataInfo &src )
+        void Copy( const ImageMetadataInfo *src )
         {
-            Copy( src );
+            m_Number    = src->m_Number;
+            m_Tag       = src->m_Tag;
+            m_Label     = src->m_Label;
+            m_Value     = src->m_Value;
         }
 
-        void Copy( const ImageMetadataInfo &src )
-        {
-            m_Number    = src.m_Number;
-            m_Tag       = src.m_Tag;
-            m_Label     = src.m_Label;
-            m_Value     = src.m_Value;
-        }
+    private:
+        Q_DISABLE_COPY(ImageMetadataInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ImageMetadataInfo  )
-Q_DECLARE_METATYPE( DTC::ImageMetadataInfo* )
-
-namespace DTC
-{
-inline void ImageMetadataInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< ImageMetadataInfo  >();
-    qRegisterMetaType< ImageMetadataInfo* >();
-}
-}
 
 #endif // IMAGEMETADATAINFO_H

--- a/mythtv/libs/libmythservicecontracts/datacontracts/imageMetadataInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/imageMetadataInfoList.h
@@ -38,10 +38,6 @@ class SERVICE_PUBLIC ImageMetadataInfoList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ImageMetadataInfoList(QObject *parent = 0)
             : QObject( parent ),
               m_Count         ( 0      ),
@@ -49,20 +45,15 @@ class SERVICE_PUBLIC ImageMetadataInfoList : public QObject
         {
         }
 
-        ImageMetadataInfoList( const ImageMetadataInfoList &src )
+        void Copy( const ImageMetadataInfoList *src )
         {
-            Copy( src );
-        }
+            m_Count         = src->m_Count;
+            m_File          = src->m_File;
+            m_Path          = src->m_Path;
+            m_Size          = src->m_Size;
+            m_Extension     = src->m_Extension;
 
-        void Copy( const ImageMetadataInfoList &src )
-        {
-            m_Count         = src.m_Count;
-            m_File          = src.m_File;
-            m_Path          = src.m_Path;
-            m_Size          = src.m_Size;
-            m_Extension     = src.m_Extension;
-
-            CopyListContents< ImageMetadataInfo >( this, m_ImageMetadataInfos, src.m_ImageMetadataInfos );
+            CopyListContents< ImageMetadataInfo >( this, m_ImageMetadataInfos, src->m_ImageMetadataInfos );
         }
 
         ImageMetadataInfo *AddNewImageMetadataInfo()
@@ -75,22 +66,10 @@ class SERVICE_PUBLIC ImageMetadataInfoList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(ImageMetadataInfoList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ImageMetadataInfoList  )
-Q_DECLARE_METATYPE( DTC::ImageMetadataInfoList* )
-
-namespace DTC
-{
-inline void ImageMetadataInfoList::InitializeCustomTypes()
-{
-    qRegisterMetaType< ImageMetadataInfoList  >();
-    qRegisterMetaType< ImageMetadataInfoList* >();
-
-    ImageMetadataInfo::InitializeCustomTypes();
-}
-}
 
 #endif // IMAGEMETADATAINFOLIST_H

--- a/mythtv/libs/libmythservicecontracts/datacontracts/imageSyncInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/imageSyncInfo.h
@@ -26,10 +26,6 @@ class SERVICE_PUBLIC ImageSyncInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ImageSyncInfo(QObject *parent = 0)
                         : QObject         ( parent ),
                           m_Running       ( false  ),
@@ -38,31 +34,17 @@ class SERVICE_PUBLIC ImageSyncInfo : public QObject
         {
         }
 
-        ImageSyncInfo( const ImageSyncInfo &src )
+        void Copy( const ImageSyncInfo *src )
         {
-            Copy( src );
+            m_Running       = src->m_Running;
+            m_Current       = src->m_Current;
+            m_Total         = src->m_Total;
         }
 
-        void Copy( const ImageSyncInfo &src )
-        {
-            m_Running       = src.m_Running;
-            m_Current       = src.m_Current;
-            m_Total         = src.m_Total;
-        }
+    private:
+        Q_DISABLE_COPY(ImageSyncInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ImageSyncInfo  )
-Q_DECLARE_METATYPE( DTC::ImageSyncInfo* )
-
-namespace DTC
-{
-inline void ImageSyncInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< ImageSyncInfo  >();
-    qRegisterMetaType< ImageSyncInfo* >();
-}
-}
 
 #endif // IMAGESYNCINFO_H

--- a/mythtv/libs/libmythservicecontracts/datacontracts/input.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/input.h
@@ -50,10 +50,6 @@ class SERVICE_PUBLIC Input : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         Input(QObject *parent = 0)
             : QObject         ( parent ),
               m_Id            ( 0      ),
@@ -66,38 +62,24 @@ class SERVICE_PUBLIC Input : public QObject
         {
         }
 
-        Input( const Input &src )
+        void Copy( const Input *src )
         {
-            Copy( src );
+            m_Id            = src->m_Id;
+            m_CardId        = src->m_CardId;
+            m_SourceId      = src->m_SourceId;
+            m_InputName     = src->m_InputName;
+            m_DisplayName   = src->m_DisplayName;
+//            m_StartChan     = src->m_StartChan;
+            m_QuickTune     = src->m_QuickTune;
+            m_RecPriority   = src->m_RecPriority;
+            m_ScheduleOrder = src->m_ScheduleOrder;
+            m_LiveTVOrder   = src->m_LiveTVOrder;
         }
 
-        void Copy( const Input &src )
-        {
-            m_Id            = src.m_Id;
-            m_CardId        = src.m_CardId;
-            m_SourceId      = src.m_SourceId;
-            m_InputName     = src.m_InputName;
-            m_DisplayName   = src.m_DisplayName;
-//            m_StartChan     = src.m_StartChan;
-            m_QuickTune     = src.m_QuickTune;
-            m_RecPriority   = src.m_RecPriority;
-            m_ScheduleOrder = src.m_ScheduleOrder;
-            m_LiveTVOrder   = src.m_LiveTVOrder;
-        }
+    private:
+        Q_DISABLE_COPY(Input);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::Input  )
-Q_DECLARE_METATYPE( DTC::Input* )
-
-namespace DTC
-{
-inline void Input::InitializeCustomTypes()
-{
-    qRegisterMetaType< Input  >();
-    qRegisterMetaType< Input* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/inputList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/inputList.h
@@ -37,23 +37,14 @@ class SERVICE_PUBLIC InputList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         InputList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        InputList( const InputList &src )
+        void Copy( const InputList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const InputList &src )
-        {
-            CopyListContents< Input >( this, m_Inputs, src.m_Inputs );
+            CopyListContents< Input >( this, m_Inputs, src->m_Inputs );
         }
 
         Input *AddNewInput()
@@ -67,22 +58,10 @@ class SERVICE_PUBLIC InputList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(InputList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::InputList  )
-Q_DECLARE_METATYPE( DTC::InputList* )
-
-namespace DTC
-{
-inline void InputList::InitializeCustomTypes()
-{
-    qRegisterMetaType< InputList  >();
-    qRegisterMetaType< InputList* >();
-
-    Input::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/labelValue.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/labelValue.h
@@ -40,10 +40,6 @@ class SERVICE_PUBLIC LabelValue : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         LabelValue(QObject *parent = 0)
             : QObject       ( parent ),
               m_Label       (       ),
@@ -54,33 +50,19 @@ class SERVICE_PUBLIC LabelValue : public QObject
         {
         }
 
-        LabelValue( const LabelValue &src )
+        void Copy( const LabelValue *src )
         {
-            Copy( src );
+            m_Label       = src->m_Label       ;
+            m_Value       = src->m_Value       ;
+            m_Description = src->m_Description ;
+            m_Active      = src->m_Active      ;
+            m_Selected    = src->m_Selected    ;
         }
 
-        void Copy( const LabelValue &src )
-        {
-            m_Label       = src.m_Label       ;
-            m_Value       = src.m_Value       ;
-            m_Description = src.m_Description ;
-            m_Active      = src.m_Active      ;
-            m_Selected    = src.m_Selected    ;
-        }
+    private:
+        Q_DISABLE_COPY(LabelValue);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::LabelValue )
-Q_DECLARE_METATYPE( DTC::LabelValue* )
-
-namespace DTC
-{
-inline void LabelValue::InitializeCustomTypes()
-{
-    qRegisterMetaType< LabelValue  >();
-    qRegisterMetaType< LabelValue* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/lineup.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/lineup.h
@@ -42,29 +42,23 @@ class SERVICE_PUBLIC Lineup : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         Lineup(QObject *parent = 0)
             : QObject         ( parent )
         {
         }
 
-        Lineup( const Lineup &src )
+        void Copy( const Lineup *src )
         {
-            Copy( src );
+            m_LineupId     = src->m_LineupId      ;
+            m_Name         = src->m_Name          ;
+            m_DisplayName  = src->m_DisplayName   ;
+            m_Type         = src->m_Type          ;
+            m_Postal       = src->m_Postal        ;
+            m_Device       = src->m_Device        ;
         }
 
-        void Copy( const Lineup &src )
-        {
-            m_LineupId     = src.m_LineupId      ;
-            m_Name         = src.m_Name          ;
-            m_DisplayName  = src.m_DisplayName   ;
-            m_Type         = src.m_Type          ;
-            m_Postal       = src.m_Postal        ;
-            m_Device       = src.m_Device        ;
-        }
+    private:
+        Q_DISABLE_COPY(Lineup);
 };
 
 class SERVICE_PUBLIC LineupList : public QObject
@@ -83,23 +77,14 @@ class SERVICE_PUBLIC LineupList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         LineupList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        LineupList( const LineupList &src )
+        void Copy( const LineupList *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const LineupList &src )
-        {
-            CopyListContents< Lineup >( this, m_Lineups, src.m_Lineups );
+            CopyListContents< Lineup >( this, m_Lineups, src->m_Lineups );
         }
 
         Lineup *AddNewLineup()
@@ -116,28 +101,5 @@ class SERVICE_PUBLIC LineupList : public QObject
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::LineupList  )
-Q_DECLARE_METATYPE( DTC::LineupList* )
-
-Q_DECLARE_METATYPE( DTC::Lineup  )
-Q_DECLARE_METATYPE( DTC::Lineup* )
-
-namespace DTC
-{
-inline void Lineup::InitializeCustomTypes()
-{
-    qRegisterMetaType< Lineup  >();
-    qRegisterMetaType< Lineup* >();
-}
-
-inline void LineupList::InitializeCustomTypes()
-{
-    qRegisterMetaType< LineupList  >();
-    qRegisterMetaType< LineupList* >();
-
-    Lineup::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/liveStreamInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/liveStreamInfo.h
@@ -67,10 +67,6 @@ class SERVICE_PUBLIC LiveStreamInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         explicit LiveStreamInfo(QObject *parent = 0)
             : QObject            ( parent ),
               m_Id               ( 0      ),
@@ -90,52 +86,38 @@ class SERVICE_PUBLIC LiveStreamInfo : public QObject
               m_AudioOnlyBitrate ( 0      )
         { 
         }
-        
-        LiveStreamInfo( const LiveStreamInfo &src )
+
+        void Copy( const LiveStreamInfo *src )
         {
-            Copy( src );
+            m_Id                = src->m_Id                ;
+            m_Width             = src->m_Width             ;
+            m_Height            = src->m_Height            ;
+            m_Bitrate           = src->m_Bitrate           ;
+            m_AudioBitrate      = src->m_AudioBitrate      ;
+            m_SegmentSize       = src->m_SegmentSize       ;
+            m_MaxSegments       = src->m_MaxSegments       ;
+            m_StartSegment      = src->m_StartSegment      ;
+            m_CurrentSegment    = src->m_CurrentSegment    ;
+            m_SegmentCount      = src->m_SegmentCount      ;
+            m_PercentComplete   = src->m_PercentComplete   ;
+            m_Created           = src->m_Created           ;
+            m_LastModified      = src->m_LastModified      ;
+            m_RelativeURL       = src->m_RelativeURL       ;
+            m_FullURL           = src->m_FullURL           ;
+            m_StatusStr         = src->m_StatusStr         ;
+            m_StatusInt         = src->m_StatusInt         ;
+            m_StatusMessage     = src->m_StatusMessage     ;
+            m_SourceFile        = src->m_SourceFile        ;
+            m_SourceHost        = src->m_SourceHost        ;
+            m_SourceWidth       = src->m_SourceWidth       ;
+            m_SourceHeight      = src->m_SourceHeight      ;
+            m_AudioOnlyBitrate  = src->m_AudioOnlyBitrate  ;
         }
 
-        void Copy( const LiveStreamInfo &src )
-        {
-            m_Id                = src.m_Id                ;
-            m_Width             = src.m_Width             ;
-            m_Height            = src.m_Height            ;
-            m_Bitrate           = src.m_Bitrate           ;
-            m_AudioBitrate      = src.m_AudioBitrate      ;
-            m_SegmentSize       = src.m_SegmentSize       ;
-            m_MaxSegments       = src.m_MaxSegments       ;
-            m_StartSegment      = src.m_StartSegment      ;
-            m_CurrentSegment    = src.m_CurrentSegment    ;
-            m_SegmentCount      = src.m_SegmentCount      ;
-            m_PercentComplete   = src.m_PercentComplete   ;
-            m_Created           = src.m_Created           ;
-            m_LastModified      = src.m_LastModified      ;
-            m_RelativeURL       = src.m_RelativeURL       ;
-            m_FullURL           = src.m_FullURL           ;
-            m_StatusStr         = src.m_StatusStr         ;
-            m_StatusInt         = src.m_StatusInt         ;
-            m_StatusMessage     = src.m_StatusMessage     ;
-            m_SourceFile        = src.m_SourceFile        ;
-            m_SourceHost        = src.m_SourceHost        ;
-            m_SourceWidth       = src.m_SourceWidth       ;
-            m_SourceHeight      = src.m_SourceHeight      ;
-            m_AudioOnlyBitrate  = src.m_AudioOnlyBitrate  ;
-        }
+    private:
+        Q_DISABLE_COPY(LiveStreamInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::LiveStreamInfo  )
-Q_DECLARE_METATYPE( DTC::LiveStreamInfo* )
-
-namespace DTC
-{
-inline void LiveStreamInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< LiveStreamInfo   >();
-    qRegisterMetaType< LiveStreamInfo*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/liveStreamInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/liveStreamInfoList.h
@@ -27,23 +27,14 @@ class SERVICE_PUBLIC LiveStreamInfoList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         explicit LiveStreamInfoList(QObject *parent = 0)
             : QObject( parent )               
         {
         }
-        
-        LiveStreamInfoList( const LiveStreamInfoList &src ) 
-        {
-            Copy( src );
-        }
 
-        void Copy( const LiveStreamInfoList &src )
+        void Copy( const LiveStreamInfoList *src )
         {
-            CopyListContents< LiveStreamInfo >( this, m_LiveStreamInfos, src.m_LiveStreamInfos );
+            CopyListContents< LiveStreamInfo >( this, m_LiveStreamInfos, src->m_LiveStreamInfos );
         }
 
         LiveStreamInfo *AddNewLiveStreamInfo()
@@ -57,22 +48,10 @@ class SERVICE_PUBLIC LiveStreamInfoList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(LiveStreamInfoList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::LiveStreamInfoList  )
-Q_DECLARE_METATYPE( DTC::LiveStreamInfoList* )
-
-namespace DTC
-{
-inline void LiveStreamInfoList::InitializeCustomTypes()
-{
-    qRegisterMetaType< LiveStreamInfoList   >();
-    qRegisterMetaType< LiveStreamInfoList*  >();
-
-    LiveStreamInfo::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/logInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/logInfo.h
@@ -32,41 +32,23 @@ class SERVICE_PUBLIC LogInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         LogInfo(QObject *parent = 0)
             : QObject    ( parent ),
               m_LogArgs  ( ""     )
         {
         }
 
-        LogInfo( const LogInfo &src )
+        void Copy( const LogInfo *src )
         {
-            Copy( src );
+            m_LogArgs   = src->m_LogArgs  ;
         }
 
-        void Copy( const LogInfo &src )
-        {
-            m_LogArgs   = src.m_LogArgs  ;
-        }
+    private:
+        Q_DISABLE_COPY(LogInfo);
 };
 
 typedef LogInfo* LogInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::LogInfo  )
-Q_DECLARE_METATYPE( DTC::LogInfo* )
-
-namespace DTC
-{
-inline void LogInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< LogInfo  >();
-    qRegisterMetaType< LogInfo* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/logMessage.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/logMessage.h
@@ -59,10 +59,6 @@ class SERVICE_PUBLIC LogMessage : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         LogMessage(QObject *parent = 0)
             : QObject       ( parent ),
               m_HostName    (        ),
@@ -79,39 +75,25 @@ class SERVICE_PUBLIC LogMessage : public QObject
         {
         }
 
-        LogMessage( const LogMessage &src )
+        void Copy( const LogMessage *src )
         {
-            Copy( src );
+            m_HostName        = src->m_HostName       ;
+            m_Application     = src->m_Application    ;
+            m_PID             = src->m_PID            ;
+            m_TID             = src->m_TID            ;
+            m_Thread          = src->m_Thread         ;
+            m_Filename        = src->m_Filename       ;
+            m_Line            = src->m_Line           ;
+            m_Function        = src->m_Function       ;
+            m_Time            = src->m_Time           ;
+            m_Level           = src->m_Level          ;
+            m_Message         = src->m_Message        ;
         }
 
-        void Copy( const LogMessage &src )
-        {
-            m_HostName        = src.m_HostName       ;
-            m_Application     = src.m_Application    ;
-            m_PID             = src.m_PID            ;
-            m_TID             = src.m_TID            ;
-            m_Thread          = src.m_Thread         ;
-            m_Filename        = src.m_Filename       ;
-            m_Line            = src.m_Line           ;
-            m_Function        = src.m_Function       ;
-            m_Time            = src.m_Time           ;
-            m_Level           = src.m_Level          ;
-            m_Message         = src.m_Message        ;
-        }
+    private:
+        Q_DISABLE_COPY(LogMessage);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::LogMessage )
-Q_DECLARE_METATYPE( DTC::LogMessage* )
-
-namespace DTC
-{
-inline void LogMessage::InitializeCustomTypes()
-{
-    qRegisterMetaType< LogMessage  >();
-    qRegisterMetaType< LogMessage* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/logMessageList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/logMessageList.h
@@ -34,28 +34,19 @@ class SERVICE_PUBLIC LogMessageList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         LogMessageList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        LogMessageList( const LogMessageList &src )
-        {
-            Copy( src );
-        }
-
-        void Copy( const LogMessageList &src )
+        void Copy( const LogMessageList *src )
         {
             CopyListContents< LabelValue >( this, m_HostNames,
-                                            src.m_HostNames );
+                                            src->m_HostNames );
             CopyListContents< LabelValue >( this, m_Applications,
-                                            src.m_Applications );
+                                            src->m_Applications );
             CopyListContents< LogMessage >( this, m_LogMessages,
-                                            src.m_LogMessages );
+                                            src->m_LogMessages );
         }
 
         LabelValue *AddNewHostName()
@@ -91,23 +82,10 @@ class SERVICE_PUBLIC LogMessageList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(LogMessageList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::LogMessageList  )
-Q_DECLARE_METATYPE( DTC::LogMessageList* )
-
-namespace DTC
-{
-inline void LogMessageList::InitializeCustomTypes()
-{
-    qRegisterMetaType< LogMessageList   >();
-    qRegisterMetaType< LogMessageList*  >();
-
-    LabelValue::InitializeCustomTypes();
-    LogMessage::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/musicMetadataInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/musicMetadataInfo.h
@@ -61,10 +61,6 @@ class SERVICE_PUBLIC MusicMetadataInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         MusicMetadataInfo(QObject *parent = 0)
                         : QObject         ( parent ),
                           m_Id            ( 0      ),
@@ -77,43 +73,26 @@ class SERVICE_PUBLIC MusicMetadataInfo : public QObject
         {
         }
 
-        MusicMetadataInfo( const MusicMetadataInfo &src )
+        void Copy( const MusicMetadataInfo *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const MusicMetadataInfo &src )
-        {
-            m_Id                 = src.m_Id;
-            m_Artist             = src.m_Artist;
-            m_CompilationArtist  = src.m_CompilationArtist;
-            m_Album              = src.m_Album;
-            m_Title              = src.m_Title;
-            m_TrackNo            = src.m_TrackNo;
-            m_Genre              = src.m_Genre;
-            m_Year               = src.m_Year;
-            m_PlayCount          = src.m_PlayCount;
-            m_Length             = src.m_Length;
-            m_Rating             = src.m_Rating;
-            m_FileName           = src.m_FileName;
-            m_HostName           = src.m_HostName;
-            m_LastPlayed         = src.m_LastPlayed;
-            m_Compilation        = src.m_Compilation;
+            m_Id                 = src->m_Id;
+            m_Artist             = src->m_Artist;
+            m_CompilationArtist  = src->m_CompilationArtist;
+            m_Album              = src->m_Album;
+            m_Title              = src->m_Title;
+            m_TrackNo            = src->m_TrackNo;
+            m_Genre              = src->m_Genre;
+            m_Year               = src->m_Year;
+            m_PlayCount          = src->m_PlayCount;
+            m_Length             = src->m_Length;
+            m_Rating             = src->m_Rating;
+            m_FileName           = src->m_FileName;
+            m_HostName           = src->m_HostName;
+            m_LastPlayed         = src->m_LastPlayed;
+            m_Compilation        = src->m_Compilation;
         }
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::MusicMetadataInfo  )
-Q_DECLARE_METATYPE( DTC::MusicMetadataInfo* )
-
-namespace DTC
-{
-inline void MusicMetadataInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< MusicMetadataInfo  >();
-    qRegisterMetaType< MusicMetadataInfo* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/musicMetadataInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/musicMetadataInfoList.h
@@ -56,10 +56,6 @@ class SERVICE_PUBLIC MusicMetadataInfoList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         MusicMetadataInfoList(QObject *parent = 0)
             : QObject( parent ),
               m_StartIndex    ( 0      ),
@@ -70,21 +66,16 @@ class SERVICE_PUBLIC MusicMetadataInfoList : public QObject
         {
         }
 
-        MusicMetadataInfoList( const MusicMetadataInfoList &src )
+        void Copy( const MusicMetadataInfoList *src )
         {
-            Copy( src );
-        }
+            m_StartIndex    = src->m_StartIndex     ;
+            m_Count         = src->m_Count          ;
+            m_TotalAvailable= src->m_TotalAvailable ;
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const MusicMetadataInfoList &src )
-        {
-            m_StartIndex    = src.m_StartIndex     ;
-            m_Count         = src.m_Count          ;
-            m_TotalAvailable= src.m_TotalAvailable ;
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< MusicMetadataInfo >( this, m_MusicMetadataInfos, src.m_MusicMetadataInfos );
+            CopyListContents< MusicMetadataInfo >( this, m_MusicMetadataInfos, src->m_MusicMetadataInfos );
         }
 
         MusicMetadataInfo *AddNewMusicMetadataInfo()
@@ -101,19 +92,5 @@ class SERVICE_PUBLIC MusicMetadataInfoList : public QObject
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::MusicMetadataInfoList  )
-Q_DECLARE_METATYPE( DTC::MusicMetadataInfoList* )
-
-namespace DTC
-{
-inline void MusicMetadataInfoList::InitializeCustomTypes()
-{
-    qRegisterMetaType< MusicMetadataInfoList  >();
-    qRegisterMetaType< MusicMetadataInfoList* >();
-
-    MusicMetadataInfo::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/programAndChannel.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/programAndChannel.h
@@ -89,10 +89,6 @@ class SERVICE_PUBLIC ChannelInfo : public QObject
 
     public:
 
-        static void InitializeCustomTypes();
-
-    public:
-
         ChannelInfo(QObject *parent = 0) 
             : QObject           ( parent ),
               m_ChanId          ( 0      ),
@@ -109,31 +105,28 @@ class SERVICE_PUBLIC ChannelInfo : public QObject
               m_SerializeDetails( true   )
         {
         }
-        
-        ChannelInfo( const ChannelInfo &src )
-        {
-            Copy( src );
-        }
 
-        void Copy( const ChannelInfo &src )
+        void Copy( const ChannelInfo *src )
         {
-            m_ChanId       = src.m_ChanId      ;
-            m_ChanNum      = src.m_ChanNum     ;
-            m_CallSign     = src.m_CallSign    ;
-            m_IconURL      = src.m_IconURL     ;
-            m_ChannelName  = src.m_ChannelName ;
-            m_ChanFilters  = src.m_ChanFilters ;
-            m_SourceId     = src.m_SourceId    ;
-            m_InputId      = src.m_InputId     ;
-            m_CommFree     = src.m_CommFree    ;
-            m_UseEIT       = src.m_UseEIT      ;
-            m_Visible      = src.m_Visible     ;
+            m_ChanId       = src->m_ChanId      ;
+            m_ChanNum      = src->m_ChanNum     ;
+            m_CallSign     = src->m_CallSign    ;
+            m_IconURL      = src->m_IconURL     ;
+            m_ChannelName  = src->m_ChannelName ;
+            m_ChanFilters  = src->m_ChanFilters ;
+            m_SourceId     = src->m_SourceId    ;
+            m_InputId      = src->m_InputId     ;
+            m_CommFree     = src->m_CommFree    ;
+            m_UseEIT       = src->m_UseEIT      ;
+            m_Visible      = src->m_Visible     ;
 
-            CopyListContents< Program >( this, m_Programs, src.m_Programs );
+            CopyListContents< Program >( this, m_Programs, src->m_Programs );
         }
 
         Program *AddNewProgram();
 
+    private:
+        Q_DISABLE_COPY(ChannelInfo);
 };
 
 class SERVICE_PUBLIC Program : public QObject
@@ -224,10 +217,6 @@ class SERVICE_PUBLIC Program : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         Program(QObject *parent = 0) 
             : QObject               ( parent ),
               m_Repeat              ( false  ),
@@ -252,56 +241,51 @@ class SERVICE_PUBLIC Program : public QObject
         {
         }
 
-        Program( const Program &src )
+        void Copy( const Program *src )
         {
-            Copy( src );
-        }
-
-        void Copy( const Program &src )
-        {
-            m_StartTime         = src.m_StartTime;
-            m_EndTime           = src.m_EndTime;
-            m_Title             = src.m_Title;
-            m_SubTitle          = src.m_SubTitle;
-            m_Category          = src.m_Category;
-            m_CatType           = src.m_CatType;
-            m_Repeat            = src.m_Repeat;
-            m_SeriesId          = src.m_SeriesId;
-            m_ProgramId         = src.m_ProgramId;
-            m_Stars             = src.m_Stars;
-            m_LastModified      = src.m_LastModified;
-            m_ProgramFlags      = src.m_ProgramFlags;
-            m_VideoProps        = src.m_VideoProps;
-            m_AudioProps        = src.m_AudioProps;
-            m_SubProps          = src.m_SubProps;
-            m_Airdate           = src.m_Airdate;
-            m_Description       = src.m_Description;
-            m_Inetref           = src.m_Inetref;
-            m_Season            = src.m_Season;
-            m_Episode           = src.m_Episode;
-            m_TotalEpisodes     = src.m_TotalEpisodes;
+            m_StartTime         = src->m_StartTime;
+            m_EndTime           = src->m_EndTime;
+            m_Title             = src->m_Title;
+            m_SubTitle          = src->m_SubTitle;
+            m_Category          = src->m_Category;
+            m_CatType           = src->m_CatType;
+            m_Repeat            = src->m_Repeat;
+            m_SeriesId          = src->m_SeriesId;
+            m_ProgramId         = src->m_ProgramId;
+            m_Stars             = src->m_Stars;
+            m_LastModified      = src->m_LastModified;
+            m_ProgramFlags      = src->m_ProgramFlags;
+            m_VideoProps        = src->m_VideoProps;
+            m_AudioProps        = src->m_AudioProps;
+            m_SubProps          = src->m_SubProps;
+            m_Airdate           = src->m_Airdate;
+            m_Description       = src->m_Description;
+            m_Inetref           = src->m_Inetref;
+            m_Season            = src->m_Season;
+            m_Episode           = src->m_Episode;
+            m_TotalEpisodes     = src->m_TotalEpisodes;
             // DEPRECATED
-            m_FileSize          = src.m_FileSize;
-            m_FileName          = src.m_FileName;
-            m_HostName          = src.m_HostName;
+            m_FileSize          = src->m_FileSize;
+            m_FileName          = src->m_FileName;
+            m_HostName          = src->m_HostName;
             // ----
-            m_SerializeDetails  = src.m_SerializeDetails;
-            m_SerializeChannel  = src.m_SerializeChannel;    
-            m_SerializeRecording= src.m_SerializeRecording;  
-            m_SerializeArtwork  = src.m_SerializeArtwork;
-            m_SerializeCast     = src.m_SerializeCast;
+            m_SerializeDetails  = src->m_SerializeDetails;
+            m_SerializeChannel  = src->m_SerializeChannel;
+            m_SerializeRecording= src->m_SerializeRecording;
+            m_SerializeArtwork  = src->m_SerializeArtwork;
+            m_SerializeCast     = src->m_SerializeCast;
 
-            if ( src.m_Channel != NULL)
-                Channel()->Copy( src.m_Channel );
+            if ( src->m_Channel != NULL)
+                Channel()->Copy( src->m_Channel );
 
-            if ( src.m_Recording != NULL)
-                Recording()->Copy( src.m_Recording );
+            if ( src->m_Recording != NULL)
+                Recording()->Copy( src->m_Recording );
 
-            if ( src.m_Artwork != NULL)
-                Artwork()->Copy( src.m_Artwork );
+            if ( src->m_Artwork != NULL)
+                Artwork()->Copy( src->m_Artwork );
 
-            if (src.m_Cast != NULL)
-                Cast()->Copy( src.m_Cast );
+            if (src->m_Cast != NULL)
+                Cast()->Copy( src->m_Cast );
         }
 
 };
@@ -318,41 +302,5 @@ inline Program *ChannelInfo::AddNewProgram()
 }
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::Program  )
-Q_DECLARE_METATYPE( DTC::Program* )
-
-Q_DECLARE_METATYPE( DTC::ChannelInfo  )
-Q_DECLARE_METATYPE( DTC::ChannelInfo* )
-
-namespace DTC
-{
-inline void ChannelInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< ChannelInfo  >();
-    qRegisterMetaType< ChannelInfo* >();
-
-    if (QMetaType::type( "DTC::Program" ) == 0)
-        Program::InitializeCustomTypes();
-}
-
-inline void Program::InitializeCustomTypes()
-{
-    qRegisterMetaType< Program  >();
-    qRegisterMetaType< Program* >();
-
-    if (QMetaType::type( "DTC::ChannelInfo" ) == 0)
-        ChannelInfo::InitializeCustomTypes();
-
-    if (QMetaType::type( "DTC::RecordingInfo" ) == 0)
-        RecordingInfo::InitializeCustomTypes();
-
-    if (QMetaType::type( "DTC::ArtworkInfoList" ) == 0)
-        ArtworkInfoList::InitializeCustomTypes();
-
-     if (QMetaType::type( "DTC::CastMemberList" ) == 0)
-        CastMemberList::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/programGuide.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/programGuide.h
@@ -71,10 +71,6 @@ class SERVICE_PUBLIC ProgramGuide : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ProgramGuide(QObject *parent = 0) 
             : QObject           ( parent ),
               m_Details         ( false  ),
@@ -83,25 +79,20 @@ class SERVICE_PUBLIC ProgramGuide : public QObject
               m_TotalAvailable  ( 0      )
         {
         }
-        
-        ProgramGuide( const ProgramGuide &src )
-        {
-            Copy( src );
-        }
 
-        void Copy( const ProgramGuide &src )
+        void Copy( const ProgramGuide *src )
         {                                       
-            m_StartTime      = src.m_StartTime      ;
-            m_EndTime        = src.m_EndTime        ;
-            m_Details        = src.m_Details        ;
-            m_StartIndex     = src.m_StartIndex     ;
-            m_Count          = src.m_Count          ;
-            m_TotalAvailable = src.m_TotalAvailable ;
-            m_AsOf           = src.m_AsOf           ;
-            m_Version        = src.m_Version        ;
-            m_ProtoVer       = src.m_ProtoVer       ;
+            m_StartTime      = src->m_StartTime      ;
+            m_EndTime        = src->m_EndTime        ;
+            m_Details        = src->m_Details        ;
+            m_StartIndex     = src->m_StartIndex     ;
+            m_Count          = src->m_Count          ;
+            m_TotalAvailable = src->m_TotalAvailable ;
+            m_AsOf           = src->m_AsOf           ;
+            m_Version        = src->m_Version        ;
+            m_ProtoVer       = src->m_ProtoVer       ;
         
-            CopyListContents< ChannelInfo >( this, m_Channels, src.m_Channels );
+            CopyListContents< ChannelInfo >( this, m_Channels, src->m_Channels );
         }
 
         ChannelInfo *AddNewChannel()
@@ -115,22 +106,10 @@ class SERVICE_PUBLIC ProgramGuide : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(ProgramGuide);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ProgramGuide  )
-Q_DECLARE_METATYPE( DTC::ProgramGuide* )
-
-namespace DTC
-{
-inline void ProgramGuide::InitializeCustomTypes()
-{
-    qRegisterMetaType< ProgramGuide  >();
-    qRegisterMetaType< ProgramGuide* >();
-
-    ChannelInfo::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/programList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/programList.h
@@ -54,10 +54,6 @@ class SERVICE_PUBLIC ProgramList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ProgramList(QObject *parent = 0) 
             : QObject         ( parent ),
               m_StartIndex    ( 0      ),
@@ -65,22 +61,17 @@ class SERVICE_PUBLIC ProgramList : public QObject
               m_TotalAvailable( 0      )   
         {
         }
-        
-        ProgramList( const ProgramList &src ) 
-        {
-            Copy( src );
-        }
 
-        void Copy( const ProgramList &src )
+        void Copy( const ProgramList *src )
         {
-            m_StartIndex    = src.m_StartIndex     ;
-            m_Count         = src.m_Count          ;
-            m_TotalAvailable= src.m_TotalAvailable ;
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
+            m_StartIndex    = src->m_StartIndex     ;
+            m_Count         = src->m_Count          ;
+            m_TotalAvailable= src->m_TotalAvailable ;
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
         
-            CopyListContents< Program >( this, m_Programs, src.m_Programs );
+            CopyListContents< Program >( this, m_Programs, src->m_Programs );
         }
 
         Program *AddNewProgram()
@@ -94,22 +85,10 @@ class SERVICE_PUBLIC ProgramList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(ProgramList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::ProgramList  )
-Q_DECLARE_METATYPE( DTC::ProgramList* )
-
-namespace DTC
-{
-inline void ProgramList::InitializeCustomTypes()
-{
-    qRegisterMetaType< ProgramList  >();
-    qRegisterMetaType< ProgramList* >();
-
-    Program::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/recRule.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/recRule.h
@@ -120,10 +120,6 @@ class SERVICE_PUBLIC RecRule : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         RecRule(QObject *parent = 0)
             : QObject         ( parent ),
               m_Id            ( 0      ),
@@ -153,75 +149,60 @@ class SERVICE_PUBLIC RecRule : public QObject
         {
         }
 
-        RecRule( const RecRule &src )
+        void Copy( const RecRule *src )
         {
-            Copy( src );
+            m_Id            = src->m_Id            ;
+            m_ParentId      = src->m_ParentId      ;
+            m_Inactive      = src->m_Inactive      ;
+            m_Title         = src->m_Title         ;
+            m_SubTitle      = src->m_SubTitle      ;
+            m_Description   = src->m_Description   ;
+            m_Season        = src->m_Season        ;
+            m_Episode       = src->m_Episode       ;
+            m_Category      = src->m_Category      ;
+            m_StartTime     = src->m_StartTime     ;
+            m_EndTime       = src->m_EndTime       ;
+            m_SeriesId      = src->m_SeriesId      ;
+            m_ProgramId     = src->m_ProgramId     ;
+            m_Inetref       = src->m_Inetref       ;
+            m_ChanId        = src->m_ChanId        ;
+            m_CallSign      = src->m_CallSign      ;
+            m_FindDay       = src->m_FindDay       ;
+            m_FindTime      = src->m_FindTime      ;
+            m_Type          = src->m_Type          ;
+            m_SearchType    = src->m_SearchType    ;
+            m_RecPriority   = src->m_RecPriority   ;
+            m_PreferredInput= src->m_PreferredInput;
+            m_StartOffset   = src->m_StartOffset   ;
+            m_EndOffset     = src->m_EndOffset     ;
+            m_DupMethod     = src->m_DupMethod     ;
+            m_DupIn         = src->m_DupIn         ;
+            m_Filter        = src->m_Filter        ;
+            m_RecProfile    = src->m_RecProfile    ;
+            m_RecGroup      = src->m_RecGroup      ;
+            m_StorageGroup  = src->m_StorageGroup  ;
+            m_PlayGroup     = src->m_PlayGroup     ;
+            m_AutoExpire    = src->m_AutoExpire    ;
+            m_MaxEpisodes   = src->m_MaxEpisodes   ;
+            m_MaxNewest     = src->m_MaxNewest     ;
+            m_AutoCommflag  = src->m_AutoCommflag  ;
+            m_AutoTranscode = src->m_AutoTranscode ;
+            m_AutoMetaLookup= src->m_AutoMetaLookup;
+            m_AutoUserJob1  = src->m_AutoUserJob1  ;
+            m_AutoUserJob2  = src->m_AutoUserJob2  ;
+            m_AutoUserJob3  = src->m_AutoUserJob3  ;
+            m_AutoUserJob4  = src->m_AutoUserJob4  ;
+            m_Transcoder    = src->m_Transcoder    ;
+            m_NextRecording = src->m_NextRecording ;
+            m_LastRecorded  = src->m_LastRecorded  ;
+            m_LastDeleted   = src->m_LastDeleted   ;
+            m_AverageDelay  = src->m_AverageDelay  ;
         }
 
-        void Copy( const RecRule &src )
-        {
-            m_Id            = src.m_Id            ;
-            m_ParentId      = src.m_ParentId      ;
-            m_Inactive      = src.m_Inactive      ;
-            m_Title         = src.m_Title         ;
-            m_SubTitle      = src.m_SubTitle      ;
-            m_Description   = src.m_Description   ;
-            m_Season        = src.m_Season        ;
-            m_Episode       = src.m_Episode       ;
-            m_Category      = src.m_Category      ;
-            m_StartTime     = src.m_StartTime     ;
-            m_EndTime       = src.m_EndTime       ;
-            m_SeriesId      = src.m_SeriesId      ;
-            m_ProgramId     = src.m_ProgramId     ;
-            m_Inetref       = src.m_Inetref       ;
-            m_ChanId        = src.m_ChanId        ;
-            m_CallSign      = src.m_CallSign      ;
-            m_FindDay       = src.m_FindDay       ;
-            m_FindTime      = src.m_FindTime      ;
-            m_Type          = src.m_Type          ;
-            m_SearchType    = src.m_SearchType    ;
-            m_RecPriority   = src.m_RecPriority   ;
-            m_PreferredInput= src.m_PreferredInput;
-            m_StartOffset   = src.m_StartOffset   ;
-            m_EndOffset     = src.m_EndOffset     ;
-            m_DupMethod     = src.m_DupMethod     ;
-            m_DupIn         = src.m_DupIn         ;
-            m_Filter        = src.m_Filter        ;
-            m_RecProfile    = src.m_RecProfile    ;
-            m_RecGroup      = src.m_RecGroup      ;
-            m_StorageGroup  = src.m_StorageGroup  ;
-            m_PlayGroup     = src.m_PlayGroup     ;
-            m_AutoExpire    = src.m_AutoExpire    ;
-            m_MaxEpisodes   = src.m_MaxEpisodes   ;
-            m_MaxNewest     = src.m_MaxNewest     ;
-            m_AutoCommflag  = src.m_AutoCommflag  ;
-            m_AutoTranscode = src.m_AutoTranscode ;
-            m_AutoMetaLookup= src.m_AutoMetaLookup;
-            m_AutoUserJob1  = src.m_AutoUserJob1  ;
-            m_AutoUserJob2  = src.m_AutoUserJob2  ;
-            m_AutoUserJob3  = src.m_AutoUserJob3  ;
-            m_AutoUserJob4  = src.m_AutoUserJob4  ;
-            m_Transcoder    = src.m_Transcoder    ;
-            m_NextRecording = src.m_NextRecording ;
-            m_LastRecorded  = src.m_LastRecorded  ;
-            m_LastDeleted   = src.m_LastDeleted   ;
-            m_AverageDelay  = src.m_AverageDelay  ;
-        }
-
+    private:
+        Q_DISABLE_COPY(RecRule);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::RecRule  )
-Q_DECLARE_METATYPE( DTC::RecRule* )
-
-namespace DTC
-{
-inline void RecRule::InitializeCustomTypes()
-{
-    qRegisterMetaType< RecRule   >();
-    qRegisterMetaType< RecRule*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/recRuleFilter.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/recRuleFilter.h
@@ -25,42 +25,23 @@ class SERVICE_PUBLIC RecRuleFilter : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         RecRuleFilter(QObject *parent = 0)
             : QObject         ( parent ),
               m_Id            ( 0      )
         {
         }
 
-        RecRuleFilter( const RecRuleFilter &src )
+        void Copy( const RecRuleFilter *src )
         {
-            Copy( src );
+            m_Id            = src->m_Id            ;
+            m_Description   = src->m_Description   ;
         }
 
-        void Copy( const RecRuleFilter &src )
-        {
-            m_Id            = src.m_Id            ;
-            m_Description   = src.m_Description   ;
-        }
-
+    private:
+        Q_DISABLE_COPY(RecRuleFilter);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::RecRuleFilter  )
-Q_DECLARE_METATYPE( DTC::RecRuleFilter* )
-
-namespace DTC
-{
-inline void RecRuleFilter::InitializeCustomTypes()
-{
-    qRegisterMetaType< RecRuleFilter   >();
-    qRegisterMetaType< RecRuleFilter*  >();
-}
-}
 
 #endif
 

--- a/mythtv/libs/libmythservicecontracts/datacontracts/recRuleFilterList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/recRuleFilterList.h
@@ -44,10 +44,6 @@ class SERVICE_PUBLIC RecRuleFilterList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         RecRuleFilterList(QObject *parent = 0)
             : QObject          ( parent ),
               m_StartIndex     ( 0      ),
@@ -56,18 +52,13 @@ class SERVICE_PUBLIC RecRuleFilterList : public QObject
         {
         }
 
-        RecRuleFilterList( const RecRuleFilterList &src )
+        void Copy( const RecRuleFilterList *src )
         {
-            Copy( src );
-        }
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const RecRuleFilterList &src )
-        {
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< RecRuleFilter >( this, m_RecRuleFilters, src.m_RecRuleFilters );
+            CopyListContents< RecRuleFilter >( this, m_RecRuleFilters, src->m_RecRuleFilters );
         }
 
         RecRuleFilter *AddNewRecRuleFilter()
@@ -81,22 +72,10 @@ class SERVICE_PUBLIC RecRuleFilterList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(RecRuleFilterList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::RecRuleFilterList  )
-Q_DECLARE_METATYPE( DTC::RecRuleFilterList* )
-
-namespace DTC
-{
-inline void RecRuleFilterList::InitializeCustomTypes()
-{
-    qRegisterMetaType< RecRuleFilterList   >();
-    qRegisterMetaType< RecRuleFilterList*  >();
-
-    RecRuleFilter::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/recRuleList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/recRuleList.h
@@ -43,10 +43,6 @@ class SERVICE_PUBLIC RecRuleList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         RecRuleList(QObject *parent = 0)
             : QObject          ( parent ),
               m_StartIndex     ( 0      ),
@@ -55,18 +51,13 @@ class SERVICE_PUBLIC RecRuleList : public QObject
         {
         }
 
-        RecRuleList( const RecRuleList &src )
+        void Copy( const RecRuleList *src )
         {
-            Copy( src );
-        }
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const RecRuleList &src )
-        {
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< RecRule >( this, m_RecRules, src.m_RecRules );
+            CopyListContents< RecRule >( this, m_RecRules, src->m_RecRules );
         }
 
         RecRule *AddNewRecRule()
@@ -80,22 +71,10 @@ class SERVICE_PUBLIC RecRuleList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(RecRuleList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::RecRuleList  )
-Q_DECLARE_METATYPE( DTC::RecRuleList* )
-
-namespace DTC
-{
-inline void RecRuleList::InitializeCustomTypes()
-{
-    qRegisterMetaType< RecRuleList   >();
-    qRegisterMetaType< RecRuleList*  >();
-
-    RecRule::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/recording.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/recording.h
@@ -76,10 +76,6 @@ class SERVICE_PUBLIC RecordingInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         RecordingInfo(QObject *parent = 0) 
             : QObject           ( parent             ),
               m_RecordedId      ( 0                  ),
@@ -95,50 +91,34 @@ class SERVICE_PUBLIC RecordingInfo : public QObject
         {
         }
 
-        RecordingInfo( const RecordingInfo &src )
+        void Copy( const RecordingInfo *src )
         {
-            Copy( src );
+            m_RecordedId      = src->m_RecordedId       ;
+            m_Status          = src->m_Status           ;
+            m_Priority        = src->m_Priority         ;
+            m_StartTs         = src->m_StartTs          ;
+            m_EndTs           = src->m_EndTs            ;
+            m_FileSize        = src->m_FileSize         ;
+            m_FileName        = src->m_FileName         ;
+            m_HostName        = src->m_HostName         ;
+            m_LastModified    = src->m_LastModified     ;
+            m_RecordId        = src->m_RecordId         ;
+            m_RecGroup        = src->m_RecGroup         ;
+            m_StorageGroup    = src->m_StorageGroup     ;
+            m_PlayGroup       = src->m_PlayGroup        ;
+            m_RecType         = src->m_RecType          ;
+            m_DupInType       = src->m_DupInType        ;
+            m_DupMethod       = src->m_DupMethod        ;
+            m_EncoderId       = src->m_EncoderId        ;
+            m_EncoderName     = src->m_EncoderName      ;
+            m_Profile         = src->m_Profile          ;
+            m_SerializeDetails= src->m_SerializeDetails ;
         }
 
-        void Copy( const RecordingInfo &src )
-        {
-            m_RecordedId      = src.m_RecordedId       ;
-            m_Status          = src.m_Status           ;
-            m_Priority        = src.m_Priority         ;
-            m_StartTs         = src.m_StartTs          ;
-            m_EndTs           = src.m_EndTs            ;
-            m_FileSize        = src.m_FileSize         ;
-            m_FileName        = src.m_FileName         ;
-            m_HostName        = src.m_HostName         ;
-            m_LastModified    = src.m_LastModified     ;
-            m_RecordId        = src.m_RecordId         ;
-            m_RecGroup        = src.m_RecGroup         ;
-            m_StorageGroup    = src.m_StorageGroup     ;
-            m_PlayGroup       = src.m_PlayGroup        ;
-            m_RecType         = src.m_RecType          ;
-            m_DupInType       = src.m_DupInType        ;
-            m_DupMethod       = src.m_DupMethod        ;
-            m_EncoderId       = src.m_EncoderId        ;
-            m_EncoderName     = src.m_EncoderName      ;
-            m_Profile         = src.m_Profile          ;
-            m_SerializeDetails= src.m_SerializeDetails ;
-        }
+    private:
+        Q_DISABLE_COPY(RecordingInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::RecordingInfo  )
-Q_DECLARE_METATYPE( DTC::RecordingInfo* )
-
-namespace DTC
-{
-inline void RecordingInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< RecordingInfo  >();
-    qRegisterMetaType< RecordingInfo* >();
-
-    RecStatus::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/settingList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/settingList.h
@@ -38,34 +38,21 @@ class SERVICE_PUBLIC SettingList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         SettingList(QObject *parent = 0) 
             : QObject( parent )               
         {
         }
         
-        SettingList( const SettingList &src ) 
-            : m_HostName( src.m_HostName ),
-              m_Settings( src.m_Settings )    
+        void Copy( const SettingList *src )
         {
+            m_HostName = src->m_HostName;
+            m_Settings = src->m_Settings;
         }
+
+    private:
+        Q_DISABLE_COPY(SettingList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::SettingList  )
-Q_DECLARE_METATYPE( DTC::SettingList* )
-
-namespace DTC
-{
-inline void SettingList::InitializeCustomTypes()
-{
-    qRegisterMetaType< SettingList  >();
-    qRegisterMetaType< SettingList* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/storageGroupDir.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/storageGroupDir.h
@@ -34,48 +34,30 @@ class SERVICE_PUBLIC StorageGroupDir : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         StorageGroupDir(QObject *parent = 0) 
             : QObject         ( parent ),
               m_Id            ( 0      ),
               m_DirRead       ( false  ),
               m_DirWrite      ( false  ),
               m_KiBFree       ( 0      )
-        { 
-        }
-        
-        StorageGroupDir( const StorageGroupDir &src )
         {
-            Copy( src );
         }
 
-        void Copy( const StorageGroupDir &src )
+        void Copy( const StorageGroupDir *src )
         {
-            m_Id            = src.m_Id            ;
-            m_GroupName     = src.m_GroupName     ;
-            m_HostName      = src.m_HostName      ;
-            m_DirName       = src.m_DirName       ;
-            m_DirRead       = src.m_DirRead       ;
-            m_DirWrite      = src.m_DirWrite      ;
-            m_KiBFree       = src.m_KiBFree       ;
+            m_Id            = src->m_Id            ;
+            m_GroupName     = src->m_GroupName     ;
+            m_HostName      = src->m_HostName      ;
+            m_DirName       = src->m_DirName       ;
+            m_DirRead       = src->m_DirRead       ;
+            m_DirWrite      = src->m_DirWrite      ;
+            m_KiBFree       = src->m_KiBFree       ;
         }
+
+    private:
+        Q_DISABLE_COPY(StorageGroupDir);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::StorageGroupDir  )
-Q_DECLARE_METATYPE( DTC::StorageGroupDir* )
-
-namespace DTC
-{
-inline void StorageGroupDir::InitializeCustomTypes()
-{
-    qRegisterMetaType< StorageGroupDir   >();
-    qRegisterMetaType< StorageGroupDir*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/storageGroupDirList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/storageGroupDirList.h
@@ -27,23 +27,14 @@ class SERVICE_PUBLIC StorageGroupDirList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         StorageGroupDirList(QObject *parent = 0) 
             : QObject( parent )               
         {
         }
-        
-        StorageGroupDirList( const StorageGroupDirList &src ) 
-        {
-            Copy( src );
-        }
 
-        void Copy( const StorageGroupDirList &src )
+        void Copy( const StorageGroupDirList *src )
         {
-            CopyListContents< StorageGroupDir >( this, m_StorageGroupDirs, src.m_StorageGroupDirs );
+            CopyListContents< StorageGroupDir >( this, m_StorageGroupDirs, src->m_StorageGroupDirs );
         }
 
         StorageGroupDir *AddNewStorageGroupDir()
@@ -57,22 +48,10 @@ class SERVICE_PUBLIC StorageGroupDirList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(StorageGroupDirList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::StorageGroupDirList  )
-Q_DECLARE_METATYPE( DTC::StorageGroupDirList* )
-
-namespace DTC
-{
-inline void StorageGroupDirList::InitializeCustomTypes()
-{
-    qRegisterMetaType< StorageGroupDirList   >();
-    qRegisterMetaType< StorageGroupDirList*  >();
-
-    StorageGroupDir::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/timeZoneInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/timeZoneInfo.h
@@ -35,10 +35,6 @@ class SERVICE_PUBLIC TimeZoneInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         TimeZoneInfo(QObject *parent = 0)
             : QObject             ( parent ),
               m_TimeZoneID        (        ),
@@ -47,31 +43,17 @@ class SERVICE_PUBLIC TimeZoneInfo : public QObject
         {
         }
 
-        TimeZoneInfo( const TimeZoneInfo &src )
+        void Copy( const TimeZoneInfo *src )
         {
-            Copy( src );
+            m_TimeZoneID      = src->m_TimeZoneID     ;
+            m_UTCOffset       = src->m_UTCOffset      ;
+            m_CurrentDateTime = src->m_CurrentDateTime;
         }
 
-        void Copy( const TimeZoneInfo &src )
-        {
-            m_TimeZoneID      = src.m_TimeZoneID     ;
-            m_UTCOffset       = src.m_UTCOffset      ;
-            m_CurrentDateTime = src.m_CurrentDateTime;
-        }
+    private:
+        Q_DISABLE_COPY(TimeZoneInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::TimeZoneInfo )
-Q_DECLARE_METATYPE( DTC::TimeZoneInfo* )
-
-namespace DTC
-{
-inline void TimeZoneInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< TimeZoneInfo  >();
-    qRegisterMetaType< TimeZoneInfo* >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/titleInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/titleInfo.h
@@ -36,39 +36,23 @@ class SERVICE_PUBLIC TitleInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
         TitleInfo(QObject *parent = 0) 
             : QObject            ( parent ),
               m_Count(0)
         { 
         }
-        
-        TitleInfo( const TitleInfo &src )
+
+        void Copy( const TitleInfo *src )
         {
-            Copy( src );
+            m_Title             = src->m_Title             ;
+            m_Inetref           = src->m_Inetref           ;
+            m_Count             = src->m_Count             ;
         }
 
-        void Copy( const TitleInfo &src )
-        {
-            m_Title             = src.m_Title             ;
-            m_Inetref           = src.m_Inetref           ;
-            m_Count             = src.m_Count             ;
-        }
+    private:
+        Q_DISABLE_COPY(TitleInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::TitleInfo  )
-Q_DECLARE_METATYPE( DTC::TitleInfo* )
-
-namespace DTC
-{
-inline void TitleInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< TitleInfo   >();
-    qRegisterMetaType< TitleInfo*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/titleInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/titleInfoList.h
@@ -37,21 +37,14 @@ class SERVICE_PUBLIC TitleInfoList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
         TitleInfoList(QObject *parent = 0) 
             : QObject( parent )               
         {
         }
-        
-        TitleInfoList( const TitleInfoList &src ) 
-        {
-            Copy( src );
-        }
 
-        void Copy( const TitleInfoList &src )
+        void Copy( const TitleInfoList *src )
         {
-            CopyListContents< TitleInfo >( this, m_TitleInfos, src.m_TitleInfos );
+            CopyListContents< TitleInfo >( this, m_TitleInfos, src->m_TitleInfos );
         }
 
         TitleInfo *AddNewTitleInfo()
@@ -65,22 +58,10 @@ class SERVICE_PUBLIC TitleInfoList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(TitleInfoList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::TitleInfoList  )
-Q_DECLARE_METATYPE( DTC::TitleInfoList* )
-
-namespace DTC
-{
-inline void TitleInfoList::InitializeCustomTypes()
-{
-    qRegisterMetaType< TitleInfoList   >();
-    qRegisterMetaType< TitleInfoList*  >();
-
-    TitleInfo::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/versionInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/versionInfo.h
@@ -40,10 +40,6 @@ class SERVICE_PUBLIC VersionInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VersionInfo(QObject *parent = 0)
             : QObject   ( parent ),
               m_Version ( ""     ),
@@ -53,36 +49,22 @@ class SERVICE_PUBLIC VersionInfo : public QObject
               m_Schema  ( ""     )
         {
         }
-        
-        VersionInfo( const VersionInfo &src ) 
+
+        void Copy( const VersionInfo *src )
         {
-            Copy( src );
+            m_Version  = src->m_Version;
+            m_Branch   = src->m_Branch;
+            m_Protocol = src->m_Protocol;
+            m_Binary   = src->m_Binary;
+            m_Schema   = src->m_Schema;
         }
 
-        void Copy( const VersionInfo &src )
-        {
-            m_Version  = src.m_Version;
-            m_Branch   = src.m_Branch;
-            m_Protocol = src.m_Protocol;
-            m_Binary   = src.m_Binary;
-            m_Schema   = src.m_Schema;
-        }
+    private:
+        Q_DISABLE_COPY(VersionInfo);
 };
 
 typedef VersionInfo* VersionInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VersionInfo  )
-Q_DECLARE_METATYPE( DTC::VersionInfo* )
-
-namespace DTC
-{
-inline void VersionInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< VersionInfo   >();
-    qRegisterMetaType< VersionInfo*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoLookupInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoLookupInfo.h
@@ -41,10 +41,6 @@ class SERVICE_PUBLIC ArtworkItem : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         ArtworkItem(QObject *parent = 0)
                         : QObject         ( parent )
         {
@@ -52,19 +48,17 @@ class SERVICE_PUBLIC ArtworkItem : public QObject
             m_Height           = 0                      ;
         }
 
-        ArtworkItem( const ArtworkItem &src )
+        void Copy( const ArtworkItem *src )
         {
-            Copy( src );
+            m_Type             = src->m_Type             ;
+            m_Url              = src->m_Url              ;
+            m_Thumbnail        = src->m_Thumbnail        ;
+            m_Width            = src->m_Width            ;
+            m_Height           = src->m_Height           ;
         }
 
-        void Copy( const ArtworkItem &src )
-        {
-            m_Type             = src.m_Type             ;
-            m_Url              = src.m_Url              ;
-            m_Thumbnail        = src.m_Thumbnail        ;
-            m_Width            = src.m_Width            ;
-            m_Height           = src.m_Height           ;
-        }
+    private:
+        Q_DISABLE_COPY(ArtworkItem);
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -126,10 +120,6 @@ class SERVICE_PUBLIC VideoLookup : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoLookup(QObject *parent = 0)
                         : QObject         ( parent )
         {
@@ -143,34 +133,29 @@ class SERVICE_PUBLIC VideoLookup : public QObject
             m_Revenue          = 0                      ;
         }
 
-        VideoLookup( const VideoLookup &src )
+        void Copy( const VideoLookup *src )
         {
-            Copy( src );
-        }
+            m_Title            = src->m_Title            ;
+            m_SubTitle         = src->m_SubTitle         ;
+            m_Season           = src->m_Season           ;
+            m_Episode          = src->m_Episode          ;
+            m_Year             = src->m_Year             ;
+            m_Tagline          = src->m_Tagline          ;
+            m_Description      = src->m_Description      ;
+            m_Certification    = src->m_Certification    ;
+            m_Inetref          = src->m_Inetref          ;
+            m_Collectionref    = src->m_Collectionref    ;
+            m_HomePage         = src->m_HomePage         ;
+            m_ReleaseDate      = src->m_ReleaseDate      ;
+            m_UserRating       = src->m_UserRating       ;
+            m_Length           = src->m_Length           ;
+            m_Popularity       = src->m_Popularity       ;
+            m_Budget           = src->m_Budget           ;
+            m_Revenue          = src->m_Revenue          ;
+            m_IMDB             = src->m_IMDB             ;
+            m_TMSRef           = src->m_TMSRef           ;
 
-        void Copy( const VideoLookup &src )
-        {
-            m_Title            = src.m_Title            ;
-            m_SubTitle         = src.m_SubTitle         ;
-            m_Season           = src.m_Season           ;
-            m_Episode          = src.m_Episode          ;
-            m_Year             = src.m_Year             ;
-            m_Tagline          = src.m_Tagline          ;
-            m_Description      = src.m_Description      ;
-            m_Certification    = src.m_Certification    ;
-            m_Inetref          = src.m_Inetref          ;
-            m_Collectionref    = src.m_Collectionref    ;
-            m_HomePage         = src.m_HomePage         ;
-            m_ReleaseDate      = src.m_ReleaseDate      ;
-            m_UserRating       = src.m_UserRating       ;
-            m_Length           = src.m_Length           ;
-            m_Popularity       = src.m_Popularity       ;
-            m_Budget           = src.m_Budget           ;
-            m_Revenue          = src.m_Revenue          ;
-            m_IMDB             = src.m_IMDB             ;
-            m_TMSRef           = src.m_TMSRef           ;
-
-            CopyListContents< ArtworkItem >( this, m_Artwork, src.m_Artwork );
+            CopyListContents< ArtworkItem >( this, m_Artwork, src->m_Artwork );
         }
 
         ArtworkItem *AddNewArtwork()
@@ -184,27 +169,5 @@ class SERVICE_PUBLIC VideoLookup : public QObject
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoLookup  )
-Q_DECLARE_METATYPE( DTC::VideoLookup* )
-Q_DECLARE_METATYPE( DTC::ArtworkItem  )
-Q_DECLARE_METATYPE( DTC::ArtworkItem* )
-
-namespace DTC
-{
-inline void ArtworkItem::InitializeCustomTypes()
-{
-    qRegisterMetaType< ArtworkItem    >();
-    qRegisterMetaType< ArtworkItem*   >();
-}
-
-inline void VideoLookup::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoLookup  >();
-    qRegisterMetaType< VideoLookup* >();
-
-    ArtworkItem::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoLookupInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoLookupInfoList.h
@@ -48,29 +48,20 @@ class SERVICE_PUBLIC VideoLookupList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoLookupList(QObject *parent = 0)
             : QObject( parent ),
               m_Count         ( 0      )
         {
         }
 
-        VideoLookupList( const VideoLookupList &src )
+        void Copy( const VideoLookupList *src )
         {
-            Copy( src );
-        }
+            m_Count         = src->m_Count          ;
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const VideoLookupList &src )
-        {
-            m_Count         = src.m_Count          ;
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< VideoLookup >( this, m_VideoLookups, src.m_VideoLookups );
+            CopyListContents< VideoLookup >( this, m_VideoLookups, src->m_VideoLookups );
         }
 
         VideoLookup *AddNewVideoLookup()
@@ -84,22 +75,10 @@ class SERVICE_PUBLIC VideoLookupList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(VideoLookupList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoLookupList  )
-Q_DECLARE_METATYPE( DTC::VideoLookupList* )
-
-namespace DTC
-{
-inline void VideoLookupList::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoLookupList  >();
-    qRegisterMetaType< VideoLookupList* >();
-
-    VideoLookup::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoMetadataInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoMetadataInfo.h
@@ -111,10 +111,6 @@ class SERVICE_PUBLIC VideoMetadataInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoMetadataInfo(QObject *parent = 0)
                         : QObject         ( parent ),
                           m_Id            ( 0      ),
@@ -138,51 +134,28 @@ class SERVICE_PUBLIC VideoMetadataInfo : public QObject
         {
         }
 
-        VideoMetadataInfo( const VideoMetadataInfo &src )
+        void Copy( const VideoMetadataInfo *src )
         {
-            Copy( src );
+            m_Id               = src->m_Id;
+            m_SerializeArtwork = src->m_SerializeArtwork;
+            m_SerializeCast    = src->m_SerializeCast;
+            m_SerializeGenres  = src->m_SerializeGenres;
+
+            if ( src->m_Artwork != NULL)
+                Artwork()->Copy( src->m_Artwork );
+
+            if (src->m_Cast != NULL)
+                Cast()->Copy( src->m_Cast );
+
+            if (src->m_Genres != NULL)
+                Genres()->Copy( src->m_Genres );
+
         }
 
-        void Copy( const VideoMetadataInfo &src )
-        {
-            m_Id               = src.m_Id;
-            m_SerializeArtwork = src.m_SerializeArtwork;
-            m_SerializeCast    = src.m_SerializeCast;
-            m_SerializeGenres  = src.m_SerializeGenres;
-
-            if ( src.m_Artwork != NULL)
-                Artwork()->Copy( src.m_Artwork );
-
-            if (src.m_Cast != NULL)
-                Cast()->Copy( src.m_Cast );
-
-            if (src.m_Genres != NULL)
-                Genres()->Copy( src.m_Genres );
-
-        }
+    private:
+        Q_DISABLE_COPY(VideoMetadataInfo);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoMetadataInfo  )
-Q_DECLARE_METATYPE( DTC::VideoMetadataInfo* )
-
-namespace DTC
-{
-inline void VideoMetadataInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoMetadataInfo  >();
-    qRegisterMetaType< VideoMetadataInfo* >();
-
-    if (QMetaType::type( "DTC::ArtworkInfoList" ) == 0)
-        ArtworkInfoList::InitializeCustomTypes();
-
-    if (QMetaType::type( "DTC::CastMemberList" ) == 0)
-        CastMemberList::InitializeCustomTypes();
-
-    if (QMetaType::type( "DTC::GenreMemberList" ) == 0)
-        GenreList::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoMetadataInfoList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoMetadataInfoList.h
@@ -56,10 +56,6 @@ class SERVICE_PUBLIC VideoMetadataInfoList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoMetadataInfoList(QObject *parent = 0)
             : QObject( parent ),
               m_StartIndex    ( 0      ),
@@ -70,21 +66,16 @@ class SERVICE_PUBLIC VideoMetadataInfoList : public QObject
         {
         }
 
-        VideoMetadataInfoList( const VideoMetadataInfoList &src )
+        void Copy( const VideoMetadataInfoList *src )
         {
-            Copy( src );
-        }
+            m_StartIndex    = src->m_StartIndex     ;
+            m_Count         = src->m_Count          ;
+            m_TotalAvailable= src->m_TotalAvailable ;
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const VideoMetadataInfoList &src )
-        {
-            m_StartIndex    = src.m_StartIndex     ;
-            m_Count         = src.m_Count          ;
-            m_TotalAvailable= src.m_TotalAvailable ;
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< VideoMetadataInfo >( this, m_VideoMetadataInfos, src.m_VideoMetadataInfos );
+            CopyListContents< VideoMetadataInfo >( this, m_VideoMetadataInfos, src->m_VideoMetadataInfos );
         }
 
         VideoMetadataInfo *AddNewVideoMetadataInfo()
@@ -98,22 +89,10 @@ class SERVICE_PUBLIC VideoMetadataInfoList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(VideoMetadataInfoList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoMetadataInfoList  )
-Q_DECLARE_METATYPE( DTC::VideoMetadataInfoList* )
-
-namespace DTC
-{
-inline void VideoMetadataInfoList::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoMetadataInfoList  >();
-    qRegisterMetaType< VideoMetadataInfoList* >();
-
-    VideoMetadataInfo::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoMultiplex.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoMultiplex.h
@@ -69,10 +69,6 @@ class SERVICE_PUBLIC VideoMultiplex : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoMultiplex(QObject *parent = 0)
             : QObject         ( parent ),
               m_MplexId       ( 0      ),
@@ -86,52 +82,38 @@ class SERVICE_PUBLIC VideoMultiplex : public QObject
         {
         }
 
-        VideoMultiplex( const VideoMultiplex &src )
+        void Copy( const VideoMultiplex *src )
         {
-            Copy( src );
+            m_MplexId          = src->m_MplexId          ;
+            m_SourceId         = src->m_SourceId         ;
+            m_TransportId      = src->m_TransportId      ;
+            m_NetworkId        = src->m_NetworkId        ;
+            m_Frequency        = src->m_Frequency        ;
+            m_Inversion        = src->m_Inversion        ;
+            m_SymbolRate       = src->m_SymbolRate       ;
+            m_FEC              = src->m_FEC              ;
+            m_Polarity         = src->m_Polarity         ;
+            m_Modulation       = src->m_Modulation       ;
+            m_Bandwidth        = src->m_Bandwidth        ;
+            m_LPCodeRate       = src->m_LPCodeRate       ;
+            m_HPCodeRate       = src->m_HPCodeRate       ;
+            m_TransmissionMode = src->m_TransmissionMode ;
+            m_GuardInterval    = src->m_GuardInterval    ;
+            m_Visible          = src->m_Visible          ;
+            m_Constellation    = src->m_Constellation    ;
+            m_Hierarchy        = src->m_Hierarchy        ;
+            m_ModulationSystem = src->m_ModulationSystem ;
+            m_RollOff          = src->m_RollOff          ;
+            m_SIStandard       = src->m_SIStandard       ;
+            m_ServiceVersion   = src->m_ServiceVersion   ;
+            m_UpdateTimeStamp  = src->m_UpdateTimeStamp  ;
+            m_DefaultAuthority = src->m_DefaultAuthority ;
         }
 
-        void Copy( const VideoMultiplex &src )
-        {
-            m_MplexId          = src.m_MplexId          ;
-            m_SourceId         = src.m_SourceId         ;
-            m_TransportId      = src.m_TransportId      ;
-            m_NetworkId        = src.m_NetworkId        ;
-            m_Frequency        = src.m_Frequency        ;
-            m_Inversion        = src.m_Inversion        ;
-            m_SymbolRate       = src.m_SymbolRate       ;
-            m_FEC              = src.m_FEC              ;
-            m_Polarity         = src.m_Polarity         ;
-            m_Modulation       = src.m_Modulation       ;
-            m_Bandwidth        = src.m_Bandwidth        ;
-            m_LPCodeRate       = src.m_LPCodeRate       ;
-            m_HPCodeRate       = src.m_HPCodeRate       ;
-            m_TransmissionMode = src.m_TransmissionMode ;
-            m_GuardInterval    = src.m_GuardInterval    ;
-            m_Visible          = src.m_Visible          ;
-            m_Constellation    = src.m_Constellation    ;
-            m_Hierarchy        = src.m_Hierarchy        ;
-            m_ModulationSystem = src.m_ModulationSystem ;
-            m_RollOff          = src.m_RollOff          ;
-            m_SIStandard       = src.m_SIStandard       ;
-            m_ServiceVersion   = src.m_ServiceVersion   ;
-            m_UpdateTimeStamp  = src.m_UpdateTimeStamp  ;
-            m_DefaultAuthority = src.m_DefaultAuthority ;
-        }
+    private:
+        Q_DISABLE_COPY(VideoMultiplex);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoMultiplex  )
-Q_DECLARE_METATYPE( DTC::VideoMultiplex* )
-
-namespace DTC
-{
-inline void VideoMultiplex::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoMultiplex   >();
-    qRegisterMetaType< VideoMultiplex*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoMultiplexList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoMultiplexList.h
@@ -47,10 +47,6 @@ class SERVICE_PUBLIC VideoMultiplexList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoMultiplexList(QObject *parent = 0)
             : QObject( parent ),
               m_StartIndex      ( 0       ),
@@ -61,18 +57,13 @@ class SERVICE_PUBLIC VideoMultiplexList : public QObject
         {
         }
 
-        VideoMultiplexList( const VideoMultiplexList &src )
+        void Copy( const VideoMultiplexList *src )
         {
-            Copy( src );
-        }
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const VideoMultiplexList &src )
-        {
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< VideoMultiplex >( this, m_VideoMultiplexes, src.m_VideoMultiplexes );
+            CopyListContents< VideoMultiplex >( this, m_VideoMultiplexes, src->m_VideoMultiplexes );
         }
 
         VideoMultiplex *AddNewVideoMultiplex()
@@ -86,22 +77,10 @@ class SERVICE_PUBLIC VideoMultiplexList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(VideoMultiplexList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoMultiplexList  )
-Q_DECLARE_METATYPE( DTC::VideoMultiplexList* )
-
-namespace DTC
-{
-inline void VideoMultiplexList::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoMultiplexList   >();
-    qRegisterMetaType< VideoMultiplexList*  >();
-
-    VideoMultiplex::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoSource.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoSource.h
@@ -40,10 +40,6 @@ class SERVICE_PUBLIC VideoSource : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoSource(QObject *parent = 0)
             : QObject         ( parent ),
               m_Id            ( 0      ),
@@ -52,38 +48,24 @@ class SERVICE_PUBLIC VideoSource : public QObject
         {
         }
 
-        VideoSource( const VideoSource &src )
+        void Copy( const VideoSource *src )
         {
-            Copy( src );
+            m_Id            = src->m_Id            ;
+            m_SourceName    = src->m_SourceName    ;
+            m_Grabber       = src->m_Grabber       ;
+            m_UserId        = src->m_UserId        ;
+            m_FreqTable     = src->m_FreqTable     ;
+            m_LineupId      = src->m_LineupId      ;
+            m_Password      = src->m_Password      ;
+            m_UseEIT        = src->m_UseEIT        ;
+            m_ConfigPath    = src->m_ConfigPath    ;
+            m_NITId         = src->m_NITId         ;
         }
 
-        void Copy( const VideoSource &src )
-        {
-            m_Id            = src.m_Id            ;
-            m_SourceName    = src.m_SourceName    ;
-            m_Grabber       = src.m_Grabber       ;
-            m_UserId        = src.m_UserId        ;
-            m_FreqTable     = src.m_FreqTable     ;
-            m_LineupId      = src.m_LineupId      ;
-            m_Password      = src.m_Password      ;
-            m_UseEIT        = src.m_UseEIT        ;
-            m_ConfigPath    = src.m_ConfigPath    ;
-            m_NITId         = src.m_NITId         ;
-        }
+    private:
+        Q_DISABLE_COPY(VideoSource);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoSource  )
-Q_DECLARE_METATYPE( DTC::VideoSource* )
-
-namespace DTC
-{
-inline void VideoSource::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoSource   >();
-    qRegisterMetaType< VideoSource*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/videoSourceList.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/videoSourceList.h
@@ -37,27 +37,18 @@ class SERVICE_PUBLIC VideoSourceList : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         VideoSourceList(QObject *parent = 0)
             : QObject( parent )
         {
         }
 
-        VideoSourceList( const VideoSourceList &src )
+        void Copy( const VideoSourceList *src )
         {
-            Copy( src );
-        }
+            m_AsOf          = src->m_AsOf           ;
+            m_Version       = src->m_Version        ;
+            m_ProtoVer      = src->m_ProtoVer       ;
 
-        void Copy( const VideoSourceList &src )
-        {
-            m_AsOf          = src.m_AsOf           ;
-            m_Version       = src.m_Version        ;
-            m_ProtoVer      = src.m_ProtoVer       ;
-
-            CopyListContents< VideoSource >( this, m_VideoSources, src.m_VideoSources );
+            CopyListContents< VideoSource >( this, m_VideoSources, src->m_VideoSources );
         }
 
         VideoSource *AddNewVideoSource()
@@ -71,22 +62,10 @@ class SERVICE_PUBLIC VideoSourceList : public QObject
             return pObject;
         }
 
+    private:
+        Q_DISABLE_COPY(VideoSourceList);
 };
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::VideoSourceList  )
-Q_DECLARE_METATYPE( DTC::VideoSourceList* )
-
-namespace DTC
-{
-inline void VideoSourceList::InitializeCustomTypes()
-{
-    qRegisterMetaType< VideoSourceList   >();
-    qRegisterMetaType< VideoSourceList*  >();
-
-    VideoSource::InitializeCustomTypes();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/datacontracts/wolInfo.h
+++ b/mythtv/libs/libmythservicecontracts/datacontracts/wolInfo.h
@@ -38,10 +38,6 @@ class SERVICE_PUBLIC WOLInfo : public QObject
 
     public:
 
-        static inline void InitializeCustomTypes();
-
-    public:
-
         WOLInfo(QObject *parent = 0) 
             : QObject    ( parent ),
               m_Enabled  ( false  ),
@@ -49,35 +45,21 @@ class SERVICE_PUBLIC WOLInfo : public QObject
               m_Retry    ( 0      )   
         {
         }
-        
-        WOLInfo( const WOLInfo &src ) 
+
+        void Copy( const WOLInfo *src )
         {
-            Copy( src );
+            m_Enabled  = src->m_Enabled  ;
+            m_Reconnect= src->m_Reconnect;
+            m_Retry    = src->m_Retry    ;
+            m_Command  = src->m_Command  ;
         }
 
-        void Copy( const WOLInfo &src )
-        {
-            m_Enabled  = src.m_Enabled  ;
-            m_Reconnect= src.m_Reconnect;
-            m_Retry    = src.m_Retry    ;
-            m_Command  = src.m_Command  ;       
-        }
+    private:
+        Q_DISABLE_COPY(WOLInfo);
 };
 
 typedef WOLInfo* WOLInfoPtr;
 
 } // namespace DTC
-
-Q_DECLARE_METATYPE( DTC::WOLInfo  )
-Q_DECLARE_METATYPE( DTC::WOLInfo* )
-
-namespace DTC
-{
-inline void WOLInfo::InitializeCustomTypes()
-{
-    qRegisterMetaType< WOLInfo   >();
-    qRegisterMetaType< WOLInfo*  >();
-}
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/enums/recStatus.h
+++ b/mythtv/libs/libmythservicecontracts/enums/recStatus.h
@@ -55,19 +55,10 @@ class SERVICE_PUBLIC RecStatus : public QObject
                                  const QDateTime &recstartts);
     public:
 
-        static inline void InitializeCustomTypes();
-
         explicit RecStatus(QObject *parent = 0) : QObject(parent) {}
-        explicit RecStatus(const RecStatus & /* src */)					 {}
+
+    private:
+        Q_DISABLE_COPY(RecStatus)
 };
-
-Q_DECLARE_METATYPE( RecStatus )
-Q_DECLARE_METATYPE( RecStatus*)
-
-inline void RecStatus::InitializeCustomTypes()
-{
-    qRegisterMetaType< RecStatus  >();
-    qRegisterMetaType< RecStatus* >();
-}
 
 #endif

--- a/mythtv/libs/libmythservicecontracts/services/captureServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/captureServices.h
@@ -50,13 +50,8 @@ class SERVICE_PUBLIC CaptureServices : public Service
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         CaptureServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::CaptureCard::InitializeCustomTypes();
-            DTC::CaptureCardList::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/channelServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/channelServices.h
@@ -51,18 +51,8 @@ class SERVICE_PUBLIC ChannelServices : public Service
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         ChannelServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::ChannelInfoList::InitializeCustomTypes();
-            DTC::VideoSource::InitializeCustomTypes();
-            DTC::VideoSourceList::InitializeCustomTypes();
-            DTC::VideoMultiplex::InitializeCustomTypes();
-            DTC::VideoMultiplexList::InitializeCustomTypes();
-            DTC::Lineup::InitializeCustomTypes();
-            DTC::LineupList::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/contentServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/contentServices.h
@@ -44,13 +44,8 @@ class SERVICE_PUBLIC ContentServices : public Service  //, public QScriptable ??
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         ContentServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::ArtworkInfoList::InitializeCustomTypes();
-            DTC::LiveStreamInfoList::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/dvrServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/dvrServices.h
@@ -61,18 +61,8 @@ class SERVICE_PUBLIC DvrServices : public Service  //, public QScriptable ???
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         DvrServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::ProgramList::InitializeCustomTypes();
-            DTC::EncoderList::InitializeCustomTypes();
-            DTC::InputList::InitializeCustomTypes();
-            DTC::RecRuleList::InitializeCustomTypes();
-            DTC::TitleInfoList::InitializeCustomTypes();
-            DTC::RecRuleFilterList::InitializeCustomTypes();
-            DTC::CutList::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/frontendServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/frontendServices.h
@@ -20,8 +20,6 @@ class SERVICE_PUBLIC FrontendServices : public Service
   public:
     explicit FrontendServices(QObject *parent = 0) : Service(parent)
     {
-        DTC::FrontendStatus::InitializeCustomTypes();
-        DTC::FrontendActionList::InitializeCustomTypes();
     }
 
   public slots:

--- a/mythtv/libs/libmythservicecontracts/services/guideServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/guideServices.h
@@ -44,16 +44,8 @@ class SERVICE_PUBLIC GuideServices : public Service  //, public QScriptable ???
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         GuideServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::ProgramGuide::InitializeCustomTypes();
-            DTC::ProgramList ::InitializeCustomTypes();
-            DTC::Program     ::InitializeCustomTypes();
-            DTC::ChannelGroup::InitializeCustomTypes();
-            DTC::ChannelGroupList::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/imageServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/imageServices.h
@@ -22,14 +22,8 @@ class SERVICE_PUBLIC ImageServices : public Service
 
     public:
 
-        // Must call InitializeCustomTypes for each unique
-        // Custom Type used in public slots below.
         ImageServices( QObject *parent = 0 ) : Service( parent )
         {
-            // Must call InitializeCustomTypes for each
-            // unique Custom Type used in public slots below.
-            DTC::ImageMetadataInfoList::InitializeCustomTypes();
-            DTC::ImageSyncInfo::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/musicServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/musicServices.h
@@ -43,12 +43,8 @@ class SERVICE_PUBLIC MusicServices : public Service  //, public QScriptable ???
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         MusicServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::MusicMetadataInfoList::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/mythServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/mythServices.h
@@ -59,19 +59,8 @@ class SERVICE_PUBLIC MythServices : public Service  //, public QScriptable ???
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         MythServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::ConnectionInfo     ::InitializeCustomTypes();
-            DTC::SettingList        ::InitializeCustomTypes();
-            DTC::StorageGroupDirList::InitializeCustomTypes();
-            DTC::TimeZoneInfo       ::InitializeCustomTypes();
-            DTC::LogMessage         ::InitializeCustomTypes();
-            DTC::LogMessageList     ::InitializeCustomTypes();
-            DTC::FrontendList       ::InitializeCustomTypes();
-            DTC::BackendInfo        ::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/rttiServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/rttiServices.h
@@ -39,12 +39,8 @@ class SERVICE_PUBLIC RttiServices : public Service  //, public QScriptable ???
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         explicit RttiServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::Enum     ::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/services/videoServices.h
+++ b/mythtv/libs/libmythservicecontracts/services/videoServices.h
@@ -49,14 +49,8 @@ class SERVICE_PUBLIC VideoServices : public Service  //, public QScriptable ???
 
     public:
 
-        // Must call InitializeCustomTypes for each unique Custom Type used
-        // in public slots below.
-
         VideoServices( QObject *parent = 0 ) : Service( parent )
         {
-            DTC::VideoMetadataInfoList::InitializeCustomTypes();
-            DTC::VideoLookupList::InitializeCustomTypes();
-            DTC::BlurayInfo::InitializeCustomTypes();
         }
 
     public slots:

--- a/mythtv/libs/libmythservicecontracts/test/test.pro
+++ b/mythtv/libs/libmythservicecontracts/test/test.pro
@@ -1,0 +1,9 @@
+include (../../../settings.pro)
+
+TEMPLATE = subdirs
+
+SUBDIRS += $$files(test_*)
+
+unittest.target = test
+unittest.commands = ../../../programs/scripts/unittests.sh
+unix:QMAKE_EXTRA_TARGETS += unittest

--- a/mythtv/libs/libmythservicecontracts/test/test_datacontracts/.gitignore
+++ b/mythtv/libs/libmythservicecontracts/test/test_datacontracts/.gitignore
@@ -1,0 +1,4 @@
+test_datacontracts
+*.gcda
+*.gcno
+*.gcov

--- a/mythtv/libs/libmythservicecontracts/test/test_datacontracts/test_datacontracts.cpp
+++ b/mythtv/libs/libmythservicecontracts/test/test_datacontracts/test_datacontracts.cpp
@@ -1,0 +1,179 @@
+/*
+ *  Copyright (C) David Hampton 2017
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <QStringList>
+#include "mythversion.h"
+#include "mythdate.h"
+#include "test_datacontracts.h"
+#include "datacontracts/programAndChannel.h"
+#include "datacontracts/programList.h"
+#include "datacontracts/recRule.h"
+#include "datacontracts/recording.h"
+
+void TestDataContracts::initTestCase(void)
+{
+}
+
+void TestDataContracts::cleanupTestCase(void)
+{
+}
+
+void TestDataContracts::test_channelinfo(void)
+{
+    DTC::ChannelInfo *pChan = new DTC::ChannelInfo();
+    pChan->setChanId(1119);
+    pChan->setChanNum("119");
+    pChan->setCallSign("WEATH");
+    pChan->setChannelName("The Weather Channel");
+
+    // Convert to QVariant
+    QVariant v = QVariant::fromValue(pChan);
+    QVariant::Type known = QVariant::nameToType("DTC::ChannelInfo*");
+    QVariant::Type qtype = v.type();
+    QCOMPARE(known, qtype);
+
+    // Convert back to DTC::Program
+    DTC::ChannelInfo *pChan2 = v.value<DTC::ChannelInfo*>();
+    QCOMPARE(pChan->ChanId(), pChan2->ChanId());
+    QCOMPARE(pChan->ChanNum(), pChan2->ChanNum());
+    QCOMPARE(pChan->CallSign(), pChan2->CallSign());
+    QCOMPARE(pChan->ChannelName(), pChan2->ChannelName());
+}
+
+void TestDataContracts::test_program(void)
+{
+    // Create DTC::Program
+    DTC::Program *pProgram = new DTC::Program();
+    pProgram->setTitle("Big Buck Bunny");
+    pProgram->setDescription("Follow a day of the life of Big Buck Bunny "
+                             "when he meets three bullying rodents...");
+    pProgram->setInetref("10378");
+    pProgram->setCategory("movie");
+
+    // Convert to QVariant
+    QVariant v = QVariant::fromValue(pProgram);
+    QVariant::Type known = QVariant::nameToType("DTC::Program*");
+    QVariant::Type qtype = v.type();
+    QCOMPARE(known, qtype);
+
+    // Convert back to DTC::Program
+    DTC::Program *pProgram2 = v.value<DTC::Program*>();
+    QCOMPARE(pProgram->Title(), pProgram2->Title());
+    QCOMPARE(pProgram->Description(), pProgram2->Description());
+    QCOMPARE(pProgram->Inetref(), pProgram2->Inetref());
+    QCOMPARE(pProgram->Category(), pProgram2->Category());
+}
+
+void TestDataContracts::test_programlist(void)
+{
+    // Create ProgramList with one Program
+    DTC::ProgramList *pPrograms = new DTC::ProgramList();
+    DTC::Program *pProgram = pPrograms->AddNewProgram();
+    pProgram->setTitle("Big Buck Bunny");
+    pProgram->setDescription("Follow a day of the life of Big Buck Bunny "
+                             "when he meets three bullying rodents...");
+    pProgram->setInetref    ("10378");
+    pProgram->setCategory   ("movie");
+    pPrograms->setStartIndex    ( 1 );
+    pPrograms->setCount         ( 2 );
+    pPrograms->setTotalAvailable( 3 );
+    pPrograms->setAsOf          ( MythDate::current() );
+    pPrograms->setVersion       ( MYTH_BINARY_VERSION );
+    pPrograms->setProtoVer      ( MYTH_PROTO_VERSION  );
+
+    // Convert to QVariant
+    QVariant v = QVariant::fromValue(pPrograms);
+    QVariant::Type known = QVariant::nameToType("DTC::ProgramList*");
+    QVariant::Type qtype = v.type();
+    QCOMPARE(known, qtype);
+
+    // Convert back to DTC::ProgramList
+    DTC::ProgramList *pPrograms2 = v.value<DTC::ProgramList*>();
+    QCOMPARE(pPrograms->StartIndex(), pPrograms2->StartIndex());
+    QCOMPARE(pPrograms->Count(), pPrograms2->Count());
+    QCOMPARE(pPrograms->TotalAvailable(), pPrograms2->TotalAvailable());
+    QCOMPARE(pPrograms->Version(), pPrograms2->Version());
+    QCOMPARE(pPrograms->ProtoVer(), pPrograms2->ProtoVer());
+    QEXPECT_FAIL("", "Bogus count", Continue);
+    QCOMPARE(123, pPrograms2->Count());
+
+    // Check the program
+    QVariant v2 = pPrograms2->Programs()[0];
+    DTC::Program *pProgram2 = v2.value<DTC::Program*>();
+    QCOMPARE(pProgram->Title(), pProgram2->Title());
+    QCOMPARE(pProgram->Description(), pProgram2->Description());
+    QCOMPARE(pProgram->Inetref(), pProgram2->Inetref());
+    QCOMPARE(pProgram->Category(), pProgram2->Category());
+}
+
+void TestDataContracts::test_recrule(void)
+{
+    // Create DTC::RecRule
+    DTC::RecRule *pRule = new DTC::RecRule();
+    pRule->setId(12345);
+    pRule->setTitle("Big Buck Bunny");
+    pRule->setSubTitle("Bunny");
+    pRule->setDescription("Follow a day of the life of Big Buck Bunny "
+                          "when he meets three bullying rodents...");
+    pRule->setInetref("10378");
+    pRule->setRecPriority(3);
+
+    // Convert to QVariant
+    QVariant v = QVariant::fromValue(pRule);
+    QVariant::Type known = QVariant::nameToType("DTC::RecRule*");
+    QVariant::Type qtype = v.type();
+    QCOMPARE(known, qtype);
+
+    // Convert back to DTC::RecRule
+    DTC::RecRule *pRule2 = v.value<DTC::RecRule*>();
+    QCOMPARE(pRule->Id(), pRule2->Id());
+    QCOMPARE(pRule->Title(), pRule2->Title());
+    QCOMPARE(pRule->SubTitle(), pRule2->SubTitle());
+    QCOMPARE(pRule->Description(), pRule2->Description());
+    QCOMPARE(pRule->Inetref(), pRule2->Inetref());
+    QCOMPARE(pRule->RecPriority(), pRule2->RecPriority());
+}
+
+void TestDataContracts::test_recordinginfo(void)
+{
+    QDateTime now = QDateTime::currentDateTime();
+
+    // Create DTC::RecordingInfo
+    DTC::RecordingInfo *pRecording = new DTC::RecordingInfo();
+    pRecording->setRecordedId(12345);
+    pRecording->setStatus(RecStatus::Recorded);
+    pRecording->setStartTs(now);
+    pRecording->setEndTs(now.addSecs(3600));
+
+    // Convert to QVariant
+    QVariant v = QVariant::fromValue(pRecording);
+    QVariant::Type known = QVariant::nameToType("DTC::RecordingInfo*");
+    QVariant::Type qtype = v.type();
+    QCOMPARE(known, qtype);
+
+    // Convert back to DTC::RecordingInfo
+    DTC::RecordingInfo *pRecording2 = v.value<DTC::RecordingInfo*>();
+    QCOMPARE(pRecording->RecordedId(), pRecording2->RecordedId());
+    QCOMPARE(pRecording->Status(), pRecording2->Status());
+    QCOMPARE(pRecording->StartTs(), pRecording2->StartTs());
+    QCOMPARE(pRecording->EndTs(), pRecording2->EndTs());
+}
+
+
+
+QTEST_APPLESS_MAIN(TestDataContracts)

--- a/mythtv/libs/libmythservicecontracts/test/test_datacontracts/test_datacontracts.h
+++ b/mythtv/libs/libmythservicecontracts/test/test_datacontracts/test_datacontracts.h
@@ -1,0 +1,35 @@
+/*
+ *  Class DataContracts
+ *
+ *  Copyright (C) David Hampton 2017
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <QtTest>
+
+class TestDataContracts: public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase(void);
+    void cleanupTestCase(void);
+    void test_channelinfo(void);
+    void test_program(void);
+    void test_programlist(void);
+    void test_recrule(void);
+    void test_recordinginfo(void);
+};

--- a/mythtv/libs/libmythservicecontracts/test/test_datacontracts/test_datacontracts.pro
+++ b/mythtv/libs/libmythservicecontracts/test/test_datacontracts/test_datacontracts.pro
@@ -1,0 +1,31 @@
+include ( ../../../../settings.pro )
+
+QT += xml sql network
+
+contains(QT_VERSION, ^4\\.[0-9]\\..*) {
+CONFIG += qtestlib
+}
+contains(QT_VERSION, ^5\\.[0-9]\\..*) {
+QT += testlib
+}
+
+TEMPLATE = app
+TARGET = test_datacontracts
+DEPENDPATH += . ../.. ../../../libmyth ../../../libmythbase
+INCLUDEPATH += . ../.. ../../../libmyth ../../../libmythbase
+LIBS += -L../.. -lmythbase-$$LIBVERSION -lmyth-$$LIBVERSION -lmythservicecontracts-$$LIBVERSION
+LIBS += -Wl,$$_RPATH_$${PWD}/../..
+
+contains(QMAKE_CXX, "g++") {
+  QMAKE_CXXFLAGS += -O0 -fprofile-arcs -ftest-coverage
+  QMAKE_LFLAGS += -fprofile-arcs
+}
+
+# Input
+HEADERS += test_datacontracts.h
+SOURCES += test_datacontracts.cpp
+
+QMAKE_CLEAN += $(TARGET) $(TARGETA) $(TARGETD) $(TARGET0) $(TARGET1) $(TARGET2)
+QMAKE_CLEAN += ; rm -f *.gcov *.gcda *.gcno
+
+LIBS += $$EXTRA_LIBS $$LATE_LIBS

--- a/mythtv/libs/libs.pro
+++ b/mythtv/libs/libs.pro
@@ -57,7 +57,13 @@ libmythmetadata-test.target = buildtestmythmetadata
 libmythmetadata-test.commands = cd libmythmetadata/test && $(QMAKE) && $(MAKE)
 unix:QMAKE_EXTRA_TARGETS += libmythmetadata-test
 
-unittest.depends = libmyth-test libmythbase-test libmythtv-test libmythmetadata-test
+# unit tests libmythservicecontracts
+libmythservicecontracts-test.depends = sub-libmythservicecontracts
+libmythservicecontracts-test.target = buildtestmythservicecontracts
+libmythservicecontracts-test.commands = cd libmythservicecontracts/test && $(QMAKE) && $(MAKE)
+unix:QMAKE_EXTRA_TARGETS += libmythservicecontracts-test
+
+unittest.depends = libmyth-test libmythbase-test libmythtv-test libmythmetadata-test libmythservicecontracts-test
 unittest.target = test
 unittest.commands = ../programs/scripts/unittests.sh
 unix:QMAKE_EXTRA_TARGETS += unittest


### PR DESCRIPTION
These fixes originated from compiler warnings generated from adding
the -Wextra flag to the build.  This pull request only addresses
changes related to fixing this error:

  In copy constructor ‘blah::blah(const blah&)’:
    warning: base class ‘class blah’ should be explicitly initialized
    in the copy constructor [-Wextra]

Implementing explicit initializers for these objects results in an
error instead of a warning:

   In copy constructor ‘blah::blah(const blah&)’:
     error: ‘QObject::QObject(const QObject&)’ is private within
     this context : QObject(other)
     /usr/include/qt5/QtCore/qobject.h: note: declared private here
     Q_DISABLE_COPY(QObject)

Fix these errors by doing the following:

1) FileSystemInfo and MetaGrabberScript don't use any of the features
   of QObject, so make them standalone classes.

2) Remove public copy constructors from MythSystemLegacy.  This object
   uses Qt signals, so it has to be based on QObject.

3) Remove the copy constructor from MythCookieJar.  Do this by
   splitting it into its two components; creating a new jar and
   copying cookies from one jar to another.  This is probably not the
   ideal solution, but it has the smallest impact on the existing code
   base.  (An better solution would allow cookiejars to be created
   once, and then copy cookies back and forth.  This would eliminate
   the need to destroy and recreate the jar on each copy.)

4) Clean up the RecStatus object.  This object is essentially an enum
   with some related functions. It doesn't ever appear to actually be
   instantiated as an object.  This object is based on QObject and
   therefore the object itself cannot be used with the Qt metatype
   system.  The pointer, however, is automatically registered with the
   metatype system (as are pointers to all QObject derived classes).
   Remove the copy constructor and the unnecessary/duplicate metatype
   declaration/registration code.

5) Clean up all the data/service contract objects that are based on
   QObject.  Like RecStatus, the objects themselves cannot be used
   with the Qt MetaType system, and the pointers are automatically
   registered.  This allows all of the declaration/registration code
   to be removed from the files.  Removing the registration code
   allows all of the InitializeCustomTypes functions go away, which
   allows the service object constructors to be cleaned up.

   The CopyListContents code also needs to be simplified to not convert
   from pointer to object to reference, because this causes an implicit
   copy of the object. That means that all the object copy functions need
   to be updated to use pointers instead of references.

6) Create a test framework for the data contracts.  This currently
   builds five different types of objects, converts them to a QVariant
   and back, and then compares the results to the original.  It should
   be expanded to all the data objects, and other tests added.

These changes have been tested by working through most of the menu
items in mythfrontend, and by working through most of the items in the
new web frontend.



Fixes https://code.mythtv.org/trac/ticket/13069
