### PR TITLE
EITfixup: SuperRTL (Germany) episode number in subtitle

### DIFF
--- a/mythtv/libs/libmythtv/eitfixup.cpp
+++ b/mythtv/libs/libmythtv/eitfixup.cpp
@@ -142,6 +142,7 @@ EITFixUp::EITFixUp()
       m_DisneyChannelSubtitle(",([^,]+)\\s{0,1}(\\d{4})$"),
       m_RTLEpisodeNo1("^(Folge\\s\\d{1,4})\\.*\\s*"),
       m_RTLEpisodeNo2("^(\\d{1,2}\\/[IVX]+)\\.*\\s*"),
+      m_SuperRTLSubtitle("^Folge\\s(\\d{1,3}):\\s'(.*)'"),
       m_fiRerun("\\ ?Uusinta[a-zA-Z\\ ]*\\.?"),
       m_fiRerun2("\\([Uu]\\)"),
       m_dePremiereLength("\\s?[0-9]+\\sMin\\."),
@@ -1676,6 +1677,16 @@ void EITFixUp::FixMCA(DBEventEIT &event) const
 void EITFixUp::FixRTL(DBEventEIT &event) const
 {
     int        pos;
+
+    QRegExp tmpExpSubtitleSRTL = m_SuperRTLSubtitle;
+
+    // subtitle with episode number: "Folge *: 'subtitle'
+    if (tmpExpSubtitleSRTL.indexIn(event.subtitle) != -1)
+    {
+        event.season = 0;
+        event.episode = tmpExpSubtitleSRTL.cap(1).toUInt();
+        event.subtitle    = tmpExpSubtitleSRTL.cap(2);
+    }
 
     // No need to continue without a description or with an subtitle.
     if (event.description.length() <= 0 || event.subtitle.length() > 0)

--- a/mythtv/libs/libmythtv/eitfixup.h
+++ b/mythtv/libs/libmythtv/eitfixup.h
@@ -210,6 +210,7 @@ class EITFixUp
     const QRegExp m_DisneyChannelSubtitle;
     const QRegExp m_RTLEpisodeNo1;
     const QRegExp m_RTLEpisodeNo2;
+    const QRegExp m_SuperRTLSubtitle;
     const QRegExp m_fiRerun;
     const QRegExp m_fiRerun2;
     const QRegExp m_dePremiereLength;

--- a/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.cpp
+++ b/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.cpp
@@ -689,6 +689,25 @@ void TestEITFixups::testSkyEpisodes()
     delete event5;
 }
 
+void TestEITFixups::testRTLEpisodes()
+{
+    EITFixUp fixup;
+
+    DBEventEIT *event = SimpleDBEventEIT (EITFixUp::kFixRTL,
+                                         "Titel",
+                                         "Folge 9: 'Leckerlis auf Eis / Rettung aus höchster Not'",
+                                         "Description")
+
+    PRINT_EVENT(*event);
+    fixup.Fix(*event);
+    PRINT_EVENT(*event);
+    QCOMPARE(event->subtitle, QString("Leckerlis auf Eis / Rettung aus höchster Not"));
+    QCOMPARE(event->season,   0u);
+    QCOMPARE(event->episode, 9u);
+
+    delete event;
+}
+
 void TestEITFixups::testUnitymedia()
 {
     EITFixUp fixup;

--- a/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.h
+++ b/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.h
@@ -49,6 +49,7 @@ class TestEITFixups : public QObject
     void testDEPro7Sat1(void);
     void testHTMLFixup(void);
     void testSkyEpisodes(void);
+    void testRTLEpisodes(void);
     void testUnitymedia(void);
     void testDeDisneyChannel(void);
     void testATV(void);


### PR DESCRIPTION
EITfixup for SuperRTL (Germany): Episode number in subtitle.
Including Unit Test case.