### PR TITLE
Get banners of english season, if asked lang has none.

### DIFF
--- a/mythtv/programs/scripts/metadata/Television/ttvdb.py
+++ b/mythtv/programs/scripts/metadata/Television/ttvdb.py
@@ -2070,11 +2070,19 @@ def convert_series_to_xml(t, series_season_ep, ep_info):
 
     if t2usable:
         sxml2 = eTree.XML(dicttoxml(t2.shows[show_id].data, custom_root='series', item_func=series_ep_item_func, attr_type=False))
+        bannerelementfound=False
         for element in t.seriesInfoTree.iter():
             if element.tag == '_banners':
                 bannerselement = element
-        for newelement in sxml2.find('_banners').iter():
-            bannerselement.extend(newelement)
+                bannerelementfound=True
+        test=sxml2.find('_banners')
+        if bannerelementfound:
+            for newelement in sxml2.find('_banners').iter():
+                bannerselement.extend(newelement)
+        else:
+            series = t.seriesInfoTree.find('series')
+            series.append(sxml2.find('_banners'))
+
     t.baseXsltDir = xslt.baseXsltPath
 
 def initializeXslt(language):
@@ -2582,6 +2590,8 @@ def main():
         else:
             if opts.xml and len(series_season_ep) == 3:
                 t.getDetailedEpisodeInfo(list(t.shows.values())[0].data['id'], series_season_ep[1], series_season_ep[2])
+                if t2usable:
+                    t2.getDetailedEpisodeInfo(list(t2.shows.values())[0].data['id'], series_season_ep[1], series_season_ep[2])
                 convert_series_to_xml(t, series_season_ep, seriesfound)
                 displaySeriesXML(t, series_season_ep)
                 return 0

--- a/mythtv/programs/scripts/metadata/Television/ttvdb.py
+++ b/mythtv/programs/scripts/metadata/Television/ttvdb.py
@@ -1891,8 +1891,6 @@ def Getseries_episode_numbers(t, opts, series_season_ep):
         ep_name=series_season_ep[1] # Leave the episode name alone
 
     series = search_for_series(t, series_name, opts.language)
-    if t2usable:
-        series2 = search_for_series(t2, series_name, 'en')
     season_ep_num = series.fuzzysearch(ep_name, 'episodename')
     if len(season_ep_num) != 0:
         for episode in sorted(season_ep_num, key=lambda ep: _episode_sort(ep), reverse=True):
@@ -1900,8 +1898,6 @@ def Getseries_episode_numbers(t, opts, series_season_ep):
                 if xmlFlag:
                     # get more detailed episode info
                     t.getDetailedEpisodeInfo(series['id'], episode['airedSeason'], episode)
-                    if t2usable:
-                        t2.getDetailedEpisodeInfo(series['id'], episode['airedSeason'], episode)
                     convert_series_to_xml(t, series_season_ep, season_ep_num)
                     displaySeriesXML(t, [series_name, episode['seasonnumber'], episode['episodenumber']])
                     return 0
@@ -2471,7 +2467,7 @@ def main():
 
     global t2usable
     t2usable = False
-    if (not opts.language == 'en'):
+    if (not opts.language == 'en' and not opts.numbers):
         t2usable = True
         global t2
         t2 = Tvdb(banners=True,
@@ -2505,10 +2501,8 @@ def main():
         opts2 = deepcopy(opts)
         opts2.language = 'en'
         if t2usable:
-            if (opts.numbers == True and opts.num_seasons == False):
-                y=[]
-                y.append(series_season_ep[0])
-                searchseries(t2, opts2, y)
+            if opts.numbers == False and opts.num_seasons == False:
+                searchseries(t2, opts2, series_season_ep)
 
     # Verify that thetvdb.com has the desired series_season_ep.
     # Exit this module if series_season_ep is not found

--- a/mythtv/programs/scripts/metadata/Television/ttvdb.py
+++ b/mythtv/programs/scripts/metadata/Television/ttvdb.py
@@ -1892,6 +1892,11 @@ def Getseries_episode_numbers(t, opts, series_season_ep):
 
     series = search_for_series(t, series_name, opts.language)
     season_ep_num = series.fuzzysearch(ep_name, 'episodename')
+    
+    if len(season_ep_num) == 0:
+        series = search_for_series(t2, series_name, 'en')
+        season_ep_num = series.fuzzysearch(ep_name, 'episodename')
+
     if len(season_ep_num) != 0:
         for episode in sorted(season_ep_num, key=lambda ep: _episode_sort(ep), reverse=True):
 #            if episode.distance == 0: # exact match
@@ -2467,7 +2472,7 @@ def main():
 
     global t2usable
     t2usable = False
-    if (not opts.language == 'en' and not opts.numbers):
+    if (not opts.language == 'en'):
         t2usable = True
         global t2
         t2 = Tvdb(banners=True,
@@ -2503,6 +2508,10 @@ def main():
         if t2usable:
             if opts.numbers == False and opts.num_seasons == False:
                 searchseries(t2, opts2, series_season_ep)
+            elif opts.numbers == True and opts.num_seasons == False:
+                x2=[]
+                x2.append(series_season_ep[0]) # Only use series name in check
+                seriesfound=searchseries(t, opts2, x2)
 
     # Verify that thetvdb.com has the desired series_season_ep.
     # Exit this module if series_season_ep is not found

--- a/mythtv/programs/scripts/metadata/Television/ttvdb.py
+++ b/mythtv/programs/scripts/metadata/Television/ttvdb.py
@@ -2067,8 +2067,7 @@ def convert_series_to_xml(t, series_season_ep, ep_info):
     exml = dicttoxml(t.shows[show_id], custom_root='data', item_func=series_ep_item_func, attr_type=False)
     t.seriesInfoTree = eTree.XML(exml)
     t.seriesInfoTree.append(eTree.XML(sxml))
-    #print(t['data'])
-    #print(t2['data'])
+
     if t2usable:
         sxml2 = eTree.XML(dicttoxml(t2.shows[show_id].data, custom_root='series', item_func=series_ep_item_func, attr_type=False))
         for element in t.seriesInfoTree.iter():


### PR DESCRIPTION
Fixes: 13424

I was a bit annoyed by this one for some time. This patch lets ttvdb.py just generate a second request with lang set to english and merge the missing stuff into original output.

I tested with a newly added season aswell as with seasons already missing the posters.

As I had no experience with python 2 days ago, it's maybe not the most beautiful solution, but a working one.