### PR TITLE
Fix thetvdb Specials

### DIFF
--- a/mythtv/libs/libmythmetadata/metadatadownload.cpp
+++ b/mythtv/libs/libmythmetadata/metadatadownload.cpp
@@ -668,7 +668,7 @@ MetadataLookupList MetadataDownload::handleTelevision(MetadataLookup *lookup)
                                           lookup->GetSubtitle(), lookup, false);
         }
 
-        if (list.isEmpty() && lookup->GetSeason() && lookup->GetEpisode())
+        if (list.isEmpty() && (lookup->GetSeason() || lookup->GetEpisode()))
         {
             list = grabber.LookupData(lookup->GetInetref(), lookup->GetSeason(),
                                       lookup->GetEpisode(), lookup);


### PR DESCRIPTION
Since 0.27 the code requires both season and episode to be set, and setting season
to 0 is parsed to a false value. 0 is used to mean Specials by thetvdb that the previous
0.26 code understood. Other places in the code handle this correctly. Small change
to fix this.

Thank you for contributing to MythTV.

As many of our developers do not visit GitHub it is important to track
all contributions at our central ticket tracker over at code.mythtv.org

To prevent your contributions being overlooked please create a new ticket
there and refer to this pull request. (Bonus points for linking to the
ticket in the pull request, too. It helps us noticed potentially overlooked
pull requests due to missing tickets.)

https://code.mythtv.org/trac/wiki/TicketHowTo
https://code.mythtv.org/trac/newticket
