### PR TITLE
Remove a lingering DataDirect grabber artifact in filldata.h

### DIFF
--- a/mythtv/programs/mythfilldatabase/filldata.h
+++ b/mythtv/programs/mythfilldatabase/filldata.h
@@ -35,7 +35,6 @@ struct Source
     bool    xmltvgrabber_manualconfig {false};
     bool    xmltvgrabber_cache        {false};
     QString xmltvgrabber_prefmethod;
-    vector<int> dd_dups;
 };
 using SourceList = vector<Source>;
 


### PR DESCRIPTION
With commit 3260e981 the DataDirect grabber was removed from the
code base.

The vector dd_dups (which was only used by the DataDirect grabber)
was not removed from the Source struct at that time.  Remove it.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

