### PR TITLE
Fix empty UPnP Recodings folder on Samsung TV

### DIFF
--- a/mythtv/libs/libmythupnp/upnpcds.cpp
+++ b/mythtv/libs/libmythupnp/upnpcds.cpp
@@ -497,6 +497,11 @@ void UPnpCDS::HandleBrowse( HTTPRequest *pRequest )
 
             if (eErrorCode == UPnPResult_Success)
             {
+                while (pResult->m_List.size() > request.m_nRequestedCount)
+                {
+                    pResult->m_List.takeLast()->DecrRef();
+                }
+
                 nNumberReturned = pResult->m_List.count();
                 nTotalMatches   = pResult->m_nTotalMatches;
                 nUpdateID       = pResult->m_nUpdateID;


### PR DESCRIPTION
Returning more than requested number of elements
causes the TV to display the folder as empty.