### PR TITLE
merge ReinitDone into Init

### DIFF
--- a/mythtv/libs/libmythui/mythmainwindow.cpp
+++ b/mythtv/libs/libmythui/mythmainwindow.cpp
@@ -715,22 +715,14 @@ void MythMainWindow::Init(bool MayReInit)
 
     move(m_screenRect.topLeft());
 
-    if (m_painterWin)
-    {
-        m_oldPainterWin = m_painterWin;
-        m_painterWin = nullptr;
-    }
-
-    if (m_painter)
-    {
-        m_oldPainter = m_painter;
-        m_painter = nullptr;
-    }
-
     QString warningmsg;
-    if (!m_painter && !m_painterWin)
+    if (m_painter || m_painterWin)
+    {
+        LOG(VB_GENERAL, LOG_INFO, "Destroying painter and painter window");
+        MythPainterWindow::DestroyPainters(m_painterWin, m_painter);
         warningmsg = MythPainterWindow::CreatePainters(this, m_painterWin, m_painter);
-
+    }
+    
     if (!m_painterWin)
     {
         LOG(VB_GENERAL, LOG_ERR, "MythMainWindow failed to create a painter window.");
@@ -954,13 +946,6 @@ void MythMainWindow::ReloadKeys()
     ClearKeyContext("Browser");
     ClearKeyContext("Main Menu");
     InitKeys();
-}
-
-void MythMainWindow::ReinitDone()
-{
-    MythPainterWindow::DestroyPainters(m_oldPainterWin, m_oldPainter);
-    ShowPainterWindow();
-    MoveResize(m_screenRect);
 }
 
 void MythMainWindow::Show()

--- a/mythtv/libs/libmythui/mythmainwindow.h
+++ b/mythtv/libs/libmythui/mythmainwindow.h
@@ -42,7 +42,6 @@ class MUI_PUBLIC MythMainWindow : public MythUIScreenBounds
 
   public:
     void Init(bool MayReInit = true);
-    void ReinitDone();
     void Show();
     void MoveResize(QRect& Geometry);
 
@@ -166,9 +165,7 @@ class MUI_PUBLIC MythMainWindow : public MythUIScreenBounds
     QTimer             m_refreshTimer;
     MythThemeBase*     m_themeBase     { nullptr };
     MythPainter*       m_painter       { nullptr };
-    MythPainter*       m_oldPainter    { nullptr };
     MythPainterWindow* m_painterWin    { nullptr };
-    MythPainterWindow* m_oldPainterWin { nullptr };
     MythInputDeviceHandler* m_deviceHandler { nullptr };
     MythScreenSaverControl* m_screensaver   { nullptr };
     QTimer             m_idleTimer;

--- a/mythtv/programs/mythfrontend/main.cpp
+++ b/mythtv/programs/mythfrontend/main.cpp
@@ -1395,7 +1395,6 @@ static bool resetTheme(QString themedir, const QString &badtheme)
     MythTranslation::reload();
     gCoreContext->ReInitLocale();
     GetMythMainWindow()->Init();
-    GetMythMainWindow()->ReinitDone();
 
     return RunMenu(themedir, themename);
 }
@@ -1466,7 +1465,6 @@ static int reloadTheme(void)
     if (g_menu)
         g_menu->Close();
     GetMythMainWindow()->Init();
-    GetMythMainWindow()->ReinitDone();
     GetMythMainWindow()->SetEffectsEnabled(true);
     if (!RunMenu(themedir, themename) && !resetTheme(themedir, themename))
         return GENERIC_EXIT_NO_THEME;
@@ -2087,7 +2085,6 @@ int main(int argc, char **argv)
 #if CONFIG_DARWIN
     GetMythMainWindow()->SetEffectsEnabled(false);
     GetMythMainWindow()->Init();
-    GetMythMainWindow()->ReinitDone();
     GetMythMainWindow()->SetEffectsEnabled(true);
     gLoaded = true;
 #endif

--- a/mythtv/programs/mythscreenwizard/main.cpp
+++ b/mythtv/programs/mythscreenwizard/main.cpp
@@ -76,7 +76,6 @@ static bool resetTheme(QString themedir, const QString badtheme)
     MythTranslation::reload();
     GetMythUI()->LoadQtConfig();
     GetMythMainWindow()->Init();
-    GetMythMainWindow()->ReinitDone();
 
     return RunMenu(themedir, themename);
 }

--- a/mythtv/programs/mythtv-setup/main.cpp
+++ b/mythtv/programs/mythtv-setup/main.cpp
@@ -203,7 +203,6 @@ static bool resetTheme(QString themedir, const QString &badtheme)
 
     MythTranslation::reload();
     GetMythMainWindow()->Init();
-    GetMythMainWindow()->ReinitDone();
 
     return RunMenu(themedir, themename);
 }
@@ -226,7 +225,6 @@ static int reloadTheme(void)
     if (menu)
         menu->Close();
     GetMythMainWindow()->Init();
-    GetMythMainWindow()->ReinitDone();
     GetMythMainWindow()->SetEffectsEnabled(true);
 
     if (!RunMenu(themedir, themename) && !resetTheme(themedir, themename))


### PR DESCRIPTION
I'm not sure why it was ever split, and it is currently only called immediately
after Init.
- Removed duplicated calls from ReinitDone
- Improved logic for recreating painters

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

