### PR TITLE
correct relevance test for programgenres

### DIFF
--- a/mythtv/programs/mythfrontend/progdetails.cpp
+++ b/mythtv/programs/mythfrontend/progdetails.cpp
@@ -626,7 +626,7 @@ void ProgDetails::loadPage(void)
 
     query.prepare("SELECT genre FROM programgenres "
                   "WHERE chanid = :CHANID AND starttime = :STARTTIME "
-                  "AND relevance > 0 ORDER BY relevance;");
+                  "AND relevance <> '0' ORDER BY relevance;");
     query.bindValue(":CHANID",    m_progInfo.GetChanID());
     query.bindValue(":STARTTIME", m_progInfo.GetScheduledStartTime());
 


### PR DESCRIPTION
The relevance column is used for sequencing but
it is not a number, but a character.  Testing
for > 0 results in not returning the entire list
of genres when the set is large (which can be
generated by (at least) the schedules direct
grabbers for some programs).

    Fixes: #212

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

