### PR TITLE
Use the define property flags when creating a RecordingInfo object.

### DIFF
--- a/mythtv/libs/libmythtv/recordinginfo.cpp
+++ b/mythtv/libs/libmythtv/recordinginfo.cpp
@@ -147,8 +147,8 @@ RecordingInfo::RecordingInfo(
 
     findid = _findid;
 
-    properties = ((_subtitleType    << 11) |
-                  (_videoproperties << 6)  |
+    properties = ((_subtitleType    << kSubtitlePropertyOffset) |
+                  (_videoproperties << kVideoPropertyOffset)  |
                   _audioproperties);
 
     if (recstartts >= recendts)


### PR DESCRIPTION
This code used a hard coded shift for adding the subtitle flags to the
properties field, and that value hasn't kept up with the addition of
new flags.  Change the hard coded number to a constant defined in the
same location as the flags.  One reported visible side effect of this
bug is that mythweb would indicate that most recording are damaged.
This is the result of the "hard of hearing" subtitle flag being
wrongly shifted into the position of the "damaged" video flag.

Fixes https://code.mythtv.org/trac/ticket/13134