### PR TITLE
Python: Update JOBTYPEs

### DIFF
--- a/mythtv/bindings/python/MythTV/static.py
+++ b/mythtv/bindings/python/MythTV/static.py
@@ -119,6 +119,8 @@ class JOBTYPE( object ):
     SYSTEMJOB    = 0x00ff
     TRANSCODE    = 0x0001
     COMMFLAG     = 0x0002
+    METADATA     = 0x0004
+    PREVIEW      = 0x0008
     USERJOB      = 0xff00
     USERJOB1     = 0x0100
     USERJOB2     = 0x0200


### PR DESCRIPTION
The Python API binding is missing several constants related to jobqueue:

89b6416b50c  78 (Robert McNamara          2011-07-03 16:49:38 -0700  79)     JOB_METADATA     = 0x0004,
ab33dd919ef  80 (John Poet                2018-03-08 16:02:25 -0700  80)     JOB_PREVIEW      = 0x0008,

I already updated:
* https://www.mythtv.org/wiki/Job_Queue
* https://www.mythtv.org/wiki/Jobqueue_table

Thank you for contributing to MythTV.

As many of our developers do not visit GitHub it is important to track
all contributions at our central ticket tracker over at code.mythtv.org

To prevent your contributions being overlooked please create a new ticket
there and refer to this pull request. (Bonus points for linking to the
ticket in the pull request, too. It helps us noticed potentially overlooked
pull requests due to missing tickets.)

https://code.mythtv.org/trac/wiki/TicketHowTo
https://code.mythtv.org/trac/newticket
