### PR TITLE
Make use of mythuiwebbrowser.h bits in mythmusic optional

### DIFF
--- a/mythplugins/configure
+++ b/mythplugins/configure
@@ -614,6 +614,8 @@ if enabled browser; then
     if test "$WEBKIT" != "CONFIG_QTWEBKIT=yes"; then
         disable browser
         echo "MythBrowser requires QtWebkit."
+    else
+        append CCONFIG "using_browser"
     fi
 fi
 
@@ -687,13 +689,6 @@ if test x"$icc" != x ; then
 fi
 
 if enabled music ; then
-    if [ $qt_version -lt $(version2num "6.0.0") ]; then
-        if test "$WEBKIT" != "CONFIG_QTWEBKIT=yes"; then
-            disable music
-            echo "MythMusic requires QtWebkit."
-        fi
-    fi
-
     if ! check_lib vorbis/codec.h vorbis_info_init -lvorbis || ! check_lib vorbis/vorbisenc.h vorbis_encode_setup_vbr -lvorbisenc -lvorbis -logg ; then
         disable vorbis
         echo "MythMusic requires vorbis."
@@ -870,6 +865,10 @@ if enabled music ; then
       echo "#define HAVE_STDINT_H 1" >> ./mythmusic/mythmusic/config.h
     else
       echo "#undef  HAVE_STDINT_H" >> ./mythmusic/mythmusic/config.h
+    fi
+
+    if enabled browser ; then
+      echo "#define HAVE_BROWSER 1" >> ./mythmusic/mythmusic/config.h
     fi
 
     if enabled cdio ; then

--- a/mythplugins/mythmusic/mythmusic/editmetadata.cpp
+++ b/mythplugins/mythmusic/mythmusic/editmetadata.cpp
@@ -22,6 +22,10 @@
 #include <remotefile.h>
 #include <mthreadpool.h>
 
+#if HAVE_BROWSER
+#include <mythuiwebbrowser.h>
+#endif
+
 // mythmusic
 #include "musicdata.h"
 #include "decoder.h"
@@ -259,6 +263,8 @@ bool EditMetadataCommon::hasMetadataChanged(void)
     return changed;
 }
 
+#if HAVE_BROWSER
+
 /// search Google for images
 void EditMetadataCommon::searchForAlbumImages(void)
 {
@@ -274,6 +280,8 @@ void EditMetadataCommon::searchForAlbumImages(void)
 
     GetMythMainWindow()->HandleMedia("WebBrowser", url.toString(), GetConfDir() + "/MythMusic/", "front.jpg");
 }
+
+#endif // HAVE_BROWSER
 
 void EditMetadataCommon::scanForImages(void)
 {
@@ -485,9 +493,11 @@ void EditMetadataDialog::showMenu(void )
     menu->SetReturnEvent(this, "optionsmenu");
 
     menu->AddButton(tr("Edit Albumart Images"));
+#if HAVE_BROWSER
     menu->AddButton(tr("Search Internet For Artist Image"));
     menu->AddButton(tr("Search Internet For Album Image"));
     menu->AddButton(tr("Search Internet For Genre Image"));
+#endif
     menu->AddButton(tr("Check Track Length"));
 
     popupStack->AddScreen(menu);
@@ -708,6 +718,8 @@ void EditMetadataDialog::genreLostFocus(void)
     updateGenreImage();
 }
 
+#if HAVE_BROWSER
+
 /// search flickr for genre images
 void EditMetadataDialog::searchForGenreImages(void)
 {
@@ -732,6 +744,8 @@ void EditMetadataDialog::searchForArtistImages(void)
     GetMythMainWindow()->HandleMedia("WebBrowser", url.toString(), GetConfDir() + "/MythMusic/", "artist.jpg");
 }
 
+#endif
+
 void EditMetadataDialog::customEvent(QEvent *event)
 {
     if (event->type() == DialogCompletionEvent::kEventType)
@@ -749,6 +763,7 @@ void EditMetadataDialog::customEvent(QEvent *event)
         {
             if (resulttext == tr("Edit Albumart Images"))
                 switchToAlbumArt();
+#if HAVE_BROWSER
             else if (resulttext == tr("Search Internet For Genre Image"))
             {
                 updateMetadata();
@@ -764,6 +779,7 @@ void EditMetadataDialog::customEvent(QEvent *event)
                 updateMetadata();
                 searchForAlbumImages();
             }
+#endif
             else if (resulttext == tr("Check Track Length"))
             {
                 QStringList strList;
@@ -1052,7 +1068,9 @@ void EditAlbumartDialog::showMenu(void )
     menu->AddButton(tr("Rescan For Images"));
 
 
+#if HAVE_BROWSER
     menu->AddButton(tr("Search Internet For Images"));
+#endif
 
     MetaIO *tagger = MetaIO::createTagger(s_metadata->Filename(false));
 
@@ -1148,8 +1166,10 @@ void EditAlbumartDialog::customEvent(QEvent *event)
                 switchToMetadata();
             else if (resulttext == tr("Rescan For Images"))
                 rescanForImages();
+#if HAVE_BROWSER
             else if (resulttext == tr("Search Internet For Images"))
                 searchForAlbumImages();
+#endif
             else if (resulttext == tr("Change Image Type"))
                 showTypeMenu();
             else if (resulttext == tr("Copy Selected Image To Tag"))

--- a/mythplugins/mythmusic/mythmusic/editmetadata.h
+++ b/mythplugins/mythmusic/mythmusic/editmetadata.h
@@ -6,6 +6,8 @@
 #include <mythscreentype.h>
 #include <musicmetadata.h>
 
+#include "config.h"
+
 class MythUIStateType;
 class MythUIImage;
 class MythUIButton;
@@ -44,7 +46,9 @@ class EditMetadataCommon : public MythScreenType
   protected:
     static bool hasMetadataChanged(void);
     void updateMetadata(void);
+#if HAVE_BROWSER
     void searchForAlbumImages(void);
+#endif
     static void scanForImages(void);
 
     static bool           s_metadataOnly;
@@ -103,8 +107,10 @@ class EditMetadataDialog : public EditMetadataCommon
 
     void updateRating(void);
 
+#if HAVE_BROWSER
     void searchForArtistImages(void);
     void searchForGenreImages(void);
+#endif
 
     //
     //  GUI stuff


### PR DESCRIPTION
If qtwebkit (and therefore mythuiwebbrowser) are not available then omit the menu items relating to searching for artwork on the internet.

Fixes #328 (or at least, worksaround I suppose)

---

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

