### PR TITLE
Increase cut-off for subtitle buffer clear, too small for SSA karaoke

### DIFF
--- a/mythtv/libs/libmythtv/subtitlereader.cpp
+++ b/mythtv/libs/libmythtv/subtitlereader.cpp
@@ -1,6 +1,10 @@
 #include "mythlogging.h"
 #include "subtitlereader.h"
 
+// If the count of subtitle buffers is greater than this, force a clear
+static const int MAX_BUFFERS_BEFORE_CLEAR = 175;  // 125 too low for karaoke
+
+
 SubtitleReader::~SubtitleReader()
 {
     ClearAVSubtitles();
@@ -54,10 +58,12 @@ bool SubtitleReader::AddAVSubtitle(AVSubtitle &subtitle,
     m_avSubtitles.m_buffers.push_back(subtitle);
     // in case forced subtitles aren't displayed, avoid leaking by
     // manually clearing the subtitles
-    if (m_avSubtitles.m_buffers.size() > 40)
+    if ( m_avSubtitles.m_buffers.size() > MAX_BUFFERS_BEFORE_CLEAR )
     {
-        LOG(VB_GENERAL, LOG_ERR,
-            "SubtitleReader: >40 AVSubtitles queued - clearing.");
+        LOG( VB_GENERAL, LOG_ERR, 
+             QString( "SubtitleReader: >%1 AVSubtitles queued - clearing." )
+                 .arg( MAX_BUFFERS_BEFORE_CLEAR )
+           );
         clearsubs = true;
     }
     m_avSubtitles.m_lock.unlock();


### PR DESCRIPTION
Karaoke-style Sub-Station Alpha (SSA) subtitles with decorative animations (e.g.: bouncing ball position) do not render correctly in MythFrontend due to an arbitrary(?) subtitle-buffers-count limit of 40.  Increasing this amount, and testing on various sources leads to a better value (of 175) which works for more different of subtitle karaoke-animation styles.

Code is branched off fixes/31

Issue Ref: https://github.com/MythTV/mythtv/issues/355

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)


