### PR TITLE
libmythui: Hide the mouse cursor on gnome-shell under xwayland

### DIFF
--- a/mythtv/libs/libmythui/mythmainwindow.cpp
+++ b/mythtv/libs/libmythui/mythmainwindow.cpp
@@ -1004,12 +1004,6 @@ void MythMainWindow::Init(bool mayReInit)
     // screen position ends up stuck. Adding a border temporarily prevents this
     setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
 
-    if (!inwindow)
-    {
-        LOG(VB_GENERAL, LOG_INFO, "Using Frameless Window");
-        flags |= Qt::FramelessWindowHint;
-    }
-
     // Workaround Qt/Windows playback bug?
 #ifdef _WIN32
     flags |= Qt::MSWindowsOwnDC;


### PR DESCRIPTION
Prior to this change the mouse cursor would be visible over the UI upon startup. It would remain visible despite pressing keys or starting a video. The only way to make it disappear was to plug in a mouse and move it.

I've included this patch in the [Arch Linux mythtv-git](https://aur.archlinux.org/packages/mythtv-git) package. Thanks for a taking a look.

Sorry for missing a Trac ticket. I read through everything on the [TicketHowTo](https://code.mythtv.org/trac/wiki/TicketHowTo) but I couldn't figure out how to create a new Trac account. Without an account I cannot login. Visiting the [new ticket](https://code.mythtv.org/trac/newticket) page just tells that `TICKET_CREATE privileges are required`.