### PR TITLE
mythcommflag: add 4 settings to enhance logo detection.

### DIFF
--- a/mythtv/programs/mythcommflag/ClassicLogoDetector.cpp
+++ b/mythtv/programs/mythcommflag/ClassicLogoDetector.cpp
@@ -49,6 +49,12 @@ ClassicLogoDetector::ClassicLogoDetector(ClassicCommDetector* commdetector,
     commDetectLogoBadEdgeThreshold =
         gCoreContext->GetSetting("CommDetectLogoBadEdgeThreshold", "0.85")
         .toDouble();
+    commDetectLogoLocation =
+        gCoreContext->GetSetting("CommDetectLogoLocation", "");
+    commDetectLogoWidthRatio =
+        gCoreContext->GetNumSetting("CommDetectLogoWidthRatio", 4);
+    commDetectLogoHeightRatio =
+        gCoreContext->GetNumSetting("CommDetectLogoHeightRatio", 4);
 }
 
 unsigned int ClassicLogoDetector::getRequiredAvailableBufferForSearch()
@@ -239,8 +245,8 @@ bool ClassicLogoDetector::searchForLogo(MythPlayer* player)
         cerr << "Hit ENTER to continue" << endl;
         getchar();
 #endif
-        if (((logoMaxX - logoMinX) < (width / 4)) &&
-            ((logoMaxY - logoMinY) < (height / 4)) &&
+        if (((logoMaxX - logoMinX) < (width / commDetectLogoWidthRatio)) &&
+            ((logoMaxY - logoMinY) < (height / commDetectLogoHeightRatio)) &&
             (pixelsInMask > minPixelsInMask))
         {
             logoInfoAvailable = true;
@@ -461,14 +467,22 @@ void ClassicLogoDetector::DetectEdges(VideoFrame *frame, EdgeMaskEntry *edges,
 
     for (y = commDetectBorder + r; y < (height - commDetectBorder - r); y++)
     {
-        if ((y > (height/4)) && (y < (height * 3 / 4)))
+        if (
+            (commDetectLogoLocation.contains("N") && (y > (height/4))) ||
+            (commDetectLogoLocation.contains("S") && (y < (height * 3 / 4))) ||
+            ((y > (height/4)) && (y < (height * 3 / 4)))
+            )
             continue;
 
         for (x = commDetectBorder + r; x < (width - commDetectBorder - r); x++)
         {
             int edgeCount = 0;
 
-            if ((x > (width/4)) && (x < (width * 3 / 4)))
+            if (
+                (commDetectLogoLocation.contains("W") && (x > (width/4))) ||
+                (commDetectLogoLocation.contains("E") && (x < (width * 3 / 4))) ||
+                ((x > (width/4)) && (x < (width * 3 / 4)))
+                )
                 continue;
 
             pos = y * width + x;

--- a/mythtv/programs/mythcommflag/ClassicLogoDetector.cpp
+++ b/mythtv/programs/mythcommflag/ClassicLogoDetector.cpp
@@ -55,6 +55,8 @@ ClassicLogoDetector::ClassicLogoDetector(ClassicCommDetector* commdetector,
         gCoreContext->GetNumSetting("CommDetectLogoWidthRatio", 4);
     commDetectLogoHeightRatio =
         gCoreContext->GetNumSetting("CommDetectLogoHeightRatio", 4);
+    commDetectLogoMinPixels =
+        gCoreContext->GetNumSetting("CommDetectLogoMinPixels", 0);
 }
 
 unsigned int ClassicLogoDetector::getRequiredAvailableBufferForSearch()
@@ -107,7 +109,7 @@ bool ClassicLogoDetector::searchForLogo(MythPlayer* player)
     // I believe the minimum threshold should vary with the video's area.
     // I am using 1280x720 (for 720p) video as the baseline.
     // This should improve logo detection for SD video.
-    int minPixelsInMask = 50 * (width*height) / (1280*720 / 16);
+    int minPixelsInMask = commDetectLogoMinPixels ? commDetectLogoMinPixels : 50 * (width*height) / (1280*720 / 16);
 
     for (i = 0; edgeDiffs[i] != 0 && !logoInfoAvailable; i++)
     {

--- a/mythtv/programs/mythcommflag/ClassicLogoDetector.h
+++ b/mythtv/programs/mythcommflag/ClassicLogoDetector.h
@@ -37,6 +37,7 @@ class ClassicLogoDetector : public LogoDetectorBase
     int commDetectLogoSecondsNeeded;
     int commDetectLogoWidthRatio;
     int commDetectLogoHeightRatio;
+    int commDetectLogoMinPixels;
     double commDetectLogoGoodEdgeThreshold;
     double commDetectLogoBadEdgeThreshold;
     QString commDetectLogoLocation;

--- a/mythtv/programs/mythcommflag/ClassicLogoDetector.h
+++ b/mythtv/programs/mythcommflag/ClassicLogoDetector.h
@@ -35,8 +35,11 @@ class ClassicLogoDetector : public LogoDetectorBase
     int commDetectLogoSamplesNeeded;
     int commDetectLogoSampleSpacing;
     int commDetectLogoSecondsNeeded;
+    int commDetectLogoWidthRatio;
+    int commDetectLogoHeightRatio;
     double commDetectLogoGoodEdgeThreshold;
     double commDetectLogoBadEdgeThreshold;
+    QString commDetectLogoLocation;
 
     EdgeMaskEntry *edgeMask;
 


### PR DESCRIPTION
My patch allows to spot where to lookup the logo. 

* CommDetectLogoLocation: Choices include N (North), S (South), E (East),  W (West). The direction you choose specifies where to lookup the logo.
* CommDetectLogoWidthRatio: To specify the maximum width of the logo.
* CommDetectLogoHeightRatio: To specify the maximum height of the logo.
* CommDetectLogoMinPixels: The logo must contain more than min pixels.

_____
For the french TV channels, the reliable method to flag commercials is by logo detection. Unfortunately, the current method works fine if there is a only one logo displayed. The CSA is the French public authority of regulation of the audio-visual one. It adds another logo to protect children against harmful program. Here is a example here [1], the CSA logo is located at the bottom right corner.

Below is my commercial flagging setup and it works very fine :

```
CommDetectLogoSamplesNeeded=240
CommDetectLogoSampleSpacing=15
CommDetectLogoLocation=NE
CommDetectLogoWidthRatio=8
CommDetectLogoHeightRatio=6
CommDetectLogoBorder=64
CommDetectLogoGoodEdgeThreshold=0.80
CommercialSkipMethod=4
CommDetectLogoMinPixels=1200
```

[1] https://app.box.com/s/qwzowxodbcee0y05s6cejip75ukdrnta
track ticket: https://code.mythtv.org/trac/ticket/13335