### PR TITLE
mythtranscode: Fix #244 by detecting write errors

### DIFF
--- a/mythtv/programs/mythtranscode/external/replex/multiplex.cpp
+++ b/mythtv/programs/mythtranscode/external/replex/multiplex.cpp
@@ -301,7 +301,7 @@ static void writeout_video(multiplex_t *mx)
 	if (write(mx->fd_out, outbuf.data(), written) != written) {
 	  mx->error++;
 	  if (mx->error <= 0) mx->error = 1; // avoid int rollover to zero
-	  if (mx->error < 10) // bug12602: log only first few failures
+	  if (mx->error < 10) // mythtv#244: log only first few failures
 	    LOG(VB_GENERAL, LOG_ERR,
 		QString("%1 writes failed: %2")
 		.arg(mx->error).arg(strerror(errno)));
@@ -651,7 +651,7 @@ int finish_mpg(multiplex_t *mx)
 		write(mx->fd_out, mpeg_end.data(), 4);
 
 	if (close(mx->fd_out) < 0) {
-	  mx->error++;	    // bug12602: close could fail on full disk
+	  mx->error++;	    // mythtv#244: close could fail on full disk
 	  if (mx->error <= 0) mx->error = 1; // avoid int rollover to zero
 	  LOG(VB_GENERAL, LOG_ERR,
 	      QString("close failed: %1")
@@ -703,7 +703,7 @@ void init_multiplex( multiplex_t *mx, sequence_t *seq_head,
 	int i = 0;
 	uint32_t data_rate = 0;
 
-	mx->error = 0; // bug12602: added to catch full disk write failures
+	mx->error = 0; // mythtv#244: added to catch full disk write failures
 	mx->fill_buffers = fill_buffers;
 	mx->video_delay = video_delay;
 	mx->audio_delay = audio_delay;

--- a/mythtv/programs/mythtranscode/external/replex/multiplex.cpp
+++ b/mythtv/programs/mythtranscode/external/replex/multiplex.cpp
@@ -298,7 +298,14 @@ static void writeout_video(multiplex_t *mx)
 	//estimate next pts based on bitrate of this stream and data written
 	viu->dts = uptsdiff(viu->dts + ((nlength*viu->ptsrate)>>8), 0);
 
-	write(mx->fd_out, outbuf.data(), written);
+	if (write(mx->fd_out, outbuf.data(), written) != written) {
+	  mx->error++;
+	  if (mx->error <= 0) mx->error = 1; // avoid int rollover to zero
+	  if (mx->error < 10) // bug12602: log only first few failures
+	    LOG(VB_GENERAL, LOG_ERR,
+		QString("%1 writes failed: %2")
+		.arg(mx->error).arg(strerror(errno)));
+	}
 
 #ifdef OUT_DEBUG
 	LOG(VB_GENERAL, LOG_DEBUG, "VPTS");
@@ -578,7 +585,8 @@ void check_times( multiplex_t *mx, int *video_ok, aok_arr &ext_ok, int *start)
         (void)set_ok;
 #endif
 }
-void write_out_packs( multiplex_t *mx, int video_ok, aok_arr &ext_ok)
+
+int write_out_packs( multiplex_t *mx, int video_ok, aok_arr &ext_ok)
 {
 	if (video_ok && use_video(mx->viu.dts + mx->video_delay,
 	    mx->ext, ext_ok, mx->extcnt)) {
@@ -594,10 +602,10 @@ void write_out_packs( multiplex_t *mx, int video_ok, aok_arr &ext_ok)
 			writeout_padding(mx);
 		}
 	}
-	
+	return mx->error || 0;
 }
 
-void finish_mpg(multiplex_t *mx)
+int finish_mpg(multiplex_t *mx)
 {
 	int start=0;
 	int video_ok = 0;
@@ -642,9 +650,18 @@ void finish_mpg(multiplex_t *mx)
 	if (mx->otype == REPLEX_MPEG2)
 		write(mx->fd_out, mpeg_end.data(), 4);
 
+	if (close(mx->fd_out) < 0) {
+	  mx->error++;	    // bug12602: close could fail on full disk
+	  if (mx->error <= 0) mx->error = 1; // avoid int rollover to zero
+	  LOG(VB_GENERAL, LOG_ERR,
+	      QString("close failed: %1")
+	      .arg(strerror(errno)));
+	}
+
 	dummy_destroy(&mx->vdbuf);
 	for (int i=0; i<mx->extcnt;i++)
 		dummy_destroy(&mx->ext[i].dbuf);
+	return mx->error || 0;
 }
 
 static int get_ts_video_overhead(int pktsize, sequence_t *seq)
@@ -686,6 +703,7 @@ void init_multiplex( multiplex_t *mx, sequence_t *seq_head,
 	int i = 0;
 	uint32_t data_rate = 0;
 
+	mx->error = 0; // bug12602: added to catch full disk write failures
 	mx->fill_buffers = fill_buffers;
 	mx->video_delay = video_delay;
 	mx->audio_delay = audio_delay;

--- a/mythtv/programs/mythtranscode/external/replex/multiplex.h
+++ b/mythtv/programs/mythtranscode/external/replex/multiplex.h
@@ -86,11 +86,13 @@ struct multiplex_t {
 
 	int (*fill_buffers)(void *p, int f);
 	void *priv;
+	int error; // bug12602: added to catch full disk write failures
 };
 
 void check_times( multiplex_t *mx, int *video_ok, aok_arr &ext_ok, int *start);
-void write_out_packs( multiplex_t *mx, int video_ok, aok_arr &ext_ok);
-void finish_mpg(multiplex_t *mx);
+int write_out_packs( multiplex_t *mx, int video_ok, aok_arr &ext_ok);
+int finish_mpg(multiplex_t *mx);
+
 void init_multiplex( multiplex_t *mx, sequence_t *seq_head,
 		     audio_frame_t *extframe, int *exttype, const int *exttypcnt,
 		     uint64_t video_delay, uint64_t audio_delay, int fd,

--- a/mythtv/programs/mythtranscode/external/replex/multiplex.h
+++ b/mythtv/programs/mythtranscode/external/replex/multiplex.h
@@ -86,13 +86,12 @@ struct multiplex_t {
 
 	int (*fill_buffers)(void *p, int f);
 	void *priv;
-	int error; // bug12602: added to catch full disk write failures
+	int error; /* mythtv#244: added to catch full disk write failures */
 };
 
 void check_times( multiplex_t *mx, int *video_ok, aok_arr &ext_ok, int *start);
 int write_out_packs( multiplex_t *mx, int video_ok, aok_arr &ext_ok);
 int finish_mpg(multiplex_t *mx);
-
 void init_multiplex( multiplex_t *mx, sequence_t *seq_head,
 		     audio_frame_t *extframe, int *exttype, const int *exttypcnt,
 		     uint64_t video_delay, uint64_t audio_delay, int fd,

--- a/mythtv/programs/mythtranscode/external/replex/replex.cpp
+++ b/mythtv/programs/mythtranscode/external/replex/replex.cpp
@@ -2390,7 +2390,10 @@ static void do_replex(struct replex *rx)
 	while(1){
 		check_times( &mx, &video_ok, ext_ok, &start);
 
-		write_out_packs( &mx, video_ok, ext_ok);
+		if (write_out_packs( &mx, video_ok, ext_ok)) {
+			LOG(VB_GENERAL, LOG_ERR, "error while writing");
+			exit(1);
+		}
 	}
 }
 

--- a/mythtv/programs/mythtranscode/mpeg2fix.cpp
+++ b/mythtv/programs/mythtranscode/mpeg2fix.cpp
@@ -512,7 +512,7 @@ int MPEG2replex::WaitBuffers()
     if (m_done)
     {
         finish_mpg(m_mplex);
-	// bug12602: thread exit must return static, not stack
+	// mythtv#244: thread exit must return static, not stack
 	static int errorcount = 0;
 	errorcount = m_mplex->error;
 	if (m_mplex->error) {
@@ -577,7 +577,7 @@ void MPEG2replex::Start()
     {
         check_times( &mx, &video_ok, ext_ok, &start);
         if (write_out_packs( &mx, video_ok, ext_ok)) {
-	  // bug12602: exiting here blocks the reading thread indefinitely;
+	  // mythtv#244: exiting here blocks the reading thread indefinitely;
 	  // maybe there is a way to fail it also?
 	  // LOG(VB_GENERAL, LOG_ERR, // or comment all this to fail until close
 	  //     QString("exiting thread after %1 write errors")
@@ -2627,13 +2627,12 @@ int MPEG2fixup::Start()
         }
     }
 
-
     m_rx.m_done = 1;
     pthread_mutex_lock( &m_rx.m_mutex );
     pthread_cond_signal(&m_rx.m_cond);
     pthread_mutex_unlock( &m_rx.m_mutex );
     int ex = REENCODE_OK;
-    void *errors; // bug12602: return error if any write or close failures
+    void *errors; // mythtv#244: return error if any write or close failures
     pthread_join(m_thread, &errors);
     if (*(int *)errors) {
       LOG(VB_GENERAL, LOG_ERR,


### PR DESCRIPTION
Fix for #244 which was originally https://code.mythtv.org/trac/ticket/12602

Explanation of the patch:

* multiplex.h:
  the mx multiplex structure gets a new "int error", the error count.
  write_out_packs and finish_mpg now return int, the error count (so 0 = success)
  currently unused: callers test the error count instead
* multiplex.c:
  if write() fails, increment error count
  log only first 10 failures so we don't flood syslog and cause it to drop messages
  if close() fails, increment error count
* mpeg2fix.cpp:
  copy error count to static variable and pass it to pthread_exit
  capture error count in pthread_join and log/fail if non-zero

This all causes mythtv to keep the original recording if disk fills during transcode, instead of truncating the recording.  Of course user will need to go free space larger than this recording for a successful transcode.

In mpeg2fix.cpp there is also a commented section where I tried to exit on first write failure. This just deadlocked the other thread. It might be possible to cancel the other thread if you wish to abort at first write error but I was unsure how to do this. As-is, we just continue to fail and return the failure count when the reader is done. I monitored with top and the size doesn't grow so I assume the data is just being dropped rather than filling memory, which is a good thing.