### PR TITLE
Fix python bindings not reconnecting to database after a long pause.

### DIFF
--- a/mythtv/bindings/python/MythTV/_conn_mysqldb.py
+++ b/mythtv/bindings/python/MythTV/_conn_mysqldb.py
@@ -34,12 +34,12 @@ class LoggedCursor( MySQLdb.cursors.Cursor ):
         super(LoggedCursor, self).__init__(connection)
         self.log = None
         self.ping = ref(self._ping121)
-        if MySQLdb.version_info >= ('1','2','2'):
+        if MySQLdb.version_info[:3] >= (1, 2, 2):
             self.ping = ref(self._ping122)
         self.ping()
 
-    def _ping121(self): self._get_db().ping(True)
-    def _ping122(self): self._get_db().ping()
+    def _ping121(self): self._get_db().ping()
+    def _ping122(self): self._get_db().ping(True)
 
     def _sanitize(self, query): return query.replace('?', '%s')
 


### PR DESCRIPTION
Fix a version check that ensures the python MySQLdb library auto
reconnects in v1.2.2 or higher (earlier versions default to
auto-reconnect).

trac ticket: https://code.mythtv.org/trac/ticket/13320