### PR TITLE
mythtranscode: Fix #12602 by detecting write errors

### DIFF
--- a/mythtv/programs/mythtranscode/mpeg2fix.cpp
+++ b/mythtv/programs/mythtranscode/mpeg2fix.cpp
@@ -495,7 +495,7 @@ int MPEG2replex::WaitBuffers()
     if (done)
     {
         finish_mpg(mplex);
-	// twitham: thread exit must return static, not stack
+	// bug12602: thread exit must return static, not stack
 	static int errorcount = 0;
 	errorcount = mplex->error;
 	if (mplex->error) {
@@ -563,7 +563,7 @@ void MPEG2replex::Start()
     {
         check_times( &mx, &video_ok, ext_ok, &start);
         if (write_out_packs( &mx, video_ok, ext_ok)) {
-	  // twitham: exiting here blocks the reading thread indefinitely;
+	  // bug12602: exiting here blocks the reading thread indefinitely;
 	  // maybe there is a way to fail it also?
 	  // LOG(VB_GENERAL, LOG_ERR, // or comment all this to fail until close
 	  //     QString("exiting thread after %1 write errors")
@@ -2571,7 +2571,7 @@ int MPEG2fixup::Start()
     pthread_cond_signal(&rx.cond);
     pthread_mutex_unlock( &rx.mutex );
     int ex = REENCODE_OK;
-    void *errors; // twitham: return error if any write or close failures
+    void *errors; // bug12602: return error if any write or close failures
     pthread_join(thread, &errors);
     if (*(int *)errors > 0) {
       LOG(VB_GENERAL, LOG_ERR,

--- a/mythtv/programs/mythtranscode/mpeg2fix.cpp
+++ b/mythtv/programs/mythtranscode/mpeg2fix.cpp
@@ -2573,7 +2573,7 @@ int MPEG2fixup::Start()
     int ex = REENCODE_OK;
     void *errors; // bug12602: return error if any write or close failures
     pthread_join(thread, &errors);
-    if (*(int *)errors > 0) {
+    if (*(int *)errors) {
       LOG(VB_GENERAL, LOG_ERR,
 	  QString("joined thread failed with %1 write errors")
 	  .arg(*(int *)errors));

--- a/mythtv/programs/mythtranscode/mpeg2fix.cpp
+++ b/mythtv/programs/mythtranscode/mpeg2fix.cpp
@@ -495,7 +495,8 @@ int MPEG2replex::WaitBuffers()
     if (done)
     {
         finish_mpg(mplex);
-	static int errorcount = 0; // thread exit must return static, not stack
+	// twitham: thread exit must return static, not stack
+	static int errorcount = 0;
 	errorcount = mplex->error;
 	if (mplex->error) {
 	  LOG(VB_GENERAL, LOG_ERR,

--- a/mythtv/programs/mythtranscode/mpeg2fix.cpp
+++ b/mythtv/programs/mythtranscode/mpeg2fix.cpp
@@ -499,7 +499,7 @@ int MPEG2replex::WaitBuffers()
 	errorcount = mplex->error;
 	if (mplex->error) {
 	  LOG(VB_GENERAL, LOG_ERR,
-	      QString("twitham: thread finished with %1 write errors")
+	      QString("thread finished with %1 write errors")
 	      .arg(mplex->error));
 	}
 	pthread_exit(&errorcount);
@@ -562,10 +562,10 @@ void MPEG2replex::Start()
     {
         check_times( &mx, &video_ok, ext_ok, &start);
         if (write_out_packs( &mx, video_ok, ext_ok)) {
-	  // exiting here blocks the reading thread indefinitely;
+	  // twitham: exiting here blocks the reading thread indefinitely;
 	  // maybe there is a way to fail it also?
 	  // LOG(VB_GENERAL, LOG_ERR, // or comment all this to fail until close
-	  //     QString("twitham: exiting thread after %1 write errors")
+	  //     QString("exiting thread after %1 write errors")
 	  //     .arg(mplex->error));
 	  // pthread_exit(&mplex->error);
 	}
@@ -2570,11 +2570,11 @@ int MPEG2fixup::Start()
     pthread_cond_signal(&rx.cond);
     pthread_mutex_unlock( &rx.mutex );
     int ex = REENCODE_OK;
-    void *errors;	// return error if any write or close failures
+    void *errors; // twitham: return error if any write or close failures
     pthread_join(thread, &errors);
     if (*(int *)errors > 0) {
       LOG(VB_GENERAL, LOG_ERR,
-	  QString("twitham: joined thread failed with %1 write errors")
+	  QString("joined thread failed with %1 write errors")
 	  .arg(*(int *)errors));
       ex = REENCODE_ERROR;
     }

--- a/mythtv/programs/mythtranscode/replex/multiplex.c
+++ b/mythtv/programs/mythtranscode/replex/multiplex.c
@@ -297,7 +297,7 @@ static void writeout_video(multiplex_t *mx)
 
 	if (write(mx->fd_out, outbuf, written) != written) {
 	  mx->error++;
-	  if (!mx->error) mx->error = 1; // avoid int rollover to zero
+	  if (mx->error <= 0) mx->error = 1; // avoid int rollover to zero
 	  if (mx->error < 10) // bug12602: log only first few failures
 	    LOG(VB_GENERAL, LOG_ERR, "%d writes failed: %s",
 		mx->error, strerror(errno));
@@ -645,7 +645,7 @@ int finish_mpg(multiplex_t *mx)
 
 	if (close(mx->fd_out) < 0) {
 	  mx->error++;	    // bug12602: close could fail on full disk
-	  if (!mx->error) mx->error = 1; // avoid int rollover to zero
+	  if (mx->error <= 0) mx->error = 1; // avoid int rollover to zero
 	  LOG(VB_GENERAL, LOG_ERR, "close failed: %s",
 	      strerror(errno));
 	}

--- a/mythtv/programs/mythtranscode/replex/multiplex.c
+++ b/mythtv/programs/mythtranscode/replex/multiplex.c
@@ -296,7 +296,9 @@ static void writeout_video(multiplex_t *mx)
 	viu->dts = uptsdiff(viu->dts + ((nlength*viu->ptsrate)>>8), 0);
 
 	if (write(mx->fd_out, outbuf, written) != written) {
-	  if (mx->error++ < 10)	/* bug12602: log only first few failures */
+	  mx->error++;
+	  if (!mx->error) mx->error = 1; // avoid int rollover to zero
+	  if (mx->error < 10) // bug12602: log only first few failures
 	    LOG(VB_GENERAL, LOG_ERR, "%d writes failed: %s",
 		mx->error, strerror(errno));
 	}
@@ -642,7 +644,8 @@ int finish_mpg(multiplex_t *mx)
 		write(mx->fd_out, mpeg_end,4);
 
 	if (close(mx->fd_out) < 0) {
-	  mx->error++;	     // bug12602: close could fail on full disk
+	  mx->error++;	    // bug12602: close could fail on full disk
+	  if (!mx->error) mx->error = 1; // avoid int rollover to zero
 	  LOG(VB_GENERAL, LOG_ERR, "close failed: %s",
 	      strerror(errno));
 	}

--- a/mythtv/programs/mythtranscode/replex/multiplex.c
+++ b/mythtv/programs/mythtranscode/replex/multiplex.c
@@ -296,8 +296,8 @@ static void writeout_video(multiplex_t *mx)
 	viu->dts = uptsdiff(viu->dts + ((nlength*viu->ptsrate)>>8), 0);
 
 	if (write(mx->fd_out, outbuf, written) != written) {
-	  if (mx->error++ < 10)	/* log only first few failures */
-	    LOG(VB_GENERAL, LOG_ERR, "twitham: %d write failed: %s",
+	  if (mx->error++ < 10)	/* twitham: log only first few failures */
+	    LOG(VB_GENERAL, LOG_ERR, "%d writes failed: %s",
 		mx->error, strerror(errno));
 	}
 
@@ -642,9 +642,9 @@ int finish_mpg(multiplex_t *mx)
 		write(mx->fd_out, mpeg_end,4);
 
 	if (close(mx->fd_out) < 0) {
-	  mx->error++;
-	  LOG(VB_GENERAL, LOG_ERR, "twitham: %d close failed: %s",
-	      mx->error, strerror(errno));
+	  mx->error++;	     // twitham: close could fail on full disk
+	  LOG(VB_GENERAL, LOG_ERR, "close failed: %s",
+	      strerror(errno));
 	}
 
 	dummy_destroy(&mx->vdbuf);

--- a/mythtv/programs/mythtranscode/replex/multiplex.c
+++ b/mythtv/programs/mythtranscode/replex/multiplex.c
@@ -695,7 +695,7 @@ void init_multiplex( multiplex_t *mx, sequence_t *seq_head,
 	int i;
 	uint32_t data_rate;
 
-	mx->error = 0;
+	mx->error = 0; // twitham: added to catch full disk write failures
 	mx->fill_buffers = fill_buffers;
 	mx->video_delay = video_delay;
 	mx->audio_delay = audio_delay;

--- a/mythtv/programs/mythtranscode/replex/multiplex.c
+++ b/mythtv/programs/mythtranscode/replex/multiplex.c
@@ -296,7 +296,7 @@ static void writeout_video(multiplex_t *mx)
 	viu->dts = uptsdiff(viu->dts + ((nlength*viu->ptsrate)>>8), 0);
 
 	if (write(mx->fd_out, outbuf, written) != written) {
-	  if (mx->error++ < 10)	/* twitham: log only first few failures */
+	  if (mx->error++ < 10)	/* bug12602: log only first few failures */
 	    LOG(VB_GENERAL, LOG_ERR, "%d writes failed: %s",
 		mx->error, strerror(errno));
 	}
@@ -642,7 +642,7 @@ int finish_mpg(multiplex_t *mx)
 		write(mx->fd_out, mpeg_end,4);
 
 	if (close(mx->fd_out) < 0) {
-	  mx->error++;	     // twitham: close could fail on full disk
+	  mx->error++;	     // bug12602: close could fail on full disk
 	  LOG(VB_GENERAL, LOG_ERR, "close failed: %s",
 	      strerror(errno));
 	}
@@ -695,7 +695,7 @@ void init_multiplex( multiplex_t *mx, sequence_t *seq_head,
 	int i;
 	uint32_t data_rate;
 
-	mx->error = 0; // twitham: added to catch full disk write failures
+	mx->error = 0; // bug12602: added to catch full disk write failures
 	mx->fill_buffers = fill_buffers;
 	mx->video_delay = video_delay;
 	mx->audio_delay = audio_delay;

--- a/mythtv/programs/mythtranscode/replex/multiplex.h
+++ b/mythtv/programs/mythtranscode/replex/multiplex.h
@@ -81,11 +81,12 @@ typedef struct multiplex_s{
 
 	int (*fill_buffers)(void *p, int f);
 	void *priv;
+	int error;
 } multiplex_t;
 
 void check_times( multiplex_t *mx, int *video_ok, int *ext_ok, int *start);
-void write_out_packs( multiplex_t *mx, int video_ok, int *ext_ok);
-void finish_mpg(multiplex_t *mx);
+int write_out_packs( multiplex_t *mx, int video_ok, int *ext_ok);
+int finish_mpg(multiplex_t *mx);
 void init_multiplex( multiplex_t *mx, sequence_t *seq_head,
 		     audio_frame_t *extframe, int *exttype, int *exttypcnt,
 		     uint64_t video_delay, uint64_t audio_delay, int fd,

--- a/mythtv/programs/mythtranscode/replex/multiplex.h
+++ b/mythtv/programs/mythtranscode/replex/multiplex.h
@@ -81,7 +81,7 @@ typedef struct multiplex_s{
 
 	int (*fill_buffers)(void *p, int f);
 	void *priv;
-	int error; // twitham: added to catch full disk write failures
+	int error; // bug12602: added to catch full disk write failures
 } multiplex_t;
 
 void check_times( multiplex_t *mx, int *video_ok, int *ext_ok, int *start);

--- a/mythtv/programs/mythtranscode/replex/multiplex.h
+++ b/mythtv/programs/mythtranscode/replex/multiplex.h
@@ -81,7 +81,7 @@ typedef struct multiplex_s{
 
 	int (*fill_buffers)(void *p, int f);
 	void *priv;
-	int error;
+	int error; // twitham: added to catch full disk write failures
 } multiplex_t;
 
 void check_times( multiplex_t *mx, int *video_ok, int *ext_ok, int *start);

--- a/mythtv/programs/mythtranscode/replex/replex.c
+++ b/mythtv/programs/mythtranscode/replex/replex.c
@@ -2292,7 +2292,10 @@ static void do_replex(struct replex *rx)
 	while(1){
 		check_times( &mx, &video_ok, ext_ok, &start);
 
-		write_out_packs( &mx, video_ok, ext_ok);
+		if (write_out_packs( &mx, video_ok, ext_ok)) {
+			LOG(VB_GENERAL, LOG_ERR, "error while writing");
+			exit(1);
+		}
 	}
 }
 


### PR DESCRIPTION
Fix for https://code.mythtv.org/trac/ticket/12602

Explanation of the patch:

* multiplex.h:
  the mx multiplex structure gets a new "int error", the error count.
  write_out_packs and finish_mpg now return int, the error count (so 0 = success)
  currently unused: callers test the error count instead
* multiplex.c:
  if write() fails, increment error count
  log only first 10 failures so we don't flood syslog and cause it to drop messages
  if close() fails, increment error count
* mpeg2fix.cpp:
  copy error count to static variable and pass it to pthread_exit
  capture error count in pthread_join and log/fail if non-zero

This all causes mythtv to keep the original recording if disk fills during transcode, instead of truncating the recording.  Of course user will need to go free space larger than this recording for a successful transcode.

In mpeg2fix.cpp there is also a commented section where I tried to exit on first write failure. This just deadlocked the other thread. It might be possible to cancel the other thread if you wish to abort at first write error but I was unsure how to do this. As-is, we just continue to fail and return the failure count when the reader is done. I monitored with top and the size doesn't grow so I assume the data is just being dropped rather than filling memory, which is a good thing.
