### PR TITLE
 Handle Non Integer Refresh Rates with XRandr (Fixing JudderFree) 

### DIFF
--- a/mythtv/libs/libmythui/DisplayResX.cpp
+++ b/mythtv/libs/libmythui/DisplayResX.cpp
@@ -126,6 +126,9 @@ const DisplayResVector& DisplayResX::GetVideoModes(void) const
 
     /* The primary monitor alone. */
     XRROutputInfo *output = GetOutputInfo(display, rsc);
+    if (!output)
+        return m_videoModes;
+
     /* Needed to set the modeline later. */
     crtc = output->crtc;
     modeIdMatch.clear();
@@ -248,5 +251,11 @@ static XRROutputInfo *GetOutputInfo(MythXDisplay*& display, XRRScreenResources*&
 {
     Window root = RootWindow(display->GetDisplay(), display->GetScreen());
     RROutput primary = XRRGetOutputPrimary(display->GetDisplay(), root);
+    if (primary == 0 && rsc->noutput > 0) {
+        /* If primary is not set (and it usually is not for single displays),
+         * pick the first monitor. */
+        primary = rsc->outputs[0];
+    }
+
     return XRRGetOutputInfo(display->GetDisplay(), rsc, primary);
 }


### PR DESCRIPTION
The current code for [​JudderFree](https://www.mythtv.org/wiki/User_Manual:JudderFree) doesn't work anymore for ​[recent NVIDIA drivers](https://lists.gt.net/mythtv/users/597082#597082). It also was an NVIDIA-only solution due to relying on getting and setting refresh rates using XRandr, where they can only be integer values, or in NVIDIA's case, fake integer values.

This pull request uses an alternate method of calculating the actual refresh rate as a more accurate double value and switching to a supported modeline without trying to match the real and fake rates through the (broken) NVIDIA extension method. This should also allow Judder Free playback for other video cards so long as they support suitable implementation of XRandr.

Also attached in trac ticket [13100](https://code.mythtv.org/trac/ticket/13100)