### PR TITLE
Extra keys for samsung smart TV remote

### DIFF
--- a/mythtv/libs/libmythui/cecadapter.cpp
+++ b/mythtv/libs/libmythui/cecadapter.cpp
@@ -431,6 +431,7 @@ class CECAdapterPriv
                 action = Qt::Key_M;
                 code   = "ROOT_MENU";
                 break;
+            case CEC_USER_CONTROL_CODE_AN_RETURN: //return (Samsung) (0x91) 
             case CEC_USER_CONTROL_CODE_EXIT:
                 action = Qt::Key_Escape;
                 code   = "EXIT";
@@ -768,6 +769,7 @@ class CECAdapterPriv
                 action = Qt::Key_M;
                 code   = "ROOT_MENU";
                 break;
+            case CEC_USER_CONTROL_CODE_AN_RETURN: //return (Samsung) (0x91) 
             case CEC_USER_CONTROL_CODE_EXIT:
                 action = Qt::Key_Escape;
                 code   = "EXIT";


### PR DESCRIPTION
The remote control on a samsung smart TV sends a few non standard key codes over CEC. Specifically, the esc/back/return button to navigate menus.
