### PR TITLE
Fix musicmetadata handling of compilations

### DIFF
--- a/mythtv/libs/libmythmetadata/metaioflacvorbis.cpp
+++ b/mythtv/libs/libmythmetadata/metaioflacvorbis.cpp
@@ -125,6 +125,16 @@ MusicMetadata* MetaIOFLACVorbis::read(const QString &filename)
             compilation = true;
         }
     }
+    else if (tag->contains("ALBUMARTIST"))
+    {
+        QString compilation_artist = TStringToQString(
+            tag->fieldListMap()["ALBUMARTIST"].toString()).trimmed();
+        if (compilation_artist != metadata->Artist())
+        {
+            metadata->setCompilationArtist(compilation_artist);
+            compilation = true;
+        }
+    }
 
     if (!compilation && tag->contains("MUSICBRAINZ_ALBUMARTISTID"))
     {

--- a/mythtv/libs/libmythmetadata/musicfilescanner.cpp
+++ b/mythtv/libs/libmythmetadata/musicfilescanner.cpp
@@ -318,6 +318,10 @@ void MusicFileScanner::AddFileToDB(const QString &filename, const QString &start
                 data->setAlbumId(m_albumid[album_cache_string]);
         }
 
+        int caid = m_artistid[data->CompilationArtist().toLower()];
+        if (caid > 0)
+            data->setCompilationArtistId(caid);
+
         int gid = m_genreid[data->Genre().toLower()];
         if (gid > 0)
             data->setGenreId(gid);
@@ -328,6 +332,9 @@ void MusicFileScanner::AddFileToDB(const QString &filename, const QString &start
         // Update the cache
         m_artistid[data->Artist().toLower()] =
             data->getArtistId();
+
+        m_artistid[data->CompilationArtist().toLower()] =
+            data->getCompilationArtistId();
 
         m_genreid[data->Genre().toLower()] =
             data->getGenreId();
@@ -599,6 +606,10 @@ void MusicFileScanner::UpdateFileInDB(const QString &filename, const QString &st
                 disk_meta->setAlbumId(m_albumid[album_cache_string]);
         }
 
+        int caid = m_artistid[disk_meta->CompilationArtist().toLower()];
+        if (caid > 0)
+            disk_meta->setCompilationArtistId(caid);
+
         int gid = m_genreid[disk_meta->Genre().toLower()];
         if (gid > 0)
             disk_meta->setGenreId(gid);
@@ -613,6 +624,8 @@ void MusicFileScanner::UpdateFileInDB(const QString &filename, const QString &st
         // Update the cache
         m_artistid[disk_meta->Artist().toLower()]
             = disk_meta->getArtistId();
+        m_artistid[disk_meta->CompilationArtist().toLower()]
+            = disk_meta->getCompilationArtistId();
         m_genreid[disk_meta->Genre().toLower()]
             = disk_meta->getGenreId();
         album_cache_string = QString::number(disk_meta->getArtistId()) + "#" +

--- a/mythtv/libs/libmythmetadata/musicfilescanner.cpp
+++ b/mythtv/libs/libmythmetadata/musicfilescanner.cpp
@@ -13,7 +13,7 @@
 #include <metaio.h>
 #include <musicfilescanner.h>
 
-MusicFileScanner::MusicFileScanner()
+MusicFileScanner::MusicFileScanner(bool force) : m_forceupdate{force}
 {
     MSqlQuery query(MSqlQuery::InitCon());
 
@@ -803,7 +803,7 @@ void MusicFileScanner::ScanMusic(MusicLoadedMap &music_files)
             {
                 if (music_files[name].location == MusicFileScanner::kDatabase)
                     continue;
-                if (HasFileChanged(name, query.value(1).toString()))
+                if (m_forceupdate || HasFileChanged(name, query.value(1).toString()))
                     music_files[name].location = MusicFileScanner::kNeedUpdate;
                 else
                 {

--- a/mythtv/libs/libmythmetadata/musicfilescanner.h
+++ b/mythtv/libs/libmythmetadata/musicfilescanner.h
@@ -29,7 +29,7 @@ class META_PUBLIC MusicFileScanner
 
     using MusicLoadedMap = QMap <QString, MusicFileData>;
     public:
-        MusicFileScanner(void);
+        MusicFileScanner(bool force = false);
         ~MusicFileScanner(void) = default;
 
         void SearchDirs(const QStringList &dirList);
@@ -69,6 +69,8 @@ class META_PUBLIC MusicFileScanner
         uint m_coverartAdded     {0};
         uint m_coverartRemoved   {0};
         uint m_coverartUpdated   {0};
+
+        bool m_forceupdate;
 };
 
 #endif // _MUSICFILESCANNER_H_

--- a/mythtv/libs/libmythmetadata/musicmetadata.cpp
+++ b/mythtv/libs/libmythmetadata/musicmetadata.cpp
@@ -537,11 +537,20 @@ int MusicMetadata::getArtistId()
             }
             m_artistId = query.lastInsertId().toInt();
         }
+    }
+
+    return m_artistId;
+}
+
+int MusicMetadata::getCompilationArtistId()
+{
+    if (m_compartistId < 0) {
+        MSqlQuery query(MSqlQuery::InitCon());
 
         // Compilation Artist
         if (m_artist == m_compilationArtist)
         {
-            m_compartistId = m_artistId;
+            m_compartistId = getArtistId();
         }
         else
         {
@@ -572,7 +581,7 @@ int MusicMetadata::getArtistId()
         }
     }
 
-    return m_artistId;
+    return m_compartistId;
 }
 
 int MusicMetadata::getAlbumId()
@@ -672,6 +681,9 @@ void MusicMetadata::dumpToDatabase()
 
     if (m_artistId < 0)
         getArtistId();
+
+    if (m_compartistId < 0)
+        getCompilationArtistId();
 
     if (m_albumId < 0)
         getAlbumId();
@@ -1537,6 +1549,7 @@ void AllMusic::resync()
 
             dbMeta->setDirectoryId(query.value(11).toInt());
             dbMeta->setArtistId(query.value(1).toInt());
+            dbMeta->setCompilationArtistId(query.value(3).toInt());
             dbMeta->setAlbumId(query.value(4).toInt());
             dbMeta->setTrackCount(query.value(19).toInt());
             dbMeta->setFileSize(query.value(20).toULongLong());

--- a/mythtv/libs/libmythmetadata/musicmetadata.cpp
+++ b/mythtv/libs/libmythmetadata/musicmetadata.cpp
@@ -865,16 +865,28 @@ inline QString MusicMetadata::formatReplaceSymbols(const QString &format)
 void MusicMetadata::checkEmptyFields()
 {
     if (m_artist.isEmpty())
+    {
         m_artist = tr("Unknown Artist", "Default artist if no artist");
+        m_artistId = -1;
+    }
     // This should be the same as Artist if it's a compilation track or blank
     if (!m_compilation || m_compilationArtist.isEmpty())
+    {
         m_compilationArtist = m_artist;
+        m_compartistId = -1;
+    }
     if (m_album.isEmpty())
+    {
         m_album = tr("Unknown Album", "Default album if no album");
+        m_albumId = -1;
+    }
     if (m_title.isEmpty())
         m_title = m_filename;
     if (m_genre.isEmpty())
+    {
         m_genre = tr("Unknown Genre", "Default genre if no genre");
+        m_genreId = -1;
+    }
     ensureSortFields();
 }
 

--- a/mythtv/libs/libmythmetadata/musicmetadata.cpp
+++ b/mythtv/libs/libmythmetadata/musicmetadata.cpp
@@ -676,6 +676,8 @@ QString MusicMetadata::Url(uint index)
 
 void MusicMetadata::dumpToDatabase()
 {
+    checkEmptyFields();
+
     if (m_directoryId < 0)
         getDirectoryId();
 

--- a/mythtv/libs/libmythmetadata/musicmetadata.cpp
+++ b/mythtv/libs/libmythmetadata/musicmetadata.cpp
@@ -776,10 +776,14 @@ void MusicMetadata::dumpToDatabase()
     if (m_albumArt)
         m_albumArt->dumpToDatabase();
 
-    // make sure the compilation flag is updated
-    query.prepare("UPDATE music_albums SET compilation = :COMPILATION, year = :YEAR "
+    // update the album
+    query.prepare("UPDATE music_albums SET album_name = :ALBUM_NAME, "
+                  "artist_id = :COMP_ARTIST_ID, compilation = :COMPILATION, "
+                  "year = :YEAR "
                   "WHERE music_albums.album_id = :ALBUMID");
     query.bindValue(":ALBUMID", m_albumId);
+    query.bindValue(":ALBUM_NAME", m_album);
+    query.bindValue(":COMP_ARTIST_ID", m_compartistId);
     query.bindValue(":COMPILATION", m_compilation);
     query.bindValue(":YEAR", m_year);
 

--- a/mythtv/libs/libmythmetadata/musicmetadata.h
+++ b/mythtv/libs/libmythmetadata/musicmetadata.h
@@ -179,6 +179,9 @@ class META_PUBLIC MusicMetadata
     void setArtistId(int lartistid) { m_artistId = lartistid; }
     int getArtistId();
 
+    void setCompilationArtistId(int lartistid) { m_compartistId = lartistid; }
+    int getCompilationArtistId();
+
     void setAlbumId(int lalbumid) { m_albumId = lalbumid; }
     int getAlbumId();
 

--- a/mythtv/libs/libmythmetadata/musicmetadata.h
+++ b/mythtv/libs/libmythmetadata/musicmetadata.h
@@ -108,7 +108,6 @@ class META_PUBLIC MusicMetadata
                    m_filename(std::move(lfilename))
     {
         checkEmptyFields();
-        ensureSortFields();
     }
 
     MusicMetadata(int lid, QString lbroadcaster, QString lchannel, QString ldescription, UrlList lurls, QString llogourl,

--- a/mythtv/libs/libmythmetadata/musicmetadata.h
+++ b/mythtv/libs/libmythmetadata/musicmetadata.h
@@ -129,6 +129,7 @@ class META_PUBLIC MusicMetadata
                    const QString &lartist_sort = nullptr)
     {
         m_artist = lartist;
+        m_artistId = -1;
         m_artistSort = lartist_sort;
         m_formattedArtist.clear(); m_formattedTitle.clear();
         ensureSortFields();
@@ -140,6 +141,7 @@ class META_PUBLIC MusicMetadata
                               const QString &lcompilation_artist_sort = nullptr)
     {
         m_compilationArtist = lcompilation_artist;
+        m_compartistId = -1;
         m_compilationArtistSort = lcompilation_artist_sort;
         m_formattedArtist.clear(); m_formattedTitle.clear();
         ensureSortFields();
@@ -151,6 +153,7 @@ class META_PUBLIC MusicMetadata
                   const QString &lalbum_sort = nullptr)
     {
         m_album = lalbum;
+        m_albumId = -1;
         m_albumSort = lalbum_sort;
         m_formattedArtist.clear(); m_formattedTitle.clear();
         ensureSortFields();
@@ -170,7 +173,10 @@ class META_PUBLIC MusicMetadata
     QString FormatTitle();
 
     QString Genre() const { return m_genre; }
-    void setGenre(const QString &lgenre) { m_genre = lgenre; }
+    void setGenre(const QString &lgenre) {
+        m_genre = lgenre;
+        m_genreId = -1;
+    }
 
     void setDirectoryId(int ldirectoryid) { m_directoryId = ldirectoryid; }
     int getDirectoryId();

--- a/mythtv/programs/mythutil/commandlineparser.cpp
+++ b/mythtv/programs/mythutil/commandlineparser.cpp
@@ -232,6 +232,8 @@ void MythUtilCommandLineParser::LoadArguments(void)
         ->SetChildOf("notification");
 
     // musicmetautils.cpp
+    add("--force", "musicforce", false, "Ignore file timestamps", "")
+        ->SetChildOf("scanmusic");
     add("--songid", "songid", "", "ID of track to update", "")
         ->SetChildOf("updatemeta");
     add("--title", "title", "", "(optional) Title of track", "")

--- a/mythtv/programs/mythutil/musicmetautils.cpp
+++ b/mythtv/programs/mythutil/musicmetautils.cpp
@@ -178,9 +178,9 @@ static int ExtractImage(const MythUtilCommandLineParser &cmdline)
     return GENERIC_EXIT_OK;
 }
 
-static int ScanMusic(const MythUtilCommandLineParser &/*cmdline*/)
+static int ScanMusic(const MythUtilCommandLineParser &cmdline)
 {
-    auto *fscan = new MusicFileScanner();
+    auto *fscan = new MusicFileScanner(cmdline.toBool("musicforce"));
     QStringList dirList;
 
     if (!StorageGroup::FindDirs("Music", gCoreContext->GetHostName(), &dirList))


### PR DESCRIPTION
I was observing that I had one `music_albums` entry per track on each compilation album after the album was scanned the second time (first time it went in correctly).

There are two things I needed to fix to make this work correctly:

Firstly in the flacvorbis code handle `ALBUMARTIST` as a fallback for `COMPILATION_ARTIST`.     Although there is no real standard this is as described in https://picard.musicbrainz.org/docs/mappings/ and what one gets by default using the picard tool (as I do).

Secondly ensure that the `MusicMetadata::m_compartistId` is always properly setup, I was observing that it was still `-1` by the time the database writes were happening, which ends up as `0` in the db (because the `music_albums.album_id` field is unsigned) which then wouldn't match on subsequent lookups, so multiple albums were created for compilations (one per track). The fix is to make sure the compilation artist id is always properly set.

As well as the fixes I've also added a `--force` flag to `mythutil --scanmusic` which ignores the file timestamp, so it updates everything, this is useful when testing changes like this where the files don't actually change.

I've run this on my v30 production system as well as some tests (scanning and querying the db) on a sandboxes master build. FWIW the porting was mostly trivial but had a few clashes with Dave Hampton's various `tidy: *` commits in the interval v30..HEAD. They were:
* Various `m_*id` renamed `m_*Id`
* The way member variables are initialised in `MusicFileScanner::MusicFileScanner` is different so needed minor adjustments.

If this is a candidate for v31 backport and you want a backport I'm happy to make one (but I think the cherry-pick will be trivial, the above are v30..v31 conflicts not v31..HEAD I think)