### PR TITLE
Add support for ctags/etags/gtags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ bin
 .directory
 .vscode
 .qmake.stash
+tags
+TAGS
 GPATH
 GRTAGS
 GTAGS

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ bin
 .directory
 .vscode
 .qmake.stash
+GPATH
+GRTAGS
+GTAGS

--- a/mythtv/Makefile
+++ b/mythtv/Makefile
@@ -23,7 +23,7 @@ SUBDIRS += $(MAKE_SUBDIRS) $(QT_SUBDIRS)
 	distclean $(addsuffix _distclean,$(SUBDIRS))  \
 	install   $(addsuffix _install,  $(SUBDIRS))  \
 	uninstall $(addsuffix _uninstall,$(SUBDIRS))  \
-	global \
+	global tags TAGS \
 	libs/libmythbase/version.h force
 
 all: libs/libmythbase/version.h subdirs
@@ -90,6 +90,7 @@ distclean: $(addsuffix _distclean,$(SUBDIRS))
 	-rm -f config.ep
 	-rm -f $(addsuffix /Makefile,$(QT_SUBDIRS))
 	-rm -f ../GPATH ../GRTAGS ../GTAGS
+	-rm -f ../TAGS ../tags
 
 install: $(addsuffix _install,$(SUBDIRS))
 
@@ -100,6 +101,16 @@ uninstall: $(addsuffix _uninstall,$(SUBDIRS))
 
 test: libs/libmythbase/version.h subdirs
 	cd libs ; $(MAKE) test
+
+ctags tags:
+	@echo "Making tags..."
+	@cd .. ; rm -f tags
+	@cd .. ; find . -name \*.h -o -name \*.c -o -name \*.cpp | grep -v moc_ | xargs ctags -a
+
+etags TAGS:
+	@echo "Making TAGS..."
+	@cd .. ; rm -f TAGS
+	@cd .. ; find . -name \*.h -o -name \*.c -o -name \*.cpp | grep -v moc_ | xargs etags -a
 
 global GPATH GRTAGS GTAGS:
 	@echo "Making global tags..."

--- a/mythtv/Makefile
+++ b/mythtv/Makefile
@@ -23,6 +23,7 @@ SUBDIRS += $(MAKE_SUBDIRS) $(QT_SUBDIRS)
 	distclean $(addsuffix _distclean,$(SUBDIRS))  \
 	install   $(addsuffix _install,  $(SUBDIRS))  \
 	uninstall $(addsuffix _uninstall,$(SUBDIRS))  \
+	global \
 	libs/libmythbase/version.h force
 
 all: libs/libmythbase/version.h subdirs
@@ -88,6 +89,7 @@ distclean: $(addsuffix _distclean,$(SUBDIRS))
 	-rm -f external/FFmpeg/libavutil/avconfig.h
 	-rm -f config.ep
 	-rm -f $(addsuffix /Makefile,$(QT_SUBDIRS))
+	-rm -f ../GPATH ../GRTAGS ../GTAGS
 
 install: $(addsuffix _install,$(SUBDIRS))
 
@@ -98,3 +100,8 @@ uninstall: $(addsuffix _uninstall,$(SUBDIRS))
 
 test: libs/libmythbase/version.h subdirs
 	cd libs ; $(MAKE) test
+
+global GPATH GRTAGS GTAGS:
+	@echo "Making global tags..."
+	@cd .. ; rm -f GPATH GRTAGS GTAGS
+	@cd .. ; find . -name \*.h -o -name \*.c -o -name \*.cpp | grep -v moc_ | gtags -f -


### PR DESCRIPTION
Add support for the old ctags/etags programs for generating tags from source files.  Also add support for the newer Gnu Global source code tagging system.

Fixes https://code.mythtv.org/trac/ticket/13105