### PR TITLE
Unbreak build with Clang/LLD 9

### DIFF
--- a/mythtv/libs/libmythfreesurround/el_processor.cpp
+++ b/mythtv/libs/libmythfreesurround/el_processor.cpp
@@ -33,7 +33,7 @@ typedef FFTSample FFTComplexArray[2];
 #endif
 
 
-#ifdef USE_FFTW3
+#if defined(_WIN32) && defined(USE_FFTW3)
 #pragma comment (lib,"libfftw3f-3.lib")
 #endif
 


### PR DESCRIPTION
Regressed by https://github.com/llvm/llvm-project/commit/1d16515fb407. See [error log](http://package18.nyi.freebsd.org/data/headamd64PR240629-default/2019-09-21_22h04m49s/logs/errors/mythtv-30.0_4%2C1.log)