### PR TITLE
Compare literals using '!=' not 'is not'

### DIFF
--- a/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/data_mythtv.py
+++ b/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/data_mythtv.py
@@ -450,7 +450,7 @@ class _Mythtv_data(object):
             config_file= open(smoltfile)
             for line in config_file:
                 line = line.strip()
-                if line and line[0] is not "#" and line[-1] is not "=":
+                if line and line[0] != "#" and line[-1] != "=":
                     var,val = line.rsplit("=",1)
                     config[var.strip()] = val.strip("\"")
         except:


### PR DESCRIPTION
With Python 3.8 a syntax warning is now generated during
compilation when one is using 'is' or 'is not' to compare
to certain types of literals, as such use is not assured
to work properly to work with all interpreters.  This
syntax warning was a result of issue bpo-34850.

Fixes #370

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

