### PR TITLE
Use fully-decoded URL paths when translating to local paths

### DIFF
--- a/mythtv/libs/libmythbase/mythcorecontext.cpp
+++ b/mythtv/libs/libmythbase/mythcorecontext.cpp
@@ -753,11 +753,9 @@ QString MythCoreContext::GenMythURL(QString host, QString port, QString path, QS
 
 QString MythCoreContext::GenMythURL(QString host, int port, QString path, QString storageGroup)
 {
-    QString ret;
+    QUrl ret;
 
-    QString m_storageGroup;
     QString m_host;
-    QString m_port;
 
     QHostAddress addr(host);
     if (!addr.isNull())
@@ -767,35 +765,28 @@ QString MythCoreContext::GenMythURL(QString host, int port, QString path, QStrin
                                           "(ID). This is invalid.").arg(host).arg(path));
     }
 
-
-    if (!storageGroup.isEmpty())
-        m_storageGroup = storageGroup + "@";
-
     m_host = host;
 
     // Basically if it appears to be an IPv6 IP surround the IP with [] otherwise don't bother
     if (!addr.isNull() && addr.protocol() == QAbstractSocket::IPv6Protocol)
         m_host = "[" + addr.toString().toLower() + "]";
 
+    ret.setScheme("myth");
+    if (!storageGroup.isEmpty())
+        ret.setUserName(storageGroup);
+    ret.setHost(m_host);
     if (port > 0 && port != 6543)
-        m_port = QString(":%1").arg(port);
-    else
-        m_port = "";
-
-    QString seperator = "/";
-    if (path.startsWith("/"))
-        seperator = "";
-
-    // IPv6 addresses may contain % followed by a digit which causes .arg()
-    // to fail, so use append instead.
-    ret = QString("myth://").append(m_storageGroup).append(m_host).append(m_port).append(seperator).append(path);
+        ret.setPort(port);
+  if (!path.startsWith("/"))
+	  path = QString("/") + path;
+    ret.setPath(path);
 
 #if 0
     LOG(VB_GENERAL, LOG_DEBUG, LOC +
-        QString("GenMythURL returning %1").arg(ret));
+        QString("GenMythURL returning %1").arg(ret.toString()));
 #endif
 
-    return ret;
+    return ret.toString();
 }
 
 QString MythCoreContext::GetMasterHostPrefix(const QString &storageGroup,

--- a/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.cpp
@@ -59,10 +59,10 @@ void FileServerHandler::connectionClosed(MythSocket *socket)
     }
 }
 
-QString FileServerHandler::LocalFilePath(const QUrl &url,
+QString FileServerHandler::LocalFilePath(const QString &path,
                                            const QString &wantgroup)
 {
-    QString lpath = url.path();
+    QString lpath = QString(path);
 
     if (lpath.section('/', -2, -2) == "channels")
     {
@@ -121,7 +121,7 @@ QString FileServerHandler::LocalFilePath(const QUrl &url,
             if (!wantgroup.isEmpty())
             {
                 sgroup.Init(wantgroup);
-                lpath = url.toString();
+                lpath = QString(path);
             }
             else
             {
@@ -135,7 +135,7 @@ QString FileServerHandler::LocalFilePath(const QUrl &url,
                 LOG(VB_FILE, LOG_INFO,
                         QString("LocalFilePath(%1 '%2'), found through "
                                 "exhaustive search at '%3'")
-                            .arg(url.toString()).arg(opath).arg(lpath));
+                            .arg(path).arg(opath).arg(lpath));
             }
             else
             {
@@ -228,7 +228,7 @@ bool FileServerHandler::HandleAnnounce(MythSocket *socket,
     }
 
     QStringList::const_iterator it = slist.begin();
-    QUrl qurl           = *(++it);
+    QString path        = *(++it);
     QString wantgroup   = *(++it);
 
     QStringList checkfiles;
@@ -258,34 +258,33 @@ bool FileServerHandler::HandleAnnounce(MythSocket *socket,
             return true;
         }
 
-        QString basename = qurl.path();
-        if (basename.isEmpty())
+        if (path.isEmpty())
         {
             LOG(VB_GENERAL, LOG_ERR, QString("FileTransfer write "
-                    "filename is empty in url '%1'.")
-                    .arg(qurl.toString()));
+                    "filename is empty in path '%1'.")
+                    .arg(path));
 
             slist << "ERROR" << "filetransfer_filename_empty";
             socket->WriteStringList(slist);
             return true;
         }
 
-        if ((basename.contains("/../")) ||
-            (basename.startsWith("../")))
+        if ((path.contains("/../")) ||
+            (path.startsWith("../")))
         {
             LOG(VB_GENERAL, LOG_ERR, QString("FileTransfer write "
                     "filename '%1' does not pass sanity checks.")
-                    .arg(basename));
+                    .arg(path));
 
             slist << "ERROR" << "filetransfer_filename_dangerous";
             socket->WriteStringList(slist);
             return true;
         }
 
-        filename = dir + "/" + basename;
+        filename = dir + "/" + path;
     }
     else
-        filename = LocalFilePath(qurl, wantgroup);
+        filename = LocalFilePath(path, wantgroup);
 
     QFileInfo finfo(filename);
     if (finfo.isDir())

--- a/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.h
+++ b/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.h
@@ -49,7 +49,7 @@ class PROTOSERVER_PUBLIC FileServerHandler : public SocketRequestHandler
                                  QStringList &slist);
     bool HandleDownloadFile(SocketHandler *socket, QStringList &slist);
 
-    QString LocalFilePath(const QUrl &url, const QString &wantgroup);
+    QString LocalFilePath(const QString &path, const QString &wantgroup);
     void RunDeleteThread(void);
 
     QMap<int, FileTransfer*>        m_ftMap;

--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -34,7 +34,6 @@ using namespace std;
 #include <QWriteLocker>
 #include <QRegExp>
 #include <QEvent>
-#include <QUrl>
 #include <QTcpServer>
 #include <QTimer>
 #include <QNetworkInterface>
@@ -1909,10 +1908,11 @@ void MainServer::HandleAnnounce(QStringList &slist, QStringList commands,
         LOG(VB_NETWORK, LOG_INFO, LOC +
             QString("adding: %1 as a remote file transfer") .arg(commands[2]));
         QStringList::const_iterator it = slist.begin();
-        QUrl qurl = *(++it);
+        QString path = *(++it);
         QString wantgroup = *(++it);
         QString filename;
         QStringList checkfiles;
+
         for (++it; it != slist.end(); ++it)
             checkfiles += *it;
 
@@ -1945,35 +1945,31 @@ void MainServer::HandleAnnounce(QStringList &slist, QStringList commands,
                 return;
             }
 
-            QString basename = qurl.path();
-            if (qurl.hasFragment())
-                basename += "#" + qurl.fragment();
-
-            if (basename.isEmpty())
+            if (path.isEmpty())
             {
                 LOG(VB_GENERAL, LOG_ERR, LOC +
-                    QString("FileTransfer write filename is empty in url '%1'.")
-                        .arg(qurl.toString()));
+                    QString("FileTransfer write filename is empty in path '%1'.")
+                        .arg(path));
                 errlist << "filetransfer_filename_empty";
                 socket->WriteStringList(errlist);
                 return;
             }
 
-            if ((basename.contains("/../")) ||
-                (basename.startsWith("../")))
+            if ((path.contains("/../")) ||
+                (path.startsWith("../")))
             {
                 LOG(VB_GENERAL, LOG_ERR, LOC +
                     QString("FileTransfer write filename '%1' does not pass "
-                            "sanity checks.") .arg(basename));
+                            "sanity checks.") .arg(path));
                 errlist << "filetransfer_filename_dangerous";
                 socket->WriteStringList(errlist);
                 return;
             }
 
-            filename = dir + "/" + basename;
+            filename = dir + "/" + path;
         }
         else
-            filename = LocalFilePath(qurl, wantgroup);
+            filename = LocalFilePath(path, wantgroup);
 
         if (filename.isEmpty())
         {
@@ -8140,12 +8136,9 @@ void MainServer::SetExitCode(int exitCode, bool closeApplication)
         QCoreApplication::exit(m_exitCode);
 }
 
-QString MainServer::LocalFilePath(const QUrl &url, const QString &wantgroup)
+QString MainServer::LocalFilePath(const QString &path, const QString &wantgroup)
 {
-    QString lpath = url.path();
-
-    if (url.hasFragment())
-        lpath += "#" + url.fragment();
+    QString lpath = QString(path);
 
     if (lpath.section('/', -2, -2) == "channels")
     {
@@ -8204,7 +8197,7 @@ QString MainServer::LocalFilePath(const QUrl &url, const QString &wantgroup)
             if (!wantgroup.isEmpty())
             {
                 sgroup.Init(wantgroup);
-                lpath = url.toString();
+                lpath = QString(path);
             }
             else
             {
@@ -8218,12 +8211,12 @@ QString MainServer::LocalFilePath(const QUrl &url, const QString &wantgroup)
                 LOG(VB_FILE, LOG_INFO, LOC +
                     QString("LocalFilePath(%1 '%2'), found file through "
                             "exhaustive search at '%3'")
-                        .arg(url.toString()).arg(opath).arg(lpath));
+                        .arg(path).arg(opath).arg(lpath));
             }
             else
             {
                 LOG(VB_GENERAL, LOG_ERR, LOC + QString("ERROR: LocalFilePath "
-                    "unable to find local path for '%1'.") .arg(url.toString()));
+                    "unable to find local path for '%1'.") .arg(path));
                 lpath = "";
             }
 

--- a/mythtv/programs/mythbackend/mainserver.h
+++ b/mythtv/programs/mythbackend/mainserver.h
@@ -276,7 +276,7 @@ class MainServer : public QObject, public MythSocketCBs
     FileTransfer *GetFileTransferByID(int id);
     FileTransfer *GetFileTransferBySock(MythSocket *socket);
 
-    QString LocalFilePath(const QUrl &url, const QString &wantgroup);
+    QString LocalFilePath(const QString &path, const QString &wantgroup);
 
     int GetfsID(QList<FileSystemInfo>::iterator fsInfo);
 


### PR DESCRIPTION
Previously it was not possible to access files with certain characters in them
remotely (such as music tracks with quotes in the title) because the characters
are URL %-escaped, e.g.:

    ProcessRequest storagegroup.cpp:608 (FindFile) SG(Music): FindFile: Searching for '/Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(Music): FindFileDir: Checking '/storage/music' for '/storage/music//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(Default): FindFileDir: Checking '/var/lib/mythtv/recordings' for '/var/lib/mythtv/recordings//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythtv/.mythtv/Banners' for '/var/lib/mythtv/.mythtv/Banners//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythtv/.mythtv/Coverart' for '/var/lib/mythtv/.mythtv/Coverart//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/backups/mythtv' for '/var/backups/mythtv//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythtv/recordings' for '/var/lib/mythtv/recordings//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythtv/.mythtv/Fanart' for '/var/lib/mythtv/.mythtv/Fanart//Enslaved - Isa/01-Intro: %22Gree  Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/storage/music' for '/storage/music//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythtv/.mythtv/MusicArt' for '/var/lib/mythtv/.mythtv/MusicArt//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/storage/media' for '/storage/media//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythtv/.mythtv/Screenshots' for '/var/lib/mythtv/.mythtv/Screenshots//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythtv/.mythtv/Trailers' for '/var/lib/mythtv/.mythtv/Trailers//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:639 (FindFileDir) SG(): FindFileDir: Checking '/var/lib/mythvideo' for '/var/lib/mythvideo//Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'
    ProcessRequest storagegroup.cpp:622 (FindFile) SG(Music): FindFile: Unable to find '/Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'!
    ProcessRequest mainserver.cpp:7968 (LocalFilePath) MainServer: ERROR: LocalFilePath unable to find local path for '/Enslaved - Isa/01-Intro: %22Green Reflection%22.flac'.

This is because the actual file on disk is not %-encoded, the actual filename
is `01-Intro: "Green Reflection".flac`. If the filename had been %-encoded,
then the resulting %'s would, I beleive, have themselves been encoded as %25 by
this point.

To fix this switch from `url.toString()` to `url.path(QUrl::FullyDecoded)`.
Note that:
- `url.toString()` does not accept `QUrl::FullyDecoded`. That produces the
  error message:
  `QUrl: QUrl::FullyDecoded is not permitted when reconstructing the full URL`
- at this point in the code the URL only contains a path element and a possible
  fragment (handled separately in the code). The is no `scheme://` or hostname
  etc). I think the only reason it is a `QUrl` at this point and not a
  `QString` is the fragment handling.
- a path (not a full URL) is what `StorageGroup::FindFile` and friends expect,
  they take `QString` not `QUrl`.

Also add `QUrl::FullyDecoded` to some existing uses of `url.path()` in these
code paths.

There seems to be two very similar copies of this code (libmythprotoserver and
in mythbackend/mainserver directly) so I have adjusted both. It's not entirely
clear to me where they are each used from, but I have tested (on a backport to
fixes/29):

- recording playback (both preexisting recordings and live TV), the filenames
  here are autogenerated and are not expected to contain any quotable
  characters AFAIK.
- mythvideo (filenames with and without quote characters).
- mythmusic (filenames with and without quote characters).
- old gallery plugin (only filenames without quotes).

Signed-off-by: Ian Campbell <ijc@hellion.org.uk>

(filed as https://code.mythtv.org/trac/ticket/13315)