### PR TITLE
Make all directories leading to the ttvdb/tmdb3 cache files.

### DIFF
--- a/mythtv/programs/scripts/metadata/Movie/tmdb3.py
+++ b/mythtv/programs/scripts/metadata/Movie/tmdb3.py
@@ -297,8 +297,11 @@ def main():
                 print "Unable to find MythTV directory for metadata cache."
                 sys.exit(1)
             confdir = os.path.join(confdir, '.mythtv')
-        confpath = os.path.join(confdir, 'cache', 'pytmdb3.cache')
-        set_cache(engine='file', filename=confpath)
+        cachedir = os.path.join(confdir, 'cache')
+        if not os.path.exists(cachedir):
+            os.makedirs(cachedir)
+        cachepath = os.path.join(cachedir, 'pytmdb3.cache')
+        set_cache(engine='file', filename=cachepath)
 
     if opts.language:
         set_locale(language=opts.language, fallthrough=True)

--- a/mythtv/programs/scripts/metadata/Television/ttvdb.py
+++ b/mythtv/programs/scripts/metadata/Television/ttvdb.py
@@ -1138,7 +1138,7 @@ if IS_PY2:
 else:
     cache_dir=os.path.join(confdir, "cache/tvdb_api3/")
 if not os.path.exists(cache_dir):
-    os.mkdir(cache_dir)
+    os.makedirs(cache_dir)
 
 def _can_int(x):
     """Takes a string, checks if it is numeric.


### PR DESCRIPTION
With this change, MythTv will create all directories leading up to the
cache file, instead of only creating the final directory.  This will
solve some recent problems on the mailing list where the ttvdb/tmdb3
scripts would work in some scenarios and fail in others.

Fixes https://code.mythtv.org/trac/ticket/13128
