### PR TITLE
Add new setting `AllowConnFromSubnets`

### DIFF
--- a/mythtv/libs/libmythbase/mythcorecontext.h
+++ b/mythtv/libs/libmythbase/mythcorecontext.h
@@ -316,6 +316,8 @@ class MBASE_PUBLIC MythCoreContext : public QObject, public MythObservable, publ
     void connectionClosed(MythSocket *sock) override; // MythSocketCBs
     void readyRead(MythSocket *sock) override; // MythSocketCBs
 
+    QList<QPair<QHostAddress, int>> allowedSubnets();
+
     QMap<QString,int>     m_testOverrideInts    {};
     QMap<QString,double>  m_testOverrideFloats  {};
     QMap<QString,QString> m_testOverrideStrings {};

--- a/mythtv/programs/mythtv-setup/backendsettings.h
+++ b/mythtv/programs/mythtv-setup/backendsettings.h
@@ -19,6 +19,8 @@ class BackendSettings : public GroupSetting
     HostComboBoxSetting        *m_backendServerAddr {nullptr};
     GlobalTextEditSetting      *m_masterServerName  {nullptr};
     IpAddressSettings          *m_ipAddressSettings {nullptr};
+    HostCheckBoxSetting        *m_allowConnFromAll  {nullptr};
+    HostTextEditSetting        *m_allowConnFromSubnets {nullptr};
     bool                        m_isLoaded          {false};
     QString                     m_priorMasterName;
 
@@ -29,6 +31,7 @@ class BackendSettings : public GroupSetting
   private slots:
     void masterBackendChanged(void);
     void listenChanged(void);
+    void allowConnFromAllChanged(bool);
 };
 
 #endif


### PR DESCRIPTION
This is a fine grained version of `AllowConnFromAll` which allows configuration
of specific subnets or hosts.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

