### PR TITLE
Do not omit recording rules that are not channel specific.

### DIFF
--- a/mythtv/programs/mythbackend/scheduler.cpp
+++ b/mythtv/programs/mythbackend/scheduler.cpp
@@ -4900,11 +4900,13 @@ void Scheduler::GetAllScheduled(RecList &proglist, SchedSortColumn sortBy,
         "       channel.commmethod                      " // 25
         "FROM record "
         "LEFT JOIN channel ON channel.callsign = record.station "
-        "WHERE deleted IS NULL "
+	// Exclude deleted channels except when ...
+	// ... this is an 'always on any channel' or 'find one' recording without the 'This Channel' filter
+        "WHERE deleted IS NULL OR ((type = %3 OR type = %4) AND filter & (1 << 10) = 0) "
         "GROUP BY recordid "
         "ORDER BY %1 %2");
 
-    query = query.arg(sortColumn).arg(order);
+    query = query.arg(sortColumn).arg(order).arg(kAllRecord).arg(kOneRecord);
 
     MSqlQuery result(MSqlQuery::InitCon());
     result.prepare(query);


### PR DESCRIPTION
I noticed that call to the services endpoint Dvr/GetRecordScheduleList wasn't returning all of my rules. Some investigation lead me to notice that GetAllScheduled was excluding rules that were linked to a deleted channel. This is fine in most cases, however there may be some "Any" rules in which the channel isn't relevant. These rules should still be returned.

I've copied the logic used by mythweb to identify these and they are now returned.

Previously recording rules would be omitted if the linked channel had been
deleted but this shouldn't apply to rules that are not channel specific.

Also note that logic taken from mythweb, specifically:
    modules/tv/tmpl/default/schedules.php

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ ] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

