### PR TITLE
Update log_query to handle bytearray queries

### DIFF
--- a/mythtv/bindings/python/MythTV/_conn_mysqldb.py
+++ b/mythtv/bindings/python/MythTV/_conn_mysqldb.py
@@ -44,6 +44,9 @@ class LoggedCursor( MySQLdb.cursors.Cursor ):
     def _sanitize(self, query): return query.replace('?', '%s')
 
     def log_query(self, query, args):
+        if isinstance(query, bytearray):
+            encoding = self._get_db().encoding
+            query = query.decode(encoding)
         self.log(self.log.DATABASE, MythLog.DEBUG,
                  ' '.join(query.split()), str(args))
 


### PR DESCRIPTION
Recent versions of MySQLdb sometimes pass the query as a bytearray that has been encoded using the database encoding which then causes an exception as you can't pass a bytearray to join.