### PR TITLE
Hide generated objects in subdirectories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ release
 *.vcxproj.filters
 *.manifest
 bin
+moc
+obj
 *.ipch
 .directory
 .vscode

--- a/mythplugins/settings.pro
+++ b/mythplugins/settings.pro
@@ -83,3 +83,19 @@ contains(CONFIG_MYTHLOGSERVER, "yes") {
 LIRC_LIBS = $$CONFIG_LIRC_LIBS
 
 macx:using_firewire:using_backend:EXTRA_LIBS += -F$${CONFIG_MAC_AVC} -framework AVCVideoServices
+
+#
+# Stash generated objects in a subdirectory
+#
+win32 {
+    CONFIG(debug, debug|release) {
+        MOC_DIR         = debug/moc
+        OBJECTS_DIR     = debug/obj
+    } else {
+        MOC_DIR         = release/moc
+        OBJECTS_DIR     = release/obj
+    }
+} else {
+    MOC_DIR         = moc
+    OBJECTS_DIR     = obj
+}

--- a/mythtv/Makefile
+++ b/mythtv/Makefile
@@ -23,7 +23,7 @@ SUBDIRS += $(MAKE_SUBDIRS) $(QT_SUBDIRS)
 	distclean $(addsuffix _distclean,$(SUBDIRS))  \
 	install   $(addsuffix _install,  $(SUBDIRS))  \
 	uninstall $(addsuffix _uninstall,$(SUBDIRS))  \
-	global tags TAGS \
+	global tags TAGS cleanold \
 	libs/libmythbase/version.h force
 
 all: libs/libmythbase/version.h subdirs
@@ -116,3 +116,7 @@ global GPATH GRTAGS GTAGS:
 	@echo "Making global tags..."
 	@cd .. ; rm -f GPATH GRTAGS GTAGS
 	@cd .. ; find . -name \*.h -o -name \*.c -o -name \*.cpp | grep -v moc_ | gtags -f -
+
+cleanall: clean
+	@echo "Removing old moc and .o files missed by 'clean'..."
+	@find .. -name moc_* -o -name *.o | xargs rm

--- a/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.pro
+++ b/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.pro
@@ -15,12 +15,12 @@ DEPENDPATH += . ../..
 INCLUDEPATH += . ../.. ../../mpeg ../../../libmythui ../../../libmyth ../../../libmythbase
 INCLUDEPATH += ../../../libmythservicecontracts
 
-LIBS += ../../eitfixup.o
-LIBS += ../../dishdescriptors.o
-LIBS += ../../atsc_huffman.o
-LIBS += ../../dvbdescriptors.o
-LIBS += ../../iso6937tables.o
-LIBS += ../../freesat_huffman.o
+LIBS += ../../$(OBJECTS_DIR)/eitfixup.o
+LIBS += ../../$(OBJECTS_DIR)/dishdescriptors.o
+LIBS += ../../$(OBJECTS_DIR)/atsc_huffman.o
+LIBS += ../../$(OBJECTS_DIR)/dvbdescriptors.o
+LIBS += ../../$(OBJECTS_DIR)/iso6937tables.o
+LIBS += ../../$(OBJECTS_DIR)/freesat_huffman.o
 
 LIBS += -L../../../libmythbase -lmythbase-$$LIBVERSION
 LIBS += -L../../../libmythui -lmythui-$$LIBVERSION

--- a/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.pro
+++ b/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.pro
@@ -15,9 +15,9 @@ DEPENDPATH += . ../..
 INCLUDEPATH += . ../.. ../../mpeg ../../../libmythui ../../../libmyth ../../../libmythbase
 INCLUDEPATH += ../../../libmythservicecontracts
 
-LIBS += ../../iptvchannelfetcher.o
-LIBS += ../../scanmonitor.o
-LIBS += ../../moc_scanmonitor.o
+LIBS += ../../$(OBJECTS_DIR)iptvchannelfetcher.o
+LIBS += ../../$(OBJECTS_DIR)scanmonitor.o
+LIBS += ../../$(OBJECTS_DIR)moc_scanmonitor.o
 LIBS += -L../../../libmythbase -lmythbase-$$LIBVERSION
 LIBS += -L../../../libmythui -lmythui-$$LIBVERSION
 LIBS += -L../../../libmythupnp -lmythupnp-$$LIBVERSION

--- a/mythtv/libs/libmythtv/test/test_mpegtables/test_mpegtables.pro
+++ b/mythtv/libs/libmythtv/test/test_mpegtables/test_mpegtables.pro
@@ -15,9 +15,9 @@ DEPENDPATH += . ../..
 INCLUDEPATH += . ../.. ../../mpeg ../../../libmythui ../../../libmyth ../../../libmythbase
 INCLUDEPATH += ../../../libmythservicecontracts
 
-LIBS += ../../dvbdescriptors.o
-LIBS += ../../iso6937tables.o
-LIBS += ../../freesat_huffman.o
+LIBS += ../../$(OBJECTS_DIR)/dvbdescriptors.o
+LIBS += ../../$(OBJECTS_DIR)/iso6937tables.o
+LIBS += ../../$(OBJECTS_DIR)/freesat_huffman.o
 
 LIBS += -L../../../libmythbase -lmythbase-$$LIBVERSION
 LIBS += -L../../../libmythui -lmythui-$$LIBVERSION

--- a/mythtv/settings.pro
+++ b/mythtv/settings.pro
@@ -144,6 +144,7 @@ win32 {
             DESTDIR         = $$SRC_PATH_BARE/bin/debug
             QMAKE_LIBDIR   += $$SRC_PATH_BARE/bin/debug
             MOC_DIR         = debug/moc
+            OBJECTS_DIR     = debug/obj
 
             QMAKE_CXXFLAGS *= /MDd /MP /wd4100 /wd4996
 
@@ -157,6 +158,7 @@ win32 {
             DESTDIR         = $$SRC_PATH_BARE/bin/release
             QMAKE_LIBDIR   += $$SRC_PATH_BARE/bin/release
             MOC_DIR         = release/moc
+            OBJECTS_DIR     = release/obj
 
             QMAKE_CXXFLAGS *= /MD /MP /wd4100 /wd4996
 
@@ -265,6 +267,8 @@ win32 {
     # Allow compilation with Qt Embedded, if Qt is compiled without "-fno-rtti"
     QMAKE_CXXFLAGS -= -fno-exceptions -fno-rtti
 
+    MOC_DIR         = moc
+    OBJECTS_DIR     = obj
 }
 
 # Globals in static libraries need special treatment on OS X


### PR DESCRIPTION
Clean up working directories by stashing all the compiler generated
objects in hidden subdirectories.  This patch is a combination of a
suggestion from the "Design Patterns in C++ with Qt" book and code
already in the setting.pro file.

Fixes https://code.mythtv.org/trac/ticket/13070