### PR TITLE
mythcommflag: Abort flagging if no logo detected.

### DIFF
--- a/mythtv/programs/mythcommflag/ClassicCommDetector.cpp
+++ b/mythtv/programs/mythcommflag/ClassicCommDetector.cpp
@@ -391,7 +391,14 @@ bool ClassicCommDetector::go()
         }
         LOG(VB_GENERAL, LOG_INFO, "Finding Logo");
 
-        logoInfoAvailable = logoDetector->searchForLogo(player);
+        if ( !(logoInfoAvailable = logoDetector->searchForLogo(player)))
+        {
+            if (COMM_DETECT_LOGO == commDetectMethod) {
+
+                LOG(VB_COMMFLAG, LOG_WARNING, "No logo found, abort flagging.");
+                return false;
+            }
+        }
 
         if (showProgress)
         {


### PR DESCRIPTION
If method used is logo Detection only and no logo is found then don't scan
the video.
track ticket: https://code.mythtv.org/trac/ticket/13342