### PR TITLE
extend metadatagrabber timeout to 3 minutes

### DIFF
--- a/mythtv/libs/libmythmetadata/metadatagrabber.cpp
+++ b/mythtv/libs/libmythmetadata/metadatagrabber.cpp
@@ -425,7 +425,7 @@ MetadataLookupList MetaGrabberScript::RunGrabber(const QStringList &args,
         .arg(m_fullcommand).arg(args.join(" ")));
 
     grabber.Run();
-    if (grabber.Wait(60) != GENERIC_EXIT_OK)
+    if (grabber.Wait(180) != GENERIC_EXIT_OK)
         return list;
 
     QByteArray result = grabber.ReadAll();

--- a/mythtv/programs/scripts/metadata/Movie/tmdb3.py
+++ b/mythtv/programs/scripts/metadata/Movie/tmdb3.py
@@ -289,7 +289,7 @@ def main():
     opts, args = parser.parse_args()
 
     signal.signal(signal.SIGALRM, timeouthandler)
-    signal.alarm(30)
+    signal.alarm(180)
 
     if opts.version:
         buildVersion()


### PR DESCRIPTION
ttvdb and tmdb are sometimes quite slow to respond to queries, and the 60 seconds timeout is really too short. Extending it to 180s (3 minutes) solves issues for me, and allow fetching of metadata for all movies / series in my library (which are many).

I have a very fast (fiber) internet connection, so the issue is not my connection, also multiple reports on this issue can be found on the web. For some reason, slower replies of tmdb seem linked to certain movies. Meaning that some queries yield a reply in less than 60 seconds, yet consistent repeated queries for certain movies never return a result within 60 seconds.


