### PR TITLE
Make the Canadian weather scripts work again.

### DIFF
--- a/mythplugins/mythweather/mythweather/scripts/ca_envcan/ENVCANParser.pm
+++ b/mythplugins/mythweather/mythweather/scripts/ca_envcan/ENVCANParser.pm
@@ -111,7 +111,7 @@ sub doParse {
                 $results{'weather_icon'} = getIcon($1);
             }
             $results{'temp'}     = sprintf("%.0f", $1) 
-                if ($item->{summary}->{content} =~ /Temperature:\<\/b\>\s*(-?\d*\.?\d*)\&deg\;\C\s*\<br\/\>/s);
+                if ($item->{summary}->{content} =~ /Temperature:\<\/b\>\s*(-?\d*\.?\d*)\&deg\;C\s*\<br\/\>/s);
             $results{'pressure'} = sprintf("%d", $1 * 10)
                 if ($item->{summary}->{content} =~ /Pressure.*:\<\/b\>\s*(\d*\.?\d*) kPa\s*.*\<br\/\>/s);
             $results{'visibility'} = sprintf("%.1f", $1)
@@ -123,7 +123,7 @@ sub doParse {
                 $results{'windchill'} = $1; 
             }
             $results{'dewpoint'} = sprintf("%.0f", $1)
-                if ($item->{summary}->{content} =~ /Dewpoint:\<\/b\>\s*(-?\d*\.?\d*)\&deg\;\C\s*\<br\/\>/s);
+                if ($item->{summary}->{content} =~ /Dewpoint:\<\/b\>\s*(-?\d*\.?\d*)\&deg\;C\s*\<br\/\>/s);
             if ($item->{summary}->{content} =~ /(\d*\:\d*[\w ]*\d*[\w *]\d*)\s*\<br\/\>/s) {
                 $results{'observation_time'} = "Last updated at ". $1;
                 $results{'updatetime'} = "Last updated at ". $1;


### PR DESCRIPTION
Fix the parsing code that is looking for the letter 'C' in the
temperature and dew-point lines.  This was unnecessarily escaped as
'\C' which causes Perl to complain about a no longer supported regex.
Removing the escaping solves the problem.

Fixes https://code.mythtv.org/trac/ticket/13118
