### PR TITLE
mythmusic fixes for multiple discs

### DIFF
--- a/mythplugins/mythmusic/mythmusic/playlist.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlist.cpp
@@ -386,8 +386,10 @@ void Playlist::shuffleTracks(MusicPlayer::ShuffleMode shuffleMode)
                     }
                     else
                     {
-                        album_order = Ialbum->second * 1000;
+                        album_order = Ialbum->second * 10000;
                     }
+                    if (mdata->DiscNumber() != -1)
+                        album_order += mdata->DiscNumber()*100;
                     album_order += mdata->Track();
 
                     songMap.insert(album_order, m_songs.at(x));

--- a/mythtv/libs/libmythmetadata/metaioflacvorbis.cpp
+++ b/mythtv/libs/libmythmetadata/metaioflacvorbis.cpp
@@ -139,6 +139,30 @@ MusicMetadata* MetaIOFLACVorbis::read(const QString &filename)
     if (metadata->Length() <= 0)
         metadata->setLength(getTrackLength(flacfile));
 
+    if (tag->contains("DISCNUMBER"))
+    {
+        bool valid = false;
+        int n = tag->fieldListMap()["DISCNUMBER"].toString().toInt(&valid);
+        if (valid)
+            metadata->setDiscNumber(n);
+    }
+
+    if (tag->contains("TOTALTRACKS"))
+    {
+        bool valid = false;
+        int n = tag->fieldListMap()["TOTALTRACKS"].toString().toInt(&valid);
+        if (valid)
+            metadata->setTrackCount(n);
+    }
+
+    if (tag->contains("TOTALDISCS"))
+    {
+        bool valid = false;
+        int n = tag->fieldListMap()["TOTALDISCS"].toString().toInt(&valid);
+        if (valid)
+            metadata->setDiscCount(n);
+    }
+
     delete flacfile;
 
     return metadata;


### PR DESCRIPTION
I noticed that mythmusic wasn't handling multi-disc albums correctly.

* the flacvorbis metadata handler didn't know about the `DISCNUMBER` tag so I added it (I added `TOTALTRACKS` and `TOTALDISCS` while I was there too). My goto reference for tag names is https://picard.musicbrainz.org/docs/mappings/ (all my music is tagged using Picard so this is what I've ended up with).
* once the discnumber was in the DB I noticed that the album sort wasn't handling it correctly, e.g. for a two disc album it would sort disc.track-wise as 1.1, 2.1, 1.2, 2.2, etc rather than 1.1, 1.2, ..., 2.1, 2.2. Incorporate the disc number into the album order to correct this. I believe a single CD can have at most 99 tracks so use a multiplier of 100. This means a 10 disc box set would clash with album map order offset of 1000, so bump that to 10000.

I've been running this on my v30 based production system for a week and have tested against master.