### PR TITLE
Fix incorrect artwork urls returned from ttvdb grabber

### DIFF
--- a/mythtv/bindings/python/MythTV/ttvdb/XSLT/tvdbQuery.xsl
+++ b/mythtv/bindings/python/MythTV/ttvdb/XSLT/tvdbQuery.xsl
@@ -48,22 +48,22 @@
                         <xsl:if test=".//poster/text() != ''">
                             <xsl:element name="image">
                                 <xsl:attribute name="type">coverart</xsl:attribute>
-                                <xsl:attribute name="url"><xsl:value-of select="concat('http://www.thetvdb.com/banners/', normalize-space(poster))"/></xsl:attribute>
-                                <xsl:attribute name="thumb"><xsl:value-of select="concat('http://www.thetvdb.com/banners/_cache/', normalize-space(poster))"/></xsl:attribute>
+                                <xsl:attribute name="url"><xsl:value-of select="concat('http://www.thetvdb.com', normalize-space(poster))"/></xsl:attribute>
+                                <xsl:attribute name="thumb"><xsl:value-of select="tvdbXpath:replace(concat('http://www.thetvdb.com', normalize-space(poster)), '/banners/', '/banners/_cache/')"/></xsl:attribute>
                             </xsl:element>
                         </xsl:if>
                         <xsl:if test=".//fanart/text() != ''">
                             <xsl:element name="image">
                                 <xsl:attribute name="type">fanart</xsl:attribute>
-                                <xsl:attribute name="url"><xsl:value-of select="concat('http://www.thetvdb.com/banners/', normalize-space(fanart))"/></xsl:attribute>
-                                <xsl:attribute name="thumb"><xsl:value-of select="concat('http://www.thetvdb.com/banners/_cache/', normalize-space(fanart))"/></xsl:attribute>
+                                <xsl:attribute name="url"><xsl:value-of select="concat('http://www.thetvdb.com', normalize-space(fanart))"/></xsl:attribute>
+                                <xsl:attribute name="thumb"><xsl:value-of select="tvdbXpath:replace(concat('http://www.thetvdb.com', normalize-space(fanart)), '/banners/', '/banners/_cache/')"/></xsl:attribute>
                             </xsl:element>
                         </xsl:if>
                         <xsl:if test=".//banner/text() != ''">
                             <xsl:element name="image">
                                 <xsl:attribute name="type">banner</xsl:attribute>
-                                <xsl:attribute name="url"><xsl:value-of select="concat('http://www.thetvdb.com/banners/', normalize-space(banner))"/></xsl:attribute>
-                                <xsl:attribute name="thumb"><xsl:value-of select="concat('http://www.thetvdb.com/banners/_cache/', normalize-space(banner))"/></xsl:attribute>
+                                <xsl:attribute name="url"><xsl:value-of select="concat('http://www.thetvdb.com', normalize-space(banner))"/></xsl:attribute>
+                                <xsl:attribute name="thumb"><xsl:value-of select="tvdbXpath:replace(concat('http://www.thetvdb.com', normalize-space(banner)), '/banners/', '/banners/_cache/')"/></xsl:attribute>
                             </xsl:element>
                         </xsl:if>
                     </images>


### PR DESCRIPTION
When performing a manual search for metadata for a video, the artwork
fetch was failing: no thumbnail was shown and no artwork was being
associated with the video. Ticket 13518 mentioned strange urls containing
"banners/_cache//banners". This commit fixes the bad urls and seems to
restore the downloading of the artwork. I don't know what led to the need
for this.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x ] code compiles successfully without errors
- [x ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

