### PR TITLE
Restore realtime priority capability for vsync thread

### DIFF
--- a/mythtv/libs/libmythbase/mythmiscutil.cpp
+++ b/mythtv/libs/libmythbase/mythmiscutil.cpp
@@ -695,6 +695,18 @@ bool myth_nice(int val)
     return true;
 }
 
+bool myth_realtime(int val)
+{
+    errno = 0;
+    struct sched_param param;
+    param.sched_priority = val;
+    int ret = pthread_setschedparam(pthread_self(), SCHED_FIFO, &param);
+    if (ret !=0) {
+      LOG(VB_GENERAL, LOG_ERR, "Failed to set RT thread");
+    }
+    return ret == 0;
+}
+
 void myth_yield(void)
 {
 #ifdef _POSIX_PRIORITY_SCHEDULING

--- a/mythtv/libs/libmythbase/mythmiscutil.h
+++ b/mythtv/libs/libmythbase/mythmiscutil.h
@@ -72,6 +72,7 @@ MBASE_PUBLIC QString FileHash(QString filename);
 MBASE_PUBLIC bool IsPulseAudioRunning(void);
 
 MBASE_PUBLIC bool myth_nice(int val);
+MBASE_PUBLIC bool myth_realtime(int val);
 MBASE_PUBLIC void myth_yield(void);
 /// range -1..8, smaller is higher priority
 MBASE_PUBLIC bool myth_ioprio(int val);


### PR DESCRIPTION
MythTV has a settings item for using realtime scheduling for the video sync thread, but it's no longer hooked up to anything in the code. This patch restores realtime scheduling for this thread.