### PR TITLE
MythDisplayX11: Use accurate XRandR refresh rates

### DIFF
--- a/mythtv/libs/libmythui/DisplayRes.cpp
+++ b/mythtv/libs/libmythui/DisplayRes.cpp
@@ -236,7 +236,7 @@ bool DisplayRes::SwitchToCustomGUI(int width, int height, short rate)
 }
 
 const std::vector<double> DisplayRes::GetRefreshRates(int width,
-        int height) const
+        int height)
 {
     double tr;
     std::vector<double> empty;

--- a/mythtv/libs/libmythui/DisplayRes.h
+++ b/mythtv/libs/libmythui/DisplayRes.h
@@ -131,9 +131,9 @@ class MUI_PUBLIC DisplayRes
     /// \brief Returns the pixel aspect ratio of the display.
     double GetPixelAspectRatio(void) const { return m_pixelAspectRatio; }
     /// \brief Returns all video modes supported by the display.
-    virtual const DisplayResVector& GetVideoModes() const = 0;
+    virtual const DisplayResVector& GetVideoModes() = 0;
     /// \brief Returns refresh rates available at a specific screen resolution.
-    const std::vector<double> GetRefreshRates(int width, int height) const;
+    const std::vector<double> GetRefreshRates(int width, int height);
     /** @} */
 
   protected:

--- a/mythtv/libs/libmythui/DisplayResOSX.cpp
+++ b/mythtv/libs/libmythui/DisplayResOSX.cpp
@@ -71,7 +71,7 @@ bool DisplayResOSX::SwitchToVideoMode(int width, int height, double refreshrate)
     return (err == kCGErrorSuccess);
 }
 
-const DisplayResVector& DisplayResOSX::GetVideoModes() const
+const DisplayResVector& DisplayResOSX::GetVideoModes()
 {
     if (!m_videoModes.empty())
         return m_videoModes;

--- a/mythtv/libs/libmythui/DisplayResOSX.h
+++ b/mythtv/libs/libmythui/DisplayResOSX.h
@@ -9,7 +9,7 @@ class DisplayResOSX : public DisplayRes
     DisplayResOSX(void);
     ~DisplayResOSX(void);
 
-    const std::vector<DisplayResScreen>& GetVideoModes() const;
+    const std::vector<DisplayResScreen>& GetVideoModes();
 
   protected:
     bool GetDisplayInfo(int &w_pix, int &h_pix, int &w_mm,

--- a/mythtv/libs/libmythui/DisplayResX.h
+++ b/mythtv/libs/libmythui/DisplayResX.h
@@ -1,6 +1,8 @@
 #ifndef _DISPLAYRESX_H_
 #define _DISPLAYRESX_H_
 
+#include <QMap>
+
 #include "DisplayRes.h"
 
 class DisplayResX : public DisplayRes
@@ -9,7 +11,7 @@ class DisplayResX : public DisplayRes
     DisplayResX(void);
     ~DisplayResX(void);
 
-    const std::vector<DisplayResScreen>& GetVideoModes(void) const;
+    const std::vector<DisplayResScreen>& GetVideoModes(void);
 
   protected:
     bool GetDisplayInfo(int &w_pix, int &h_pix, int &w_mm,
@@ -18,7 +20,8 @@ class DisplayResX : public DisplayRes
 
   private:
     mutable std::vector<DisplayResScreen> m_videoModes;
-    mutable std::vector<DisplayResScreen> m_videoModesUnsorted;
+    QMap<uint64_t, unsigned long> m_modeMap { };
+    unsigned long m_crtc { 0 };
 };
 
 #endif // _DISPLAYRESX_H_


### PR DESCRIPTION
This fixes automatic frame-rate switching when using modern nvidia drivers.

Reapply parts of Mark Kendall's use of the more modern XRandR API from the
render branch, specifically the changes to GetVideoModes and
SwitchToVideoModes.

Also take on part of a later commit to filter out interlaced modes.

GetVideoModes requires selection of an output matching the screen currently used by mythfrontend.
In the original version of this code from the render branch, a reference to the screen was held in a
member variable of the class. For the fixes/29 branch, the screen has to be derived differently. The
calls to do so were also suggested by Mark.
