### PR TITLE
Include damaged status in program details attribute list.

### DIFF
--- a/mythtv/programs/mythfrontend/progdetails.cpp
+++ b/mythtv/programs/mythfrontend/progdetails.cpp
@@ -449,6 +449,8 @@ void ProgDetails::loadPage(void)
         attr += tr("720p Resolution") + ", ";
     if  (videoprop & VID_1080)
         attr += tr("1080i/p Resolution") + ", ";
+    if  (videoprop & VID_DAMAGED)
+        attr += tr("Damaged") + ", ";
 
     if (subtype & SUB_HARDHEAR)
         attr += tr("CC","Closed Captioned") + ", ";


### PR DESCRIPTION
This flag was added in https://github.com/MythTV/mythtv/commit/72d437001e74c57f64217de14c383e22e081a857

Signed-off-by: Ian Campbell <ijc@hellion.org.uk>

(filed as https://code.mythtv.org/trac/ticket/13316)