### PR TITLE
honour port setting in mythconverg backup/restore perl scripts

### DIFF
--- a/mythtv/programs/scripts/database/mythconverg_backup.pl
+++ b/mythtv/programs/scripts/database/mythconverg_backup.pl
@@ -13,7 +13,7 @@
 
 # Script info
     $NAME           = 'MythTV Database Backup Script';
-    $VERSION        = '1.0.13';
+    $VERSION        = '1.0.14';
 
 # Some variables we'll use here
     our ($username, $homedir, $mythconfdir, $database_information_file);
@@ -710,6 +710,7 @@ EOF
             }
             $dbh = DBI->connect("dbi:mysql:".
                                 "host=$temp_host:".
+                                "port=$mysql_conf{'db_port'}:".
                                 "database=$mysql_conf{'db_name'}",
                                 "$mysql_conf{'db_user'}",
                                 "$mysql_conf{'db_pass'}",

--- a/mythtv/programs/scripts/database/mythconverg_restore.pl
+++ b/mythtv/programs/scripts/database/mythconverg_restore.pl
@@ -13,7 +13,7 @@
 
 # Script info
     $NAME           = 'MythTV Database Restore Script';
-    $VERSION        = '1.0.19';
+    $VERSION        = '1.0.20';
 
 # Some variables we'll use here
     our ($username, $homedir, $mythconfdir, $database_information_file);
@@ -925,6 +925,7 @@ EOF
             }
         }
         $connect_string .= ":host=$temp_host";
+        $connect_string .= ":port=$mysql_conf{'db_port'}";
         if ($use_db)
         {
             $connect_string .= ":database=$mysql_conf{'db_name'}";


### PR DESCRIPTION
While trying to move my mythbackend sql database to my syndology nas (which uses port 3307 for its mariadb server) I discovered that mythconverg_restore.pl and mythconverg_backup.pl don't honour the port setting in config.xml when trying to login to the mysql server.

Confirmed working using mythtv/31 on my pi4 gentoo based mythtv installation