### PR TITLE
Recorded time for OSD

### DIFF
--- a/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
+++ b/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
@@ -203,6 +203,7 @@ void MythPlayerOverlayUI::UpdateSliderInfo(osdInfo &Info, bool PaddedFields)
         Info.values.insert(relPrefix + "totalseconds", static_cast<int>(playbackLen.count()));
         Info.values[relPrefix + "position"] = pos;
 
+        QDateTime wallclock = m_playerCtx->m_playingRecStart.addSecs(secsplayed);
         QString text1;
         QString text2;
         QString text3;
@@ -230,6 +231,7 @@ void MythPlayerOverlayUI::UpdateSliderInfo(osdInfo &Info, bool PaddedFields)
         Info.text[relPrefix + "description"] = desc;
         Info.text[relPrefix + "playedtime"] = text1;
         Info.text[relPrefix + "totaltime"] = text2;
+        Info.text[relPrefix + "wallclocktime"] = wallclock.toLocalTime().toString("ddd MMM d yyyy, hh:mm:ss");
         Info.text[relPrefix + "remainingtime"] = islive ? QString() : text3;
         Info.text[relPrefix + "behindtime"] = islive ? text3 : QString();
     }

--- a/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
+++ b/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
@@ -203,7 +203,7 @@ void MythPlayerOverlayUI::UpdateSliderInfo(osdInfo &Info, bool PaddedFields)
         Info.values.insert(relPrefix + "totalseconds", static_cast<int>(playbackLen.count()));
         Info.values[relPrefix + "position"] = pos;
 
-        QDateTime wallclock = m_playerCtx->m_playingRecStart.addSecs(secsplayed);
+        QDateTime wallclock = m_playerCtx->m_playingRecStart.addSecs(static_cast<qint64>(secsplayed.count()));
         QString text1;
         QString text2;
         QString text3;

--- a/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
+++ b/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
@@ -203,7 +203,7 @@ void MythPlayerOverlayUI::UpdateSliderInfo(osdInfo &Info, bool PaddedFields)
         Info.values.insert(relPrefix + "totalseconds", static_cast<int>(playbackLen.count()));
         Info.values[relPrefix + "position"] = pos;
 
-        QDateTime wallclock = m_playerCtx->m_playingRecStart.addSecs(static_cast<qint64>(secsplayed.count()));
+        QDateTime recordedtime = m_playerCtx->m_playingRecStart.addSecs(static_cast<qint64>(secsplayed.count()));
         QString text1;
         QString text2;
         QString text3;
@@ -231,9 +231,11 @@ void MythPlayerOverlayUI::UpdateSliderInfo(osdInfo &Info, bool PaddedFields)
         Info.text[relPrefix + "description"] = desc;
         Info.text[relPrefix + "playedtime"] = text1;
         Info.text[relPrefix + "totaltime"] = text2;
-        Info.text[relPrefix + "wallclocktime"] = wallclock.toLocalTime().toString("ddd MMM d yyyy, hh:mm:ss");
         Info.text[relPrefix + "remainingtime"] = islive ? QString() : text3;
         Info.text[relPrefix + "behindtime"] = islive ? text3 : QString();
+        QString dtformat = gCoreContext->GetSetting("DateFormat", "ddd MMMM d yyyy")
+            + ", " + gCoreContext->GetSetting("TimeFormat", "hh:mm");
+        Info.text[relPrefix + "recordedtime"] = recordedtime.toLocalTime().toString(dtformat);
     }
 }
 

--- a/mythtv/libs/libmythtv/playercontext.cpp
+++ b/mythtv/libs/libmythtv/playercontext.cpp
@@ -27,6 +27,7 @@
 PlayerContext::PlayerContext(QString inUseID) :
     m_recUsage(std::move(inUseID))
 {
+    m_playingRecStart = QDateTime();
     m_lastSignalMsgTime.start();
     m_lastSignalMsgTime.addMSecs(-2 * kSMExitTimeout);
 }
@@ -519,6 +520,7 @@ void PlayerContext::SetPlayingInfo(const ProgramInfo *info)
         if (!ignoreDB)
             m_playingInfo->MarkAsInUse(true, m_recUsage);
         m_playingLen = m_playingInfo->GetSecondsInRecording();
+        m_playingRecStart = m_playingInfo->GetRecordingStartTime();
     }
 }
 

--- a/mythtv/libs/libmythtv/playercontext.h
+++ b/mythtv/libs/libmythtv/playercontext.h
@@ -11,6 +11,7 @@
 #include <QHash>
 #include <QRect>
 #include <QObject>
+#include <QDateTime>
 
 // MythTV headers
 #include "videoouttypes.h"
@@ -115,6 +116,7 @@ class MTV_PUBLIC PlayerContext
     MythMediaBuffer    *m_buffer             {nullptr};
     ProgramInfo        *m_playingInfo        {nullptr}; ///< Currently playing info
     std::chrono::seconds m_playingLen        {0s};  ///< Initial CalculateLength()
+    QDateTime           m_playingRecStart;
     int                 m_lastCardid         {-1}; ///< CardID of current/last recorder
     /// 0 == normal, +1 == fast forward, -1 == rewind
     int                 m_ffRewState         {0};

--- a/mythtv/themes/MythCenter-wide/osd.xml
+++ b/mythtv/themes/MythCenter-wide/osd.xml
@@ -154,6 +154,11 @@
             <area>10,10,870,40</area>
             <align>left,vcenter</align>
         </textarea>
+        <textarea name="wallclocktime">
+            <font>medium</font>
+            <area>10,10,870,40</area>
+            <align>hcenter,vcenter</align>
+        </textarea>
         <textarea name="description">
             <font>medium</font>
             <area>10,10,870,40</area>

--- a/mythtv/themes/MythCenter-wide/osd.xml
+++ b/mythtv/themes/MythCenter-wide/osd.xml
@@ -154,7 +154,7 @@
             <area>10,10,870,40</area>
             <align>left,vcenter</align>
         </textarea>
-        <textarea name="wallclocktime">
+        <textarea name="recordedtime">
             <font>medium</font>
             <area>10,10,870,40</area>
             <align>hcenter,vcenter</align>

--- a/mythtv/themes/MythCenter/osd.xml
+++ b/mythtv/themes/MythCenter/osd.xml
@@ -148,7 +148,7 @@
             <area>4,4,560,34</area>
             <align>left,vcenter</align>
         </textarea>
-        <textarea name="wallclocktime">
+        <textarea name="recordedtime">
             <font>medium</font>
             <area>4,4,560,34</area>
             <align>hcenter,vcenter</align>

--- a/mythtv/themes/MythCenter/osd.xml
+++ b/mythtv/themes/MythCenter/osd.xml
@@ -148,6 +148,11 @@
             <area>4,4,560,34</area>
             <align>left,vcenter</align>
         </textarea>
+        <textarea name="wallclocktime">
+            <font>medium</font>
+            <area>4,4,560,34</area>
+            <align>hcenter,vcenter</align>
+        </textarea>
         <textarea name="description">
             <font>medium</font>
             <area>4,4,560,34</area>

--- a/mythtv/themes/Terra/osd.xml
+++ b/mythtv/themes/Terra/osd.xml
@@ -290,7 +290,7 @@
             <template>%PLAYEDTIME% of %TOTALTIME%\n%(|REMAININGTIME| remaining)%%(|BEHINDTIME| behind)%</template>
         </textarea>
 
-        <textarea name="wallclocktime">
+        <textarea name="recordedtime">
             <font>basesmall</font>
             <area>10,6,600,50</area>
             <align>allcenter</align>

--- a/mythtv/themes/Terra/osd.xml
+++ b/mythtv/themes/Terra/osd.xml
@@ -286,8 +286,15 @@
             <area>310,6,280,50</area>
             <multiline>true</multiline>
             <font>basesmall</font>
-            <align>allcenter</align>
+            <align>right,vcenter</align>
             <template>%PLAYEDTIME% of %TOTALTIME%\n%(|REMAININGTIME| remaining)%%(|BEHINDTIME| behind)%</template>
+        </textarea>
+
+        <textarea name="wallclocktime">
+            <font>basesmall</font>
+            <area>10,6,600,50</area>
+            <align>allcenter</align>
+            <template>%1</template>
         </textarea>
 
         <progressbar name="position">


### PR DESCRIPTION
This replaces #127 which can now be closed.

This adds "recordedtime" of the recording which themes can add to the OSD.  This is handy for delayed live events or when you are just curious what time the show aired.  The shipped Terra, MythCenter and MythCenter-wide are updated as examples.  I didn't touch default since I am not sure how to test it.  I currently use this with Mythbuntu on fixes/31 via 17d4994dd28c396f4ea7b12d4fd58d3d1446881d and a3fac2f60e6901f853ee82126dc00ba87fea71b9.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

##### Ideas for enhancement:

- Setup option to toggle this clock per user preference.  If the xml can't be conditional then the code could return an empty string to display nothing.