### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/mythplugins/mytharchive/mythburn/scripts/mythburn.py
+++ b/mythplugins/mytharchive/mythburn/scripts/mythburn.py
@@ -240,16 +240,16 @@ class FontDef(object):
         self.font = None
 
     def getFont(self):
-        if self.font == None:
+        if self.font is None:
             self.font = ImageFont.truetype(self.fontFile, int(self.size))
 
         return self.font
 
     def drawText(self, text, color=None):
-        if self.font == None:
+        if self.font is None:
             self.font = ImageFont.truetype(self.fontFile, int(self.size))
 
-        if color == None:
+        if color is None:
             color = self.color
 
         textwidth, textheight = self.font.getsize(text)
@@ -1138,7 +1138,7 @@ def paintText(draw, image, text, node, color = None,
     """Takes a piece of text and draws it onto an image inside a bounding box."""
     #The text is wider than the width of the bounding box
 
-    if x == None:
+    if x is None:
         x = getScaledAttribute(node, "x") 
         y = getScaledAttribute(node, "y")
         width = getScaledAttribute(node, "w")
@@ -1146,7 +1146,7 @@ def paintText(draw, image, text, node, color = None,
 
     font = themeFonts[node.attributes["font"].value]
 
-    if color == None:
+    if color is None:
         if node.hasAttribute("colour"):
             color = node.attributes["colour"].value
         elif node.hasAttribute("color"):
@@ -3462,7 +3462,7 @@ def drawThemeItem(page, itemsonthispage, itemnum, menuitem, bgimage, draw,
         else:
             write( "Dont know how to process %s" % node.nodeName)
 
-    if drawmask == None:
+    if drawmask is None:
         return
 
     #Draw the selection mask for this item
@@ -3647,7 +3647,7 @@ def createMenu(screensize, screendpi, numberofitems):
                             picture = Image.open(imagefile, "r").resize((previeww[itemsonthispage-1], previewh[itemsonthispage-1]))
                             picture = picture.convert("RGBA")
                             imagemaskfile = os.path.join(previewpath, "mask-i%d.png" % itemsonthispage)
-                            if previewmask[itemsonthispage-1] != None:
+                            if previewmask[itemsonthispage-1] is not None:
                                 bgimage.paste(picture, (previewx[itemsonthispage-1], previewy[itemsonthispage-1]), previewmask[itemsonthispage-1])
                             else:
                                 bgimage.paste(picture, (previewx[itemsonthispage-1], previewy[itemsonthispage-1]))
@@ -3844,7 +3844,7 @@ def createChapterMenu(screensize, screendpi, numberofitems):
                             picture = Image.open(imagefile, "r").resize((previeww[previewchapter], previewh[previewchapter]))
                             picture = picture.convert("RGBA")
                             imagemaskfile = os.path.join(previewpath, "mask-i%d.png" % previewchapter)
-                            if previewmask[previewchapter] != None:
+                            if previewmask[previewchapter] is not None:
                                 bgimage.paste(picture, (previewx[previewchapter], previewy[previewchapter]), previewmask[previewchapter])
                             else:
                                 bgimage.paste(picture, (previewx[previewchapter], previewy[previewchapter]))
@@ -3989,7 +3989,7 @@ def createDetailsPage(screensize, screendpi, numberofitems):
                         picture = Image.open(imagefile, "r").resize((previeww, previewh))
                         picture = picture.convert("RGBA")
                         imagemaskfile = os.path.join(previewpath, "mask-i%d.png" % 1)
-                        if previewmask != None:
+                        if previewmask is not None:
                             bgimage.paste(picture, (previewx, previewy), previewmask)
                         else:
                             bgimage.paste(picture, (previewx, previewy))

--- a/mythplugins/mythgame/mythgame/scripts/giantbomb/giantbomb_api.py
+++ b/mythplugins/mythgame/mythgame/scripts/giantbomb/giantbomb_api.py
@@ -167,7 +167,7 @@ class gamedbQueries():
 
 
     def textUtf8(self, text):
-        if text == None:
+        if text is None:
             return text
         try:
             return unicode(text, 'utf8')
@@ -268,15 +268,15 @@ class gamedbQueries():
         return If there is not enough information to make a date then return an empty string
         '''
         try:
-            if gameElement.find('expected_release_year').text != None:
+            if gameElement.find('expected_release_year').text is not None:
                 year = gameElement.find('expected_release_year').text
             else:
                 year = None
-            if gameElement.find('expected_release_quarter').text != None:
+            if gameElement.find('expected_release_quarter').text is not None:
                 quarter = gameElement.find('expected_release_quarter').text
             else:
                 quarter = None
-            if gameElement.find('expected_release_month').text != None:
+            if gameElement.find('expected_release_month').text is not None:
                 month = gameElement.find('expected_release_month').text
             else:
                 month = None
@@ -416,7 +416,7 @@ class gamedbQueries():
 
         items = queryXslt(queryResult)
 
-        if items.getroot() != None:
+        if items.getroot() is not None:
             if len(items.xpath('//item')):
                 sys.stdout.write(etree.tostring(items, encoding='UTF-8', method="xml", xml_declaration=True, pretty_print=True, ))
         sys.exit(0)
@@ -446,7 +446,7 @@ class gamedbQueries():
             gamebombXpath[key] = self.FuncDict[key]
         items = gameXslt(videoResult)
 
-        if items.getroot() != None:
+        if items.getroot() is not None:
             if len(items.xpath('//item')):
                 sys.stdout.write(etree.tostring(items, encoding='UTF-8', method="xml", xml_declaration=True, pretty_print=True, ))
         sys.exit(0)

--- a/mythtv/bindings/python/MythTV/ttvdb/tvdbXslt.py
+++ b/mythtv/bindings/python/MythTV/ttvdb/tvdbXslt.py
@@ -219,7 +219,7 @@ class xpathFunctions(object):
             for image in xpathFilter(args[0][0]):
                 # print("im %r" % image)
                 # print(etree.tostring(image, method="xml", xml_declaration=False, pretty_print=True, ))
-                if image.find('fileName') == None:
+                if image.find('fileName') is None:
                     continue
                 # print("im2 %r" % image)
                 tmpElement = etree.XML(u'<image></image>')
@@ -243,7 +243,7 @@ class xpathFunctions(object):
     # end imageElements()
 
     def textUtf8(self, text):
-        if text == None:
+        if text is None:
             return text
         try:
             return unicode(text, 'utf8')

--- a/mythtv/bindings/python/MythTV/ttvdb/tvdb_api.py
+++ b/mythtv/bindings/python/MythTV/ttvdb/tvdb_api.py
@@ -1061,7 +1061,7 @@ class Tvdb:
 
             self._setShowData(sid, tag, value)
         # set language
-        if language == None:
+        if language is None:
             language = self.config['language']
         self._setShowData(sid, u'language', language)
 

--- a/mythtv/bindings/python/tmdb3/tmdb3/cache_file.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/cache_file.py
@@ -381,7 +381,7 @@ class FileEngine( CacheEngine ):
             # write storage slot definitions
             prev = None
             for d in data:
-                if prev == None:
+                if prev is None:
                     d.position = 4 + 16*size
                 else:
                     d.position = prev.position + prev.size

--- a/mythtv/contrib/imports/mirobridge/mirobridge.py
+++ b/mythtv/contrib/imports/mirobridge/mirobridge.py
@@ -537,7 +537,7 @@ def _can_int(x):
     >>> _can_int("A test")
     False
     """
-    if x == None:
+    if x is None:
         return False
     try:
         int(x)
@@ -571,7 +571,7 @@ def sanitiseFileName(name):
     return a sanitised valid file name
     '''
     global filename_char_filter
-    if name == None or name == u'':
+    if name is None or name == u'':
         return u'_'
     for char in filename_char_filter:
         name = name.replace(char, u'_')
@@ -793,7 +793,7 @@ def rtnAbsolutePath(relpath, filetype=u'mythvideo'):
     return an absolute path and file name
     return the relpath sting if the file does not actually exist in the absolute path location
     '''
-    if relpath == None or relpath == u'':
+    if relpath is None or relpath == u'':
         return relpath
 
     # There is a chance that this is already an absolute path
@@ -1264,7 +1264,7 @@ def getStartEndTimes(duration, downloadedTime):
                  starttime.strftime('%Y-%m-%d %H:%M:%S'),
                  starttime.strftime('%Y%m%d%H%M%S')]
 
-    if downloadedTime != None:
+    if downloadedTime is not None:
         try:
             dummy = downloadedTime.strftime('%Y-%m-%d')
         except ValueError:
@@ -1416,7 +1416,7 @@ def createRecordedRecords(item):
     ffmpeg_details = metadata.getVideoDetails(item[u'videoFilename'])
     start_end = getStartEndTimes(ffmpeg_details[u'duration'], item[u'downloadedTime'])
 
-    if item[u'releasedate'] == None:
+    if item[u'releasedate'] is None:
         item[u'releasedate'] = item[u'downloadedTime']
     try:
         dummy = item[u'releasedate'].strftime('%Y-%m-%d')
@@ -1444,12 +1444,12 @@ def createRecordedRecords(item):
     tmp_recorded[u'hostname'] = localhostname
     tmp_recorded[u'lastmodified'] = tmp_recorded[u'endtime']
     tmp_recorded[u'filesize'] = item[u'size']
-    if item[u'releasedate'] != None:
+    if item[u'releasedate'] is not None:
         tmp_recorded[u'originalairdate'] = item[u'releasedate'].strftime('%Y-%m-%d')
 
     basename = setSymbolic(item[u'videoFilename'], u'default', u"%s_%s" % \
                                     (channel_id, start_end[2]), allow_symlink=True)
-    if basename != None:
+    if basename is not None:
         tmp_recorded[u'basename'] = basename
     else:
         logger.critical(u"The file (%s) must exist to create a recorded record" % \
@@ -1472,7 +1472,7 @@ def createRecordedRecords(item):
 
     tmp_recordedprogram[u'category'] = u"Miro"
     tmp_recordedprogram[u'category_type'] = u"series"
-    if item[u'releasedate'] != None:
+    if item[u'releasedate'] is not None:
         tmp_recordedprogram[u'airdate'] = item[u'releasedate'].strftime('%Y')
         tmp_recordedprogram[u'originalairdate'] = item[u'releasedate'].strftime('%Y-%m-%d')
     tmp_recordedprogram[u'stereo'] = ffmpeg_details[u'stereo']
@@ -1524,14 +1524,14 @@ def createVideometadataRecord(item):
     for key in details.keys():
         videometadata[key] = details[key]
 
-    if item[u'releasedate'] == None:
+    if item[u'releasedate'] is None:
         item[u'releasedate'] = item[u'downloadedTime']
     try:
         dummy = item[u'releasedate'].strftime('%Y-%m-%d')
     except ValueError:
         item[u'releasedate'] = item[u'downloadedTime']
 
-    if item[u'releasedate'] != None:
+    if item[u'releasedate'] is not None:
         videometadata[u'year'] = item[u'releasedate'].strftime('%Y')
         videometadata[u'releasedate'] = item[u'releasedate'].strftime('%Y-%m-%d')
     videometadata[u'length'] = ffmpeg_details[u'duration']/60
@@ -1544,7 +1544,7 @@ def createVideometadataRecord(item):
         videofile = setSymbolic(item[u'videoFilename'], u'mythvideo', "%s/%s - %s" % \
                             (sympath, sanitiseFileName(item[u'channelTitle']),
                              sanitiseFileName(item[u'title'])), allow_symlink=True)
-        if videofile != None:
+        if videofile is not None:
             videometadata[u'filename'] = videofile
             if not local_only and videometadata[u'filename'][0] != u'/':
                 videometadata[u'host'] = localhostname.lower()
@@ -1565,14 +1565,14 @@ def createVideometadataRecord(item):
         elif item[u'channel_icon'] and not item[u'channelTitle'].lower() in channel_icon_override:
             filename = setSymbolic(item[u'channel_icon'], u'posterdir', u"%s" % \
                                 (sanitiseFileName(item[u'channelTitle'])))
-            if filename != None:
+            if filename is not None:
                 videometadata[u'coverfile'] = filename
         else:
             if item[u'item_icon']:
                 filename = setSymbolic(item[u'item_icon'], u'posterdir', u"%s - %s" % \
                                         (sanitiseFileName(item[u'channelTitle']),
                                          sanitiseFileName(item[u'title'])))
-                if filename != None:
+                if filename is not None:
                     videometadata[u'coverfile'] = filename
     else:
         videometadata[u'coverfile'] = item[u'channel_icon']
@@ -1582,7 +1582,7 @@ def createVideometadataRecord(item):
             filename = setSymbolic(item[u'screenshot'], u'episodeimagedir', u"%s - %s" % \
                                         (sanitiseFileName(item[u'channelTitle']),
                                          sanitiseFileName(item[u'title'])))
-            if filename != None:
+            if filename is not None:
                 videometadata[u'screenshot'] = filename
     else:
         if item[u'screenshot']:
@@ -1818,7 +1818,7 @@ def updateMythRecorded(items):
     # Add new Miro unwatched videos to MythTV'd data base
     for item in items_copy:
         # Do not create records for Miro video files when Miro has a corrupt or missing file name
-        if item[u'videoFilename'] == None:
+        if item[u'videoFilename'] is None:
             continue
         # Do not create records for Miro video files that do not exist
         if not os.path.isfile(os.path.realpath(item[u'videoFilename'])):
@@ -2021,7 +2021,7 @@ def updateMythVideo(items):
                 result = takeScreenShot(item[u'videoFilename'], screenshot_mythvideo, size_limit=False)
             except:
                 result = None
-            if result != None:
+            if result is not None:
                 item[u'screenshot'] = screenshot_mythvideo
         tmp_array = createVideometadataRecord(item)
         videometadata = tmp_array[0]

--- a/mythtv/contrib/imports/mirobridge/mirobridge/metadata.py
+++ b/mythtv/contrib/imports/mirobridge/mirobridge/metadata.py
@@ -169,7 +169,7 @@ class MetaData(object):
         # If there is no Record rule then check ttvdb.com
         if not len(recordedRules_array):
             inetref = self.searchTvdb(title)
-            if inetref != None:     # Create a new rule for this Miro Channel title
+            if inetref is not None:     # Create a new rule for this Miro Channel title
                 ttvdbGraphics['inetref'] = inetref
                 self.makeRecordRule['title'] = title
                 self.makeRecordRule['inetref'] = inetref

--- a/mythtv/contrib/imports/mirobridge/mirobridge/mirobridge_interpreter_4_0_2.py
+++ b/mythtv/contrib/imports/mirobridge/mirobridge/mirobridge_interpreter_4_0_2.py
@@ -280,7 +280,7 @@ class MiroInterpreter(cmd.Cmd):
                         continue
 
                 # Any item without a proper file name needs to be removed as Miro metadata is corrupt
-                if it.get_filename() == None:
+                if it.get_filename() is None:
                     it.expire()
                     self.statistics[u'Miro_videos_deleted']+=1
                     logging.info(u'Unwatched video (%s) has been removed from Miro as item had no valid file name' % it.get_title())
@@ -314,7 +314,7 @@ class MiroInterpreter(cmd.Cmd):
                         continue
 
                 # Any item without a proper file name needs to be removed as Miro metadata is corrupt
-                if it.get_filename() == None:
+                if it.get_filename() is None:
                     it.expire()
                     self.statistics[u'Miro_videos_deleted']+=1
                     logging.info(u'Watched video (%s) has been removed from Miro as item had no valid file name' % it.get_title())

--- a/mythtv/contrib/imports/mirobridge/mirobridge/mirobridge_interpreter_6_0_0.py
+++ b/mythtv/contrib/imports/mirobridge/mirobridge/mirobridge_interpreter_6_0_0.py
@@ -292,7 +292,7 @@ class MiroInterpreter(cmd.Cmd):
 
                 # Any item without a proper file name needs to be removed
                 # as Miro metadata is corrupt
-                if it.get_filename() == None:
+                if it.get_filename() is None:
                     it.expire()
                     self.statistics[u'Miro_videos_deleted']+=1
                     logging.info(
@@ -327,7 +327,7 @@ u'Unwatched video (%s) has been removed from Miro as item had no valid file name
                         continue
 
                 # Any item without a proper file name needs to be removed as Miro metadata is corrupt
-                if it.get_filename() == None:
+                if it.get_filename() is None:
                     it.expire()
                     self.statistics[u'Miro_videos_deleted']+=1
                     logging.info(

--- a/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/uuiddb.py
+++ b/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/uuiddb.py
@@ -123,7 +123,7 @@ _uuid_db_instance = None
 def UuidDb():
     """Simple singleton wrapper with lazy initialization"""
     global _uuid_db_instance
-    if _uuid_db_instance == None:
+    if _uuid_db_instance is None:
         import config
         from smolt import get_config_attr
         _uuid_db_instance =  _UuidDb(get_config_attr("UUID_DB", os.path.expanduser('~/.smolt/uuiddb.cfg')))

--- a/mythtv/programs/scripts/hardwareprofile/sendProfile.py
+++ b/mythtv/programs/scripts/hardwareprofile/sendProfile.py
@@ -283,7 +283,7 @@ def mention_profile_web_view(opts, pub_uuid, admin):
 
 
 def get_proxies(opts):
-    if opts.httpproxy == None:
+    if opts.httpproxy is None:
         proxies = None
     else:
         proxies = {'http':opts.httpproxy}

--- a/mythtv/programs/scripts/hardwareprofile/smolt.py
+++ b/mythtv/programs/scripts/hardwareprofile/smolt.py
@@ -354,7 +354,7 @@ def ignoreDevice(device):
     ignore = 1
     if device.bus == 'Unknown' or device.bus == 'unknown':
         return 1
-    if device.vendorid in (0, None) and device.type == None:
+    if device.vendorid in (0, None) and device.type is None:
         return 1
     if device.bus == 'usb' and device.driver == 'hub':
         return 1
@@ -366,7 +366,7 @@ def ignoreDevice(device):
         return 1
     if device.bus == 'block' and device.type == 'DISK':
         return 1
-    if device.bus == 'usb_device' and device.type == None:
+    if device.bus == 'usb_device' and device.type is None:
         return 1
     return 0
 

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/bbciplayer/bbciplayer_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/bbciplayer/bbciplayer_api.py
@@ -349,7 +349,7 @@ class Videos(object):
         pubDate = datetime.datetime.now().strftime(self.common.pubDateFormat)
 
         # Set the display type for the link (Fullscreen, Web page, Game Console)
-        if self.userPrefs.find('displayURL') != None:
+        if self.userPrefs.find('displayURL') is not None:
             urlType = self.userPrefs.find('displayURL').text
         else:
             urlType = u'fullscreen'
@@ -519,7 +519,7 @@ class Videos(object):
         searchResultTree = []
         searchFilter = etree.XPath(u"//item")
         userSearchStrings = u'userSearchStrings'
-        if self.userPrefs.find(userSearchStrings) != None:
+        if self.userPrefs.find(userSearchStrings) is not None:
             userSearch = self.userPrefs.find(userSearchStrings).xpath('./userSearch')
             if len(userSearch):
                 for searchDetails in userSearch:
@@ -554,7 +554,7 @@ class Videos(object):
         # Create a structure of feeds that can be concurrently downloaded
         rssData = etree.XML(u'<xml></xml>')
         for feedType in [u'treeviewURLS', u'userFeeds']:
-            if self.userPrefs.find(feedType) == None:
+            if self.userPrefs.find(feedType) is None:
                 continue
             if not len(self.userPrefs.find(feedType).xpath('./url')):
                 continue
@@ -581,7 +581,7 @@ class Videos(object):
             print
 
         # Get the RSS Feed data
-        if rssData.find('url') != None:
+        if rssData.find('url') is not None:
             try:
                 resultTree = self.common.getUrlData(rssData)
             except Exception, errormsg:
@@ -592,7 +592,7 @@ class Videos(object):
                 print
 
              # Set the display type for the link (Fullscreen, Web page, Game Console)
-            if self.userPrefs.find('displayURL') != None:
+            if self.userPrefs.find('displayURL') is not None:
                 urlType = self.userPrefs.find('displayURL').text
             else:
                 urlType = u'fullscreen'
@@ -638,7 +638,7 @@ class Videos(object):
                 channelLanguage = u'en'
                 # Create a new directory and/or subdirectory if required
                 if names[0] != categoryDir:
-                    if categoryDir != None:
+                    if categoryDir is not None:
                         channelTree.append(categoryElement)
                     categoryElement = etree.XML(u'<directory></directory>')
                     categoryElement.attrib['name'] = names[0]
@@ -714,8 +714,8 @@ class Videos(object):
                             break
 
             # Add the last directory processed
-            if categoryElement != None:
-                if categoryElement.xpath('.//item') != None:
+            if categoryElement is not None:
+                if categoryElement.xpath('.//item') is not None:
                     channelTree.append(categoryElement)
 
         # Check that there was at least some items

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/bliptv/bliptv_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/bliptv/bliptv_api.py
@@ -279,7 +279,7 @@ class Videos(object):
 
         ip = getExternalIP()
 
-        if ip == None:
+        if ip is None:
             return {}
 
         try:
@@ -371,7 +371,7 @@ class Videos(object):
 
 
     def textUtf8(self, text):
-        if text == None:
+        if text is None:
             return text
         try:
             return unicode(text, 'utf8')
@@ -541,7 +541,7 @@ class Videos(object):
             sys.stderr.write(u"! Error: Unknown error during a Video search (%s)\nError(%s)\n" % (title, e))
             sys.exit(1)
 
-        if data == None:
+        if data is None:
             return None
         if not len(data):
             return None

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/common/common_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/common/common_api.py
@@ -276,7 +276,7 @@ class Common(object):
 
 
     def textUtf8(self, text):
-        if text == None:
+        if text is None:
             return text
         try:
             return unicode(text, 'utf8')
@@ -369,7 +369,7 @@ class Common(object):
 
         ip = getExternalIP()
 
-        if ip == None:
+        if ip is None:
             return {}
 
         try:
@@ -508,7 +508,7 @@ class Common(object):
             urlDictionary[key]['morePages'] = u'false'
             urlDictionary[key]['tmp'] = None
             urlDictionary[key]['tree'] = None
-            if element.find('parameter') != None:
+            if element.find('parameter') is not None:
                 urlDictionary[key]['parameter'] = element.find('parameter').text
 
         if self.debug:
@@ -747,7 +747,7 @@ for xsltExtension in %(filename)s.__xsltExtentionList__:
         # Currently there are no link specific Web pages
         if not self.linksWebPage:
             self.linksWebPage = etree.parse(u'%s/nv_python_libs/configs/XML/customeHtmlPageList.xml' % (self.baseProcessingDir, ))
-        if self.linksWebPage.find(sourceLink) != None:
+        if self.linksWebPage.find(sourceLink) is not None:
             return u'file://%s/nv_python_libs/configs/HTML/%s' % (self.baseProcessingDir, self.linksWebPage.find(sourceLink).text)
         return u'file://%s/nv_python_libs/configs/HTML/%s' % (self.baseProcessingDir, 'nodownloads.html')
     # end linkWebPage()
@@ -1015,7 +1015,7 @@ self.urlDictionary[self.urlKey]['parameter']) )
                     else:
                         continue
                 # Was any data found?
-                if self.urlDictionary[self.urlKey]['tmp'].getroot() == None:
+                if self.urlDictionary[self.urlKey]['tmp'].getroot() is None:
                     sys.stderr.write(u"No Xslt results for Name(%s)\n" % self.urlKey)
                     sys.stderr.write(u"No Xslt results for url(%s)\n" % self.urlDictionary[self.urlKey]['href'])
                     if len(self.urlDictionary[self.urlKey]['filter']) == index-1:

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/dailymotion/dailymotion_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/dailymotion/dailymotion_api.py
@@ -566,7 +566,7 @@ class Videos(object):
 
         ip = getExternalIP()
 
-        if ip == None:
+        if ip is None:
             return {}
 
         try:
@@ -658,7 +658,7 @@ class Videos(object):
 
 
     def textUtf8(self, text):
-        if text == None:
+        if text is None:
             return text
         try:
             return unicode(text, 'utf8')
@@ -747,7 +747,7 @@ class Videos(object):
             sys.stderr.write(u"! Error: Unknown error during a Video search (%s)\nError(%s)\n" % (title, e))
             sys.exit(1)
 
-        if data == None:
+        if data is None:
             return None
         if not len(data):
             return None

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/hulu/hulu_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/hulu/hulu_api.py
@@ -478,7 +478,7 @@ class Videos(object):
         searchResultTree = []
         searchFilter = etree.XPath(u"//item")
         userSearchStrings = u'userSearchStrings'
-        if self.userPrefs.find(userSearchStrings) != None:
+        if self.userPrefs.find(userSearchStrings) is not None:
             userSearch = self.userPrefs.find(userSearchStrings).xpath('./userSearch')
             if len(userSearch):
                 for searchDetails in userSearch:
@@ -513,7 +513,7 @@ class Videos(object):
         # Create a structure of feeds that can be concurrently downloaded
         rssData = etree.XML(u'<xml></xml>')
         for feedType in [u'treeviewURLS', ]:
-            if self.userPrefs.find(feedType) == None:
+            if self.userPrefs.find(feedType) is None:
                 continue
             if not len(self.userPrefs.find(feedType).xpath('./url')):
                 continue
@@ -540,7 +540,7 @@ class Videos(object):
             print
 
         # Get the RSS Feed data
-        if rssData.find('url') != None:
+        if rssData.find('url') is not None:
             try:
                 resultTree = self.common.getUrlData(rssData)
             except Exception, errormsg:
@@ -591,7 +591,7 @@ class Videos(object):
                 channelLanguage = u'en'
                 # Create a new directory and/or subdirectory if required
                 if names[0] != categoryDir:
-                    if categoryDir != None:
+                    if categoryDir is not None:
                         channelTree.append(categoryElement)
                     categoryElement = etree.XML(u'<directory></directory>')
                     categoryElement.attrib['name'] = names[0]
@@ -617,7 +617,7 @@ class Videos(object):
                         huluItem.find('author').text = u'Hulu'
                     huluItem.find('pubDate').text = pubdate
                     description = etree.HTML(etree.tostring(descriptionFilter(itemData)[0], method="text", encoding=unicode).strip())
-                    if descFilter2(description)[0].text != None:
+                    if descFilter2(description)[0].text is not None:
                         huluItem.find('description').text = self.common.massageText(descFilter2(description)[0].text.strip())
                     else:
                         huluItem.find('description').text = u''
@@ -667,8 +667,8 @@ class Videos(object):
                             break
 
             # Add the last directory processed
-            if categoryElement != None:
-                if categoryElement.xpath('.//item') != None:
+            if categoryElement is not None:
+                if categoryElement.xpath('.//item') is not None:
                     channelTree.append(categoryElement)
 
         # Check that there was at least some items

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/mainProcess.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/mainProcess.py
@@ -241,7 +241,7 @@ xmlns:mythtv="http://www.mythtv.org/wiki/MythNetvision_Grabber_Script_Format">""
         self.config['target'].mashup_title = self.mashup_title
 
         data_sets = self.config['target'].searchForVideos(search_text, pagenumber)
-        if data_sets == None:
+        if data_sets is None:
             return
         if not len(data_sets):
             return
@@ -272,7 +272,7 @@ xmlns:mythtv="http://www.mythtv.org/wiki/MythNetvision_Grabber_Script_Format">""
         self.config['target'].mashup_title = self.mashup_title
 
         data_sets = self.config['target'].displayTreeView()
-        if data_sets == None:
+        if data_sets is None:
             return
         if not len(data_sets):
             return

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/mashups/mashups_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/mashups/mashups_api.py
@@ -395,7 +395,7 @@ class Videos(object):
             print
 
         # Get the source data
-        if sourceData.find('url') != None:
+        if sourceData.find('url') is not None:
             # Process each directory of the user preferences that have an enabled rss feed
             try:
                 resultTree = self.common.getUrlData(sourceData)
@@ -488,7 +488,7 @@ class Videos(object):
             url = etree.XML(u'<url></url>')
             etree.SubElement(url, "name").text = uniqueName
             etree.SubElement(url, "href").text = source.attrib.get('url')
-            if source.attrib.get('parameter') != None:
+            if source.attrib.get('parameter') is not None:
                 etree.SubElement(url, "parameter").text = source.attrib.get('parameter')
             if len(xsltFilename(source)):
                 for xsltName in xsltFilename(source):
@@ -502,7 +502,7 @@ class Videos(object):
             print
 
         # Get the source data
-        if sourceData.find('url') != None:
+        if sourceData.find('url') is not None:
             # Process each directory of the user preferences that have an enabled rss feed
             try:
                 resultTree = self.common.getUrlData(sourceData)
@@ -566,7 +566,7 @@ class Videos(object):
 
                 # Create a new directory and/or subdirectory if required
                 if names[0] != categoryDir:
-                    if categoryDir != None:
+                    if categoryDir is not None:
                         channelTree.append(categoryElement)
                     categoryElement = etree.XML(u'<directory></directory>')
                     categoryElement.attrib['name'] = names[0]
@@ -627,7 +627,7 @@ class Videos(object):
                                 break
 
             # Add the last directory processed and the "Special" directories
-            if categoryElement != None:
+            if categoryElement is not None:
                 if len(itemFilter(categoryElement)):
                     channelTree.append(categoryElement)
                 # Add the special directories videos

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/mtv/mtv_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/mtv/mtv_api.py
@@ -307,7 +307,7 @@ class Videos(object):
 
 
     def textUtf8(self, text):
-        if text == None:
+        if text is None:
             return text
         try:
             return unicode(text, 'utf8')
@@ -392,7 +392,7 @@ class Videos(object):
         # Make sure there are no item elements that are None
         for item in data:
             for key in item.keys():
-                if item[key] == None:
+                if item[key] is None:
                     item[key] = u''
 
         # Massage each field and eliminate any item without a URL
@@ -420,7 +420,7 @@ class Videos(object):
                 if key == 'content':
                     if len(item[key]):
                         if item[key][0].has_key('language'):
-                            if item[key][0]['language'] != None:
+                            if item[key][0]['language'] is not None:
                                 item['language'] = item[key][0]['language']
                 if key == 'published_parsed': # '2009-12-21T00:00:00Z'
                     if item[key]:
@@ -465,7 +465,7 @@ class Videos(object):
         metadata = {}
         cur_size = True
         for e in etree:
-            if e.tag.endswith(u'content') and e.text == None:
+            if e.tag.endswith(u'content') and e.text is None:
                 index = e.get('url').rindex(u':')
                 metadata['video'] = self.mtvHtmlPath % (title,  e.get('url')[index+1:])
                 # !! This tag will need to be added at a later date
@@ -536,7 +536,7 @@ class Videos(object):
             sys.stderr.write(u"! Error: Unknown error during a Video search (%s)\nError(%s)\n" % (title, e))
             sys.exit(1)
 
-        if data == None:
+        if data is None:
             return None
         if not len(data):
             return None
@@ -696,25 +696,25 @@ class Videos(object):
             metadata['language'] = self.config['language']
             for e in elements:
                 if e.tag.endswith(u'title'):
-                    if e.text != None:
+                    if e.text is not None:
                         metadata['title'] = self.massageDescription(e.text.strip())
                     else:
                         metadata['title'] = u''
                     continue
                 if e.tag == u'content':
-                    if e.text != None:
+                    if e.text is not None:
                         metadata['media_description'] = self.massageDescription(e.text.strip())
                     else:
                         metadata['media_description'] = u''
                     continue
                 if e.tag.endswith(u'published'): # '2007-03-06T00:00:00Z'
-                    if e.text != None:
+                    if e.text is not None:
                         pub_time = time.strptime(e.text.strip(), "%Y-%m-%dT%H:%M:%SZ")
                         metadata['published_parsed'] = time.strftime('%a, %d %b %Y %H:%M:%S GMT', pub_time)
                     else:
                         metadata['published_parsed'] = u''
                     continue
-                if e.tag.endswith(u'content') and e.text == None:
+                if e.tag.endswith(u'content') and e.text is None:
                     metadata['video'] =  self.ampReplace(e.get('url'))
                     metadata['duration'] =  e.get('duration')
                     continue

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/rev3/rev3_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/rev3/rev3_api.py
@@ -332,13 +332,13 @@ class Videos(object):
                     tmpName = anchor.text
                 if tmpName == u'Revision3 Beta':
                     continue
-                if showURL != None:
+                if showURL is not None:
                     url = etree.SubElement(tmpDirectory, "url")
                     etree.SubElement(url, "name").text = tmpName
                     etree.SubElement(url, "href").text = showURL
                     etree.SubElement(url, "filter").text = showFilter
                     etree.SubElement(url, "parserType").text = u'html'
-            if tmpDirectory.find('url') != None:
+            if tmpDirectory.find('url') is not None:
                 showData.append(tmpDirectory)
 
         if self.config['debug_enabled']:
@@ -391,11 +391,11 @@ class Videos(object):
                             mp4Format.attrib['enabled'] = u'false'
                         mp4Format.attrib['name'] = format.text
                         mp4Format.attrib['rss'] = link
-                    if tmpShow.find('mp4Format') != None:
+                    if tmpShow.find('mp4Format') is not None:
                         tmpDirectory.append(tmpShow)
 
             # If there is any data then add to new rev3.xml element tree
-            if tmpDirectory.find('show') != None:
+            if tmpDirectory.find('show') is not None:
                 userRev3.append(tmpDirectory)
 
         if self.config['debug_enabled']:
@@ -731,16 +731,16 @@ class Videos(object):
             for index in range(len(names)):
                 names[index] = self.common.massageText(names[index])
             channel = channelFilter(result)[0]
-            if channel.find('image') != None:
+            if channel.find('image') is not None:
                 channelThumbnail = self.common.ampReplace(imageFilter(channel)[0].text)
             else:
                 channelThumbnail = self.common.ampReplace(channel.find('link').text.replace(u'/watch/', u'/images/')+u'100.jpg')
             channelLanguage = u'en'
-            if channel.find('language') != None:
+            if channel.find('language') is not None:
                 channelLanguage = channel.find('language').text[:2]
             # Create a new directory and/or subdirectory if required
             if names[0] != categoryDir:
-                if categoryDir != None:
+                if categoryDir is not None:
                     channelTree.append(categoryElement)
                 categoryElement = etree.XML(u'<directory></directory>')
                 if names[0] == personalFeed:
@@ -813,7 +813,7 @@ class Videos(object):
                 showElement.append(rev3Item)
 
         # Add the last directory processed
-        if categoryElement.xpath('.//item') != None:
+        if categoryElement.xpath('.//item') is not None:
             channelTree.append(categoryElement)
 
         # Check that there was at least some items

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/thewb/thewb_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/thewb/thewb_api.py
@@ -92,7 +92,7 @@ def can_int(x):
     >>> _can_int("A test")
     False
     """
-    if x == None:
+    if x is None:
         return False
     try:
         int(x)
@@ -433,7 +433,7 @@ class Videos(object):
         itemDwnLink = etree.XPath('.//media:content', namespaces=self.common.namespaces)
         itemDict = {}
         for result in searchResults:
-            if linkFilter(result) != None:   # Make sure that this result actually has a video
+            if linkFilter(result) is not None:   # Make sure that this result actually has a video
                 thewbItem = etree.XML(self.common.mnvItem)
                 # These videos are only viewable in the US so add a country indicator
                 etree.SubElement(thewbItem, "{http://www.mythtv.org/wiki/MythNetvision_Grabber_Script_Format}country").text = u'us'
@@ -600,11 +600,11 @@ class Videos(object):
 
         # Process any user specified searches
         showItems = {}
-        if len(showFeeds) != None:
+        if len(showFeeds) is not None:
             for searchDetails in showFeeds:
                 try:
                     data = self.searchTitle(searchDetails.text.strip(), 1, self.page_limit, ignoreError=True)
-                    if data[0] == None:
+                    if data[0] is None:
                     	continue
                 except TheWBVideoNotFound, msg:
                     sys.stderr.write(u"%s\n" % msg)
@@ -685,7 +685,7 @@ class Videos(object):
         self.rssName = etree.XPath('title', namespaces=self.common.namespaces)
         self.feedFilter = etree.XPath('//url[text()=$url]')
         self.HTMLparser = etree.HTMLParser()
-        if rssData.find('url') != None:
+        if rssData.find('url') is not None:
             try:
                 resultTree = self.common.getUrlData(rssData)
             except Exception, errormsg:

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/vimeo/vimeo_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/vimeo/vimeo_api.py
@@ -231,7 +231,7 @@ class SimpleOAuthClient(oauth.OAuthClient):
         self.authorization_url = authorization_url
         self.consumer = oauth.OAuthConsumer(self.key, self.secret)
 
-        if token != None and token_secret != None:
+        if token is not None and token_secret is not None:
             self.token = oauth.OAuthToken(token, token_secret)
         else:
             self.token = None
@@ -325,9 +325,9 @@ class SimpleOAuthClient(oauth.OAuthClient):
         params = {'user_id': user_id}
         if sort in ('newest', 'oldest', 'alphabetical'):
             params['sort'] = sort
-        if per_page != None:
+        if per_page is not None:
             params['per_page'] = per_page
-        if page != None:
+        if page is not None:
             params['page'] = page
         return self._do_vimeo_unauthenticated_call(inspect.stack()[0][3].replace('_', '.'),
                                                    parameters=params)
@@ -347,9 +347,9 @@ class SimpleOAuthClient(oauth.OAuthClient):
             params['sort'] = sort
         else:
             params['sort'] = 'most_liked'
-        if per_page != None:
+        if per_page is not None:
             params['per_page'] = per_page
-        if page != None:
+        if page is not None:
             params['page'] = page
         params['full_response'] = '1'
         #params['query'] = query.replace(u' ', u'_')
@@ -371,9 +371,9 @@ class SimpleOAuthClient(oauth.OAuthClient):
         if sort in ('newest', 'oldest', 'alphabetical',
                     'most_videos', 'most_subscribed', 'most_recently_updated'):
             params['sort'] = sort
-        if per_page != None:
+        if per_page is not None:
             params['per_page'] = per_page
-        if page != None:
+        if page is not None:
             params['page'] = page
 
         return self._do_vimeo_unauthenticated_call(inspect.stack()[0][3].replace('_', '.'),
@@ -388,13 +388,13 @@ class SimpleOAuthClient(oauth.OAuthClient):
         """
         # full_response channel_id
         params = {}
-        if channel_id != None:
+        if channel_id is not None:
             params['channel_id'] = channel_id
-        if full_response != None:
+        if full_response is not None:
             params['full_response'] = 1
-        if per_page != None:
+        if per_page is not None:
             params['per_page'] = per_page
-        if page != None:
+        if page is not None:
             params['page'] = page
 
         return self._do_vimeo_unauthenticated_call(inspect.stack()[0][3].replace('_', '.'),
@@ -824,7 +824,7 @@ class Videos(object):
 
 
     def textUtf8(self, text):
-        if text == None:
+        if text is None:
             return text
         try:
             return unicode(text, 'utf8')
@@ -915,7 +915,7 @@ class Videos(object):
         except Exception, msg:
             raise VimeoVideosSearchError(u'%s' % msg)
 
-        if xml_data == None:
+        if xml_data is None:
             raise VimeoVideoNotFound(self.error_messages['VimeoVideoNotFound'] % title)
 
         if not len(xml_data.keys()):
@@ -1063,7 +1063,7 @@ class Videos(object):
             sys.stderr.write(u"! Error: Unknown error during a Video search (%s)\nError(%s)\n" % (title, e))
             sys.exit(1)
 
-        if data == None:
+        if data is None:
             return None
         if not len(data):
             return None
@@ -1123,7 +1123,7 @@ class Videos(object):
                     except Exception, msg:
                         raise VimeoAllChannelError(u'%s' % msg)
 
-                    if xml_data == None:
+                    if xml_data is None:
                         raise VimeoAllChannelError(self.error_messages['1-VimeoAllChannelError'] % sort)
 
                     if not len(xml_data.keys()):
@@ -1311,7 +1311,7 @@ class Videos(object):
         except Exception, msg:
             raise VimeoVideosSearchError(u'%s' % msg)
 
-        if xml_data == None:
+        if xml_data is None:
             raise VimeoVideoNotFound(self.error_messages['VimeoVideoNotFound'] % self.dir_name)
 
         if not len(xml_data.keys()):

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/cinemarv_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/cinemarv_api.py
@@ -111,7 +111,7 @@ class xpathFunctions(object):
         webURL = args[0]
         # If this is for the download then just return what was found for the "link" element
         if self.persistence.has_key('cinemarvLinkGeneration'):
-            if self.persistence['cinemarvLinkGeneration'] != None:
+            if self.persistence['cinemarvLinkGeneration'] is not None:
                 returnValue = self.persistence['cinemarvLinkGeneration']
                 self.persistence['cinemarvLinkGeneration'] = None
                 return returnValue
@@ -124,7 +124,7 @@ class xpathFunctions(object):
         except Exception, errmsg:
             sys.stderr.write(u'!Warning: The web page URL(%s) could not be read, error(%s)\n' % (webURL, errmsg))
             return webURL
-        if webPageElement == None:
+        if webPageElement is None:
             self.persistence['cinemarvLinkGeneration'] = webURL
             return webURL
 
@@ -147,7 +147,7 @@ class xpathFunctions(object):
         return True if the link does not starts with "http://"
         return False if the link starts with "http://"
         '''
-        if self.persistence['cinemarvLinkGeneration'] == None:
+        if self.persistence['cinemarvLinkGeneration'] is None:
             return False
 
         if self.persistence['cinemarvLinkGeneration'].startswith(u'http://'):

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/nasa_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/nasa_api.py
@@ -124,7 +124,7 @@ class xpathFunctions(object):
         mythtv = "{%s}" % mythtvNamespace
         NSMAP = {'mythtv' : mythtvNamespace}
         elementTmp = etree.Element(mythtv + "mythtv", nsmap=NSMAP)
-        if not episodeNumber == None:
+        if not episodeNumber is None:
             etree.SubElement(elementTmp, "title").text = u"EP%02d: %s" % (episodeNumber, title)
             etree.SubElement(elementTmp, mythtv + "episode").text = u"%s" % episodeNumber
         else:

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/skyAtNight_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/skyAtNight_api.py
@@ -117,7 +117,7 @@ class xpathFunctions(object):
         mythtv = "{%s}" % mythtvNamespace
         NSMAP = {'mythtv' : mythtvNamespace}
         elementTmp = etree.Element(mythtv + "mythtv", nsmap=NSMAP)
-        if not episodeNumber == None:
+        if not episodeNumber is None:
             etree.SubElement(elementTmp, "title").text = u"EP%02d" % episodeNumber
             etree.SubElement(elementTmp, mythtv + "episode").text = u"%s" % episodeNumber
         else:

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/tributeca_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/xsltfunctions/tributeca_api.py
@@ -115,7 +115,7 @@ class xpathFunctions(object):
 
         # If this is for the download then just return what was found for the "link" element
         if self.persistence.has_key('tributecaLinkGeneration'):
-            if self.persistence['tributecaLinkGeneration'] != None:
+            if self.persistence['tributecaLinkGeneration'] is not None:
                 returnValue = self.persistence['tributecaLinkGeneration']
                 self.persistence['tributecaLinkGeneration'] = None
                 if returnValue != webURL:
@@ -233,7 +233,7 @@ class xpathFunctions(object):
         return True if the link does not starts with "http://"
         return False if the link starts with "http://"
         '''
-        if self.persistence['tributecaLinkGeneration'] == None:
+        if self.persistence['tributecaLinkGeneration'] is None:
             return False
 
         if self.persistence['tributecaLinkGeneration'].startswith(u'http://'):

--- a/mythtv/programs/scripts/internetcontent/nv_python_libs/youtube/youtube_api.py
+++ b/mythtv/programs/scripts/internetcontent/nv_python_libs/youtube/youtube_api.py
@@ -171,7 +171,7 @@ class Videos(object):
 
         # Read region code from user preferences, used by tree view
         region = self.userPrefs.find("region")
-        if region != None and region.text:
+        if region is not None and region.text:
             self.config['region'] = region.text
         else:
             self.config['region'] = u'us'
@@ -179,7 +179,7 @@ class Videos(object):
         self.apikey = getData().update(getData().a)
 
         apikey = self.userPrefs.find("apikey")
-        if apikey != None and apikey.text:
+        if apikey is not None and apikey.text:
             self.apikey = apikey.text
 
         self.feed_icons = {
@@ -256,7 +256,7 @@ class Videos(object):
 
         ip = getExternalIP()
 
-        if ip == None:
+        if ip is None:
             return {}
 
         try:
@@ -445,7 +445,7 @@ class Videos(object):
 
             for key in item.keys():
                 # Make sure there are no item elements that are None
-                if item[key] == None:
+                if item[key] is None:
                     item[key] = u''
                 elif key == 'published_parsed': # 2010-01-23T08:38:39.000Z
                     if item[key]:
@@ -499,7 +499,7 @@ class Videos(object):
             sys.stderr.write(u"! Error: Unknown error during a Video search (%s)\nError(%s)\n" % (title, e))
             sys.exit(1)
 
-        if data == None:
+        if data is None:
             return None
         if not len(data):
             return None

--- a/mythtv/programs/scripts/metadata/Music/lyrics/darklyrics.py
+++ b/mythtv/programs/scripts/metadata/Music/lyrics/darklyrics.py
@@ -97,7 +97,7 @@ class LyricsFetcher:
         utilities.log(debug, "%s: searching lyrics for %s - %s - %s" % (__title__, lyrics.artist, lyrics.album, lyrics.title))
         links = self.search(lyrics.artist, lyrics.title);
 
-        if(links == None or len(links) == 0):
+        if(links is None or len(links) == 0):
             return False;
         elif len(links) > 1:
             lyrics.list = links

--- a/mythtv/programs/scripts/metadata/Music/mbutils.py
+++ b/mythtv/programs/scripts/metadata/Music/mbutils.py
@@ -237,7 +237,7 @@ def find_disc(cddrive):
         if "offset-list" in result['disc']:
             offsets = None
             for offset in result['disc']['offset-list']:
-                if offsets == None:
+                if offsets is None:
                     offsets = str(offset)
                 else:
                     offsets += " " + str(offset)
@@ -349,11 +349,11 @@ def main():
         performSelfTest()
 
     if opts.searchreleases:
-        if opts.artist == None:
+        if opts.artist is None:
             print("Missing --artist argument")
             sys.exit(1)
 
-        if opts.album == None:
+        if opts.album is None:
             print("Missing --album argument")
             sys.exit(1)
  
@@ -364,7 +364,7 @@ def main():
         search_releases(opts.artist, opts.album, limit)
 
     if opts.searchartists:
-        if opts.artist == None:
+        if opts.artist is None:
             print("Missing --artist argument")
             sys.exit(1)
 
@@ -375,25 +375,25 @@ def main():
         search_artists(opts.artist, limit)
 
     if opts.getartist:
-        if opts.id == None:
+        if opts.id is None:
             print("Missing --id argument")
             sys.exit(1)
 
         get_artist(opts.id)
 
     if opts.finddisc:
-        if opts.cddevice == None:
+        if opts.cddevice is None:
             print("Missing --cddevice argument")
             sys.exit(1)
 
         find_disc(opts.cddevice)
 
     if opts.findcoverart:
-        if opts.id == None and opts.relgroupid == None:
+        if opts.id is None and opts.relgroupid is None:
             print("Missing --id or --relgroupid argument")
             sys.exit(1)
 
-        if opts.id != None:
+        if opts.id is not None:
             find_coverart(opts.id)
         else:
             find_coverart_releasegroup(opts.relgroupid)

--- a/mythtv/programs/scripts/metadata/Music/musicbrainzngs/util.py
+++ b/mythtv/programs/scripts/metadata/Music/musicbrainzngs/util.py
@@ -17,7 +17,7 @@ def _unicode(string, encoding=None):
     if isinstance(string, compat.unicode):
         unicode_string = string
     elif isinstance(string, compat.bytes):
-        # use given encoding, stdin, preferred until something != None is found
+        # use given encoding, stdin, preferred until something is not None is found
         if encoding is None:
             encoding = sys.stdin.encoding
         if encoding is None:

--- a/mythtv/programs/scripts/metadata/Television/ttvdb.py
+++ b/mythtv/programs/scripts/metadata/Television/ttvdb.py
@@ -1451,7 +1451,7 @@ class Season( tvdb_api.Season ):
 class Episode( tvdb_api.Episode ):
     _re_strippart = re.compile('(.*) \([0-9]+\)')
     def fuzzysearch(self, term = None, key = None):
-        if term == None:
+        if term is None:
             raise TypeError("must supply string to search for (contents)")
 
         term = unicode(term).lower()
@@ -1639,7 +1639,7 @@ def get_graphics(t, opts, series_season_ep, graphics_type, single_option, langua
     graphics = sorted(graphics, key=lambda k: k['rating'], reverse=True)
     for URL in graphics:
         if graphics_type == 'filename':
-            if URL[graphics_type] == None:
+            if URL[graphics_type] is None:
                 continue
         if language and 'language' in URL:        # Is there a language to filter URLs on?
             if language == URL['language']:
@@ -1749,7 +1749,7 @@ def Getseries_episode_data(t, opts, series_season_ep, language = None):
         genres_string = series_data[u'genre'].encode('utf-8')
     except:
         genres_string=''
-    if genres_string != None and genres_string != '':
+    if genres_string is not None and genres_string != '':
         genres = change_amp(genres_string)
         genres = change_to_commas(genres)
 
@@ -1787,7 +1787,7 @@ def Getseries_episode_data(t, opts, series_season_ep, language = None):
                         continue
                     i = data_keys.index(key) # Include only specific episode data
                 except ValueError:
-                    if series_data[season][episode][key] != None:
+                    if series_data[season][episode][key] is not None:
                         text = series_data[season][episode][key]
                         if isinstance(text, dict):
                             # handle language tuple
@@ -1806,11 +1806,11 @@ def Getseries_episode_data(t, opts, series_season_ep, language = None):
                     continue
                 text = series_data[season][episode][key]
 
-                if text == None and key.title() == 'Director':
+                if text is None and key.title() == 'Director':
                     text = u"Unknown"
                 if isinstance(text, list):
                     text = ', '.join(text)
-                if text == None or text == 'None':
+                if text is None or text == 'None':
                     continue
                 else:
                     # handle language tuple
@@ -1828,7 +1828,7 @@ def Getseries_episode_data(t, opts, series_season_ep, language = None):
                 print(u"Title:%s" % series_data[u'seriesname'])
 
             for key in data_titles:
-                if key_values[index] != None:
+                if key_values[index] is not None:
                     if data_titles[index] == u'ReleaseDate:' and len(key_values[index]) > 4:
                         print(u'%s%s'% (u'Year:', key_values[index][:4]))
                     if key_values[index] != 'None':
@@ -2105,7 +2105,7 @@ def displaySearchXML(tvdb_api):
 
     tvdbQueryXslt = etree.XSLT(etree.parse(u'%s%s' % (tvdb_api.baseXsltDir, u'tvdbQuery.xsl')))
     items = tvdbQueryXslt(tvdb_api.searchTree)
-    if items.getroot() != None:
+    if items.getroot() is not None:
         if len(items.xpath('//item')):
             sys.stdout.write(etree.tostring(items, encoding='UTF-8', method="xml", xml_declaration=True, pretty_print=True, ))
     return 0
@@ -2130,7 +2130,7 @@ def displaySeriesXML(tvdb_api, series_season_ep):
 
     tvdbQueryXslt = etree.XSLT(etree.parse(u'%s%s' % (tvdb_api.baseXsltDir, u'tvdbVideo.xsl')))
     items = tvdbQueryXslt(allDataElement)
-    if items.getroot() != None:
+    if items.getroot() is not None:
         if len(items.xpath('//item')):
             sys.stdout.write(etree.tostring(items, encoding='UTF-8', method="xml", xml_declaration=True, pretty_print=True, ))
     return 0
@@ -2155,7 +2155,7 @@ def displayCollectionXML(tvdb_api):
 
     tvdbCollectionXslt = etree.XSLT(etree.parse(u'%s%s' % (tvdb_api.baseXsltDir, u'tvdbCollection.xsl')))
     items = tvdbCollectionXslt(tvdb_api.seriesInfoTree)
-    if items.getroot() != None:
+    if items.getroot() is not None:
         if len(items.xpath('//item')):
             sys.stdout.write(etree.tostring(items, encoding='UTF-8', method="xml", xml_declaration=True, pretty_print=True, ))
     return 0


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations