### PR TITLE
IPTV fix for deadlock, handle redirects

### DIFF
--- a/mythtv/libs/libmythtv/channelscan/iptvchannelfetcher.h
+++ b/mythtv/libs/libmythtv/channelscan/iptvchannelfetcher.h
@@ -44,6 +44,13 @@ class IPTVChannelInfo
     {
     }
 
+ protected:
+    friend class TestIPTVRecorder;
+    bool IsValid(void) const
+    {
+        return !m_name.isEmpty() && m_tuning.IsValid();
+    }
+
   public:
     QString        m_name;
     QString        m_xmltvid;

--- a/mythtv/libs/libmythtv/iptvtuningdata.h
+++ b/mythtv/libs/libmythtv/iptvtuningdata.h
@@ -218,6 +218,11 @@ class MTV_PUBLIC IPTVTuningData
             m_protocol = IPTVTuningData::inValid;
     }
 
+  IPTVProtocol GetProtocol(void) const
+  {
+      return m_protocol;
+  }
+
   protected:
     bool IsHLSPlaylist(void) const
     {

--- a/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.h
+++ b/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.h
@@ -163,51 +163,59 @@ class TestIPTVRecorder: public QObject
         /* test plain old MPEG-2 TS over multicast playlist */
         chanmap = IPTVChannelFetcher::ParsePlaylist (rawdataUDP, nullptr);
         QCOMPARE (chanmap["001"].m_name, QString ("La 1"));
-        QVERIFY (chanmap["001"].IsValid ());
-        QVERIFY (chanmap["001"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["001"].IsValid ());
+        QVERIFY (!chanmap["001"].m_tuning.IsValid ());
+        QCOMPARE (chanmap["001"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["001"].m_tuning.GetDataURL().toString(), QString ("udp://239.0.0.76:8208"));
 
         /* test playlist for Neutrino STBs */
         chanmap = IPTVChannelFetcher::ParsePlaylist (rawdataHTTP, nullptr);
-        QVERIFY (chanmap["1"].IsValid ());
-        QVERIFY (chanmap["1"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["1"].IsValid ());
+        QVERIFY (!chanmap["1"].m_tuning.IsValid ());
         QCOMPARE (chanmap["1"].m_name, QString ("SVT1 HD Mitt"));
         QCOMPARE (chanmap["1"].m_xmltvid, QString ("svt1hd.svt.se"));
         QCOMPARE (chanmap["1"].m_programNumber, (uint) 1330);
+        QCOMPARE (chanmap["1"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["1"].m_tuning.GetDataURL().toString(), QString ("http://192.168.0.234:8001/1:0:19:532:6:22F1:EEEE0000:0:0:0:"));
 
         /* test playlist for FreeboxTV, last channel in playlist "wins" */
         chanmap = IPTVChannelFetcher::ParsePlaylist (rawdataRTSP, nullptr);
-        QVERIFY (chanmap["2"].IsValid ());
-        QVERIFY (chanmap["2"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["2"].IsValid ());
+        QVERIFY (!chanmap["2"].m_tuning.IsValid ());
         QCOMPARE (chanmap["2"].m_name, QString ("France 2 (auto)"));
+        QCOMPARE (chanmap["2"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["2"].m_tuning.GetDataURL().toString(), QString ("rtsp://mafreebox.freebox.fr/fbxtv_pub/stream?namespace=1&service=201"));
 
         /* test playlist for SAT>IP with "#. name" instead of "# - name" */
         chanmap = IPTVChannelFetcher::ParsePlaylist (rawdataSATIP, nullptr);
-        QVERIFY (chanmap["10"].IsValid ());
-        QVERIFY (chanmap["10"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["10"].IsValid ());
+        QVERIFY (!chanmap["10"].m_tuning.IsValid ());
+        QCOMPARE (chanmap["10"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["10"].m_name, QString ("ZDFinfokanal"));
 
         /* test playlist from A1 TV with empty lines and tvg-num */
         chanmap = IPTVChannelFetcher::ParsePlaylist (rawdataA1TV, nullptr);
-        QVERIFY (chanmap["1"].IsValid ());
-        QVERIFY (chanmap["1"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["1"].IsValid ());
+        QVERIFY (!chanmap["1"].m_tuning.IsValid ());
+        QCOMPARE (chanmap["1"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["1"].m_name, QString ("ORFeins"));
 
         /* test playlist from Movistar TV with channel number in braces */
         chanmap = IPTVChannelFetcher::ParsePlaylist (rawdataMovistarTV, nullptr);
-        QVERIFY (chanmap["001"].IsValid ());
-        QVERIFY (chanmap["001"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["001"].IsValid ());
+        QVERIFY (!chanmap["001"].m_tuning.IsValid ());
+        QCOMPARE (chanmap["001"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["001"].m_name, QString ("La 1"));
-        QVERIFY (chanmap["2275"].IsValid ());
-        QVERIFY (chanmap["2275"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["2275"].IsValid ());
+        QVERIFY (!chanmap["2275"].m_tuning.IsValid ());
+        QCOMPARE (chanmap["2275"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["2275"].m_name, QString ("Canal Sur Andalucía"));
 
         /* test playlist from iptv.ink with channel number in duration */
         chanmap = IPTVChannelFetcher::ParsePlaylist (rawdataIPTVInk, nullptr);
-        QVERIFY (chanmap["0002"].IsValid ());
-        QVERIFY (chanmap["0002"].m_tuning.IsValid ());
+        QVERIFY (!chanmap["0002"].IsValid ());
+        QVERIFY (!chanmap["0002"].m_tuning.IsValid ());
+        QCOMPARE (chanmap["0002"].m_tuning.GetProtocol(), IPTVTuningData::inValid);
         QCOMPARE (chanmap["0002"].m_name, QString ("[COLOR gold]Das Erste[/COLOR]"));
     }
 


### PR DESCRIPTION
~~(trac is currently down for maintenance. I will reflect this there once it is back)~~ Now filed at https://code.mythtv.org/trac/ticket/13488.

I recently ended up with some IPTV channels and found a few issues:

* A deadlock in HLSReader cancel path
* Not handling m3u8 which has a 302 redirect (the streams need to be calculated relative to the target URL in this case, and we need to deal with the redirect changing on subsequent m3u8 downloads)
* A segfault when combining overlapping segments which have gone backwards (which shouldn't happen, but I've seen it in practice, I think as a result of a previous error in the stream which jumped forward)
* Avoid hitting the servers for every single channel when doing a channel scan, we don't need precise protocol information at that time.
* A few other random typos, log improvements, setting a User-Agent header.

I developed and tested this on fixes/30 (since I only have my production system available) and rebased onto master where I have only build tested. The fixes/30 version is [here](https://github.com/ijc/mythtv/tree/fixes/30-iptv) for reference. There were some minor textual conflicts with e1217e91dd059360641eb7cdb47900d45baf73ee, 28b709dd339f9367d7abc01c20a054687f29bd31 and df1d911f248c3ff6b79c7354134299aceadadd3a (first two are `Use c++11 initialization.  Use m_ for class member names` for `libmythtv/recorders 5/5` and `libmythbase` respectively the third is `tidy: Change function declarations variables to match definition.`). There was a small logical conflict with 839c9402a696ad9602600b3ff1604843a65abc6e (`tidy: Return failure from DownloadURL() if too many redirects.`). For reference the fixes/30 version of that hunk is https://github.com/ijc/mythtv/commit/ba483782740bebb13afc6209d501576e7b3e73c4#diff-95c3c5682cb303162f692e1f4a621fe4R84-R87:
```diff
+        else if (final_url != nullptr)
+        {
+            *final_url = url.toString();
+        }
```
 while in master it ended up as https://github.com/ijc/mythtv/commit/cc4ebcff387846dace11f1662a2e563b60868341#diff-95c3c5682cb303162f692e1f4a621fe4R84-R85:
```diff
        else if (m_errorcode == QNetworkReply::NoError)
        {
+           if (final_url != nullptr)
+               *final_url = url.toString();
            *m_buffer += m_reply->readAll();
            m_errorstring.clear();
```

Looking at the history of the files I've touched between fixes/30 and now I think there aren't any other logical conflicts (looks like lots of cleanup and some fixes to unrelated code paths):
```console
$ git --oneline origin/fixes/30..origin/master -- mythtv/libs/libmythbase/mythdownloadmanager.* mythtv/libs/libmythbase/mythsingledownload.* mythtv/libs/libmythtv/channelscan/iptvchannelfetcher.h mythtv/libs/libmythtv/iptvtuningdata.h mythtv/libs/libmythtv/recorders/HLS mythtv/libs/libmythtv/recorders/hlsstreamhandler.*
7d0337e777 cppcheck: Mark objects as not copyable.
96508c6297 tidy: Fix simple warnings of 'value stored is never read'.
839c9402a6 tidy: Return failure from DownloadURL() if too many redirects.
f13e3fb40a Test the return value of QEventLoop::exec earlier.
bba55f4481 tidy: Use uppercase for literal suffixes (e.g. 'U', 'ULL', 'F'). (1/2)
d24ae5b838 tidy: Simplify boolean expressions. (libs)
df1d911f24 tidy: Change function declarations variables to match definition.
c5531fca22 tidy: Remove extraneous 'if' checks before calling delete. (libs)
5d4d4fc0ec tidy: Clean up control flow jumps followed by else statements. (libs)
a7df6daea3 tidy: Clean up control flow jumps followed by else statements. (libs/libmythtv)
59b89ef3f1 Use c++11 initialization.  Use m_ for class member names. (libmythtv 7/7)
13c54be8ff Use c++11 initialization.  Use m_ for class member names. (libmythtv 4/7)
e1217e91dd Use c++11 initialization.  Use m_ for class member names. (libmythtv/recorders 5/5)
266f1eb11a Use c++11 initialization.  Use m_ for class member names. (libmythtv/recorders 3/5)
28b709dd33 Use c++11 initialization.  Use m_ for class member names. (libmythbase)

```