### PR TITLE
Rearrange cached files and add aging.

### DIFF
--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -22,6 +22,10 @@ static QString themedir = QString::null;
 static QString pluginsdir = QString::null;
 static QString translationsdir = QString::null;
 static QString filtersdir = QString::null;
+static QString cachedir = QString::null;
+static QString remotecachedir = QString::null;
+static QString themebasecachedir = QString::null;
+static QString thumbnaildir = QString::null;
 
 void InitializeMythDirs(void)
 {
@@ -179,6 +183,10 @@ void InitializeMythDirs(void)
 
     if (confdir.length() == 0)
         confdir = QDir::homePath() + "/.mythtv";
+    cachedir = confdir + "/cache";
+    remotecachedir = cachedir + "/remotecache";
+    themebasecachedir = cachedir + "/themecache";
+    thumbnaildir = cachedir + "/thumbnails";
 
 #if defined(Q_OS_ANDROID)
     themedir        = sharedir + "themes/";
@@ -196,13 +204,17 @@ void InitializeMythDirs(void)
     LOG(VB_GENERAL, LOG_NOTICE, QString("Using configuration directory = %1")
                                    .arg(confdir));
 
-    LOG(VB_GENERAL, LOG_DEBUG, QString( "appbindir      = "+ appbindir      ));
-    LOG(VB_GENERAL, LOG_DEBUG, QString( "sharedir       = "+ sharedir       ));
-    LOG(VB_GENERAL, LOG_DEBUG, QString( "libdir         = "+ libdir         ));
-    LOG(VB_GENERAL, LOG_DEBUG, QString( "themedir       = "+ themedir       ));
-    LOG(VB_GENERAL, LOG_DEBUG, QString( "pluginsdir     = "+ pluginsdir     ));
-    LOG(VB_GENERAL, LOG_DEBUG, QString( "translationsdir= "+ translationsdir));
-    LOG(VB_GENERAL, LOG_DEBUG, QString( "filtersdir     = "+ filtersdir     ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "appbindir         = "+ appbindir        ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "sharedir          = "+ sharedir         ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "libdir            = "+ libdir           ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "themedir          = "+ themedir         ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "pluginsdir        = "+ pluginsdir       ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "translationsdir   = "+ translationsdir  ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "filtersdir        = "+ filtersdir       ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "cachedir          = "+ cachedir         ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "remotecachedir    = "+ remotecachedir   ));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "themebasecachedir = "+ themebasecachedir));
+    LOG(VB_GENERAL, LOG_DEBUG, QString( "thumbnaildir      = "+ thumbnaildir));
 }
 
 QString GetInstallPrefix(void) { return installprefix; }
@@ -214,6 +226,35 @@ QString GetThemesParentDir(void) { return themedir; }
 QString GetPluginsDir(void) { return pluginsdir; }
 QString GetTranslationsDir(void) { return translationsdir; }
 QString GetFiltersDir(void) { return filtersdir; }
+
+/**
+ * Returns the base directory for all cached files.  On linux this
+ * will default to ~/.mythtv/cache.
+ */
+QString GetCacheDir(void) { return cachedir; }
+
+/**
+ * Returns the directory for all files cached from the backend.  On
+ * linux this will default to ~/.mythtv/cache/remotecache.  Items in
+ * this directory will be expired after a certain amount of time.
+ */
+QString GetRemoteCacheDir(void) { return remotecachedir; }
+
+/**
+ * Returns the directory where all non-theme thumbnail files should be
+ * cached.  On linux this will default to ~/.mythtv/cache/thumbnails.
+ * Items in this directory will be expired after a certain amount of
+ * time.
+ */
+QString GetThumbnailDir(void) { return thumbnaildir; }
+
+/**
+ * Returns the base directory where all theme related files should be
+ * cached.  On linux this will default to ~/.mythtv/cache/themecache.
+ * Within this directory, a sub-directory will be created for each
+ * theme used.
+ */
+QString GetThemeBaseCacheDir(void) { return themebasecachedir; }
 
 // These defines provide portability for different
 // plugin file names.

--- a/mythtv/libs/libmythbase/mythdirs.h
+++ b/mythtv/libs/libmythbase/mythdirs.h
@@ -15,6 +15,10 @@
  MBASE_PUBLIC  QString GetPluginsDir(void);
  MBASE_PUBLIC  QString GetTranslationsDir(void);
  MBASE_PUBLIC  QString GetFiltersDir(void);
+ MBASE_PUBLIC  QString GetCacheDir(void);
+ MBASE_PUBLIC  QString GetRemoteCacheDir(void);
+ MBASE_PUBLIC  QString GetThemeBaseCacheDir(void);
+ MBASE_PUBLIC  QString GetThumbnailDir(void);
 
  MBASE_PUBLIC  QString GetFiltersNameFilter(void);
  MBASE_PUBLIC  QString GetPluginsNameFilter(void);

--- a/mythtv/libs/libmythtv/previewgeneratorqueue.cpp
+++ b/mythtv/libs/libmythtv/previewgeneratorqueue.cpp
@@ -301,8 +301,8 @@ QString PreviewGeneratorQueue::GeneratePreviewImage(
 
         if (streaming)
         {
-            ret_file = QString("%1/cache/remotecache/%2")
-                .arg(GetConfDir()).arg(filename.section('/', -1));
+            ret_file = QString("%1/%2")
+                .arg(GetRemoteCacheDir()).arg(filename.section('/', -1));
 
             QFileInfo finfo(ret_file);
             if (finfo.isReadable() && finfo.lastModified() >= cmp_ts)

--- a/mythtv/libs/libmythui/mythuihelper.cpp
+++ b/mythtv/libs/libmythui/mythuihelper.cpp
@@ -761,9 +761,7 @@ bool MythUIHelper::IsImageInCache(const QString &url)
 
 QString MythUIHelper::GetThemeCacheDir(void)
 {
-    QString cachedirname = GetConfDir() + "/cache/themecache/";
-
-    QString tmpcachedir = cachedirname +
+    QString tmpcachedir = GetThemeBaseCacheDir() + "/" +
                           GetMythDB()->GetSetting("Theme", DEFAULT_UI_THEME) +
                           "." + QString::number(d->m_screenwidth) +
                           "." + QString::number(d->m_screenheight);
@@ -773,7 +771,7 @@ QString MythUIHelper::GetThemeCacheDir(void)
 
 void MythUIHelper::ClearOldImageCache(void)
 {
-    QString cachedirname = GetConfDir() + "/cache/themecache/";
+    QString cachedirname = GetThemeBaseCacheDir();
 
     d->themecachedir = GetThemeCacheDir();
 
@@ -837,7 +835,7 @@ void MythUIHelper::ClearOldImageCache(void)
 
 void MythUIHelper::RemoveCacheDir(const QString &dirname)
 {
-    QString cachedirname = GetConfDir() + "/cache/themecache/";
+    QString cachedirname = GetThemeBaseCacheDir();
 
     if (!dirname.startsWith(cachedirname))
         return;

--- a/mythtv/libs/libmythui/mythuihelper.h
+++ b/mythtv/libs/libmythui/mythuihelper.h
@@ -59,6 +59,7 @@ class MUI_PUBLIC MythUIHelper
     void RemoveFromCacheByFile(const QString &fname);
     bool IsImageInCache(const QString &url);
     QString GetThemeCacheDir(void);
+    QString GetCacheDirByUrl(QString url);
 
     void IncludeInCacheSize(MythImage *im);
     void ExcludeFromCacheSize(MythImage *im);
@@ -152,6 +153,7 @@ class MUI_PUBLIC MythUIHelper
 
     void ClearOldImageCache(void);
     void RemoveCacheDir(const QString &dirname);
+    void PruneCacheDir(QString dirname);
 
     MythUIHelperPrivate *d;
 

--- a/mythtv/programs/mythfrontend/main.cpp
+++ b/mythtv/programs/mythfrontend/main.cpp
@@ -2127,6 +2127,7 @@ int main(int argc, char **argv)
     if (ret==0)
         gContext-> saveSettingsCache();
 
+    DestroyMythUI();
     PreviewGeneratorQueue::TeardownPreviewGeneratorQueue();
 
     delete housekeeping;

--- a/mythtv/programs/mythfrontend/themechooser.cpp
+++ b/mythtv/programs/mythfrontend/themechooser.cpp
@@ -242,7 +242,7 @@ void ThemeChooser::LoadVersion(const QString &version,
     QString themeSite = QString("%1/%2")
         .arg(gCoreContext->GetSetting("ThemeRepositoryURL",
              "http://themes.mythtv.org/themes/repository")).arg(version);
-    QString destdir = GetConfDir().append("/cache/themechooser/");
+    QString destdir = GetCacheDir().append("/themechooser/");
     QString versiondir = QString("%1/%2").arg(destdir).arg(version);
     QDir remoteThemesDir(versiondir);
 

--- a/mythtv/programs/mythfrontend/themechooser.cpp
+++ b/mythtv/programs/mythfrontend/themechooser.cpp
@@ -242,8 +242,9 @@ void ThemeChooser::LoadVersion(const QString &version,
     QString themeSite = QString("%1/%2")
         .arg(gCoreContext->GetSetting("ThemeRepositoryURL",
              "http://themes.mythtv.org/themes/repository")).arg(version);
-    QDir remoteThemesDir(GetMythUI()->GetThemeCacheDir()
-                             .append("/themechooser/").append(version));
+    QString destdir = GetConfDir().append("/cache/themechooser/");
+    QString versiondir = QString("%1/%2").arg(destdir).arg(version);
+    QDir remoteThemesDir(versiondir);
 
     int downloadFailures =
         gCoreContext->GetNumSetting("ThemeInfoDownloadFailures", 0);
@@ -285,9 +286,6 @@ void ThemeChooser::LoadVersion(const QString &version,
 
         QString url = themeSite;
         url.append("/themes.zip");
-        QString destdir = GetMythUI()->GetThemeCacheDir();
-        destdir.append("/themechooser");
-        QString versiondir = QString("%1/%2").arg(destdir).arg(version);
         if (!removeThemeDir(versiondir))
             ShowOkPopup(tr("Unable to remove '%1'").arg(versiondir));
         QDir dir;


### PR DESCRIPTION
Create a couple of additional caching directories, and implement aging on them.  By default anything not accessed in one week is removed, and this aging is performed with mythfrontend starts and exits. (Specifically its when the MythUIHelper object is created/destroyed.) The cache directories used by this commit are all under ~/.cache and are:

1. remotecache : Existing. Copies of video screenshots from the backend. Now aged out.
2. themecache/\<themename\>-\<size\> : Existing. Now contains only theme related thumbnails. No aging.
3. thumbnails : New. Non theme related thumbnails are now stored here instead of in the themecache directories. Aged out.
4. themechooser : Location where the downloaded themes.zip is unpacked by the theme chooser. Moved here from \<themename\>-\<size\>/themechooser so now there is only ever one instance.

Fixes https://code.mythtv.org/trac/ticket/12274
