### PR TITLE
changed exit prompted to only appear in a single case

### DIFF
--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -263,12 +263,15 @@ void ExitPrompter::Confirm(MythPower::Feature Action) const
     else 
     {
       // no prompts required, take a specific action required
+      // calling these exitprompter functions with (true) fails build
+      bool isTrue;
+      isTrue=true;
       if (Action == MythPower::FeatureShutdown)
-          ExitPrompter::DoHalt(true);
+          ExitPrompter::DoHalt(isTrue);
       else if (Action == MythPower::FeatureRestart)
-          ExitPrompter::DoReboot(true);
+          ExitPrompter::DoReboot(isTrue);
       else if (Action == MythPower::FeatureSuspend)
-          ExitPrompter::DoSuspend(true);
+          ExitPrompter::DoSuspend(isTrue);
     }
 
     gContext->SetDisableEventPopup(false);

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -36,7 +36,7 @@ void ExitPrompter::ConfirmHalt() const
     Confirm(MythPower::FeatureShutdown);
 }
 
-void ExitPrompter::DoHalt(const bool Confirmed) const
+void ExitPrompter::DoHalt(const bool Confirmed)
 {
     if (!Confirmed)
         return;
@@ -67,7 +67,7 @@ void ExitPrompter::ConfirmReboot() const
     Confirm(MythPower::FeatureRestart);
 }
 
-void ExitPrompter::DoReboot(const bool Confirmed) const
+void ExitPrompter::DoReboot(const bool Confirmed)
 {
     if (!Confirmed)
         return;
@@ -97,7 +97,7 @@ void ExitPrompter::ConfirmSuspend(void) const
     Confirm(MythPower::FeatureSuspend);
 }
 
-void ExitPrompter::DoSuspend(const bool Confirmed) const
+void ExitPrompter::DoSuspend(const bool Confirmed)
 {
     if (!Confirmed)
         return;

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -263,15 +263,12 @@ void ExitPrompter::Confirm(MythPower::Feature Action) const
     else 
     {
       // no prompts required, take a specific action required
-      // calling these exitprompter functions with (true) fails build
-      bool isTrue;
-      isTrue=true;
       if (Action == MythPower::FeatureShutdown)
-          ExitPrompter::DoHalt(isTrue);
+          DoHalt(true);
       else if (Action == MythPower::FeatureRestart)
-          ExitPrompter::DoReboot(isTrue);
+          DoReboot(true);
       else if (Action == MythPower::FeatureSuspend)
-          ExitPrompter::DoSuspend(isTrue);
+          DoSuspend(true);
     }
 
     gContext->SetDisableEventPopup(false);

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -264,11 +264,11 @@ void ExitPrompter::Confirm(MythPower::Feature Action) const
     {
       // no prompts required, take a specific action required
       if (Action == MythPower::FeatureShutdown)
-          ExitPrompter::DoHalt;
+          ExitPrompter::DoHalt(true);
       else if (Action == MythPower::FeatureRestart)
-          ExitPrompter::DoReboot;
+          ExitPrompter::DoReboot(true);
       else if (Action == MythPower::FeatureSuspend)
-          ExitPrompter::DoSuspend;
+          ExitPrompter::DoSuspend(true);
     }
 
     gContext->SetDisableEventPopup(false);

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -36,7 +36,7 @@ void ExitPrompter::ConfirmHalt() const
     Confirm(MythPower::FeatureShutdown);
 }
 
-void ExitPrompter::DoHalt(const bool Confirmed)
+void ExitPrompter::DoHalt(const bool Confirmed) const
 {
     if (!Confirmed)
         return;
@@ -67,7 +67,7 @@ void ExitPrompter::ConfirmReboot() const
     Confirm(MythPower::FeatureRestart);
 }
 
-void ExitPrompter::DoReboot(const bool Confirmed)
+void ExitPrompter::DoReboot(const bool Confirmed) const
 {
     if (!Confirmed)
         return;
@@ -97,7 +97,7 @@ void ExitPrompter::ConfirmSuspend(void) const
     Confirm(MythPower::FeatureSuspend);
 }
 
-void ExitPrompter::DoSuspend(const bool Confirmed)
+void ExitPrompter::DoSuspend(const bool Confirmed) const
 {
     if (!Confirmed)
         return;

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -263,12 +263,15 @@ void ExitPrompter::Confirm(MythPower::Feature Action) const
     else 
     {
       // no prompts required, take a specific action required
+      // calling these exitprompter functions with (true) fails build
+      bool isTrue;
+      isTrue=true;
       if (Action == MythPower::FeatureShutdown)
-          DoHalt(true);
+          DoHalt(isTrue);
       else if (Action == MythPower::FeatureRestart)
-          DoReboot(true);
+          DoReboot(isTrue);
       else if (Action == MythPower::FeatureSuspend)
-          DoSuspend(true);
+          DoSuspend(isTrue);
     }
 
     gContext->SetDisableEventPopup(false);

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -36,7 +36,7 @@ void ExitPrompter::ConfirmHalt() const
     Confirm(MythPower::FeatureShutdown);
 }
 
-void ExitPrompter::DoHalt(bool Confirmed)
+void ExitPrompter::DoHalt(const bool Confirmed)
 {
     if (!Confirmed)
         return;
@@ -67,7 +67,7 @@ void ExitPrompter::ConfirmReboot() const
     Confirm(MythPower::FeatureRestart);
 }
 
-void ExitPrompter::DoReboot(bool Confirmed)
+void ExitPrompter::DoReboot(const bool Confirmed)
 {
     if (!Confirmed)
         return;
@@ -97,7 +97,7 @@ void ExitPrompter::ConfirmSuspend(void) const
     Confirm(MythPower::FeatureSuspend);
 }
 
-void ExitPrompter::DoSuspend(bool Confirmed)
+void ExitPrompter::DoSuspend(const bool Confirmed)
 {
     if (!Confirmed)
         return;
@@ -264,14 +264,12 @@ void ExitPrompter::Confirm(MythPower::Feature Action) const
     {
       // no prompts required, take a specific action required
       // calling these exitprompter functions with (true) fails build
-      bool isTrue;
-      isTrue=true;
       if (Action == MythPower::FeatureShutdown)
-          DoHalt(isTrue);
+          DoHalt(true);
       else if (Action == MythPower::FeatureRestart)
-          DoReboot(isTrue);
+          DoReboot(true);
       else if (Action == MythPower::FeatureSuspend)
-          DoSuspend(isTrue);
+          DoSuspend(true);
     }
 
     gContext->SetDisableEventPopup(false);

--- a/mythtv/programs/mythfrontend/exitprompt.h
+++ b/mythtv/programs/mythfrontend/exitprompt.h
@@ -11,10 +11,10 @@ class ExitPrompter : public QObject
 
   public slots:
     static void DoQuit(void);
-    void DoHalt(bool Confirmed = true);
-    void DoReboot(bool Confirmed = true);
+    void DoHalt(bool Confirmed = true) const;
+    void DoReboot(bool Confirmed = true) const;
     static void DoStandby(void);
-    void DoSuspend(bool Confirmed = true);
+    void DoSuspend(bool Confirmed = true) const;
     void HandleExit(void);
     void ConfirmHalt(void) const;
     void ConfirmReboot(void) const;


### PR DESCRIPTION
changed exit prompted to only appear in a single case - where the backend and frontend are on the same system

any other prompting is excessive as there is already an unlikely-to-be-an-accident combination of keystrokes to get to this point
even if the user did mistakenly press the unlikely-to-be-a-mistake key sequence to shutdown, then this is unlikely to be of significant consequence to the user as they can just restart the computer/application

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ x] documentation added/updated/removed where necessary
- [ x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

