### PR TITLE
Adjust for the removal of the ABCs from the python collections module

### DIFF
--- a/mythplugins/mytharchive/mytharchivehelper/main.cpp
+++ b/mythplugins/mytharchive/mytharchivehelper/main.cpp
@@ -569,7 +569,7 @@ int NativeArchive::exportRecording(QDomElement   &itemNode,
 
     // add the recordedseek table
     QDomElement recordedseek = doc.createElement("recordedseek");
-    query.prepare("SELECT chanid, starttime, mark, offset, type "
+    query.prepare("SELECT chanid, starttime, mark, `offset`, type "
             "FROM recordedseek "
             "WHERE chanid = :CHANID and starttime = :STARTTIME;");
     query.bindValue(":CHANID", chanID);
@@ -1113,7 +1113,7 @@ int NativeArchive::importRecording(const QDomElement &itemNode,
                 QDomNode n6 = nodeList.item(x);
                 QDomElement e = n6.toElement();
                 query.prepare("INSERT INTO recordedseek (chanid, starttime, "
-                        "mark, offset, type)"
+                        "mark, `offset`, type)"
                         "VALUES(:CHANID,:STARTTIME,:MARK,:OFFSET,:TYPE);");
                 query.bindValue(":CHANID", chanID);
                 query.bindValue(":STARTTIME", startTime);

--- a/mythtv/bindings/perl/MythTV.pm
+++ b/mythtv/bindings/perl/MythTV.pm
@@ -390,7 +390,7 @@ EOF
         $self->{'master_port'} = $self->backend_setting('BackendServerPort',"$mastname");
 
         if (!$self->{'master_host'} || !$self->{'master_port'}) {
-            die "MasterServerIP or MasterServerPort not found!\n"
+            die "BackendServerAddr or BackendServerPort not found!\n"
                ."You may need to check your settings.php file or re-run mythtv-setup.\n";
         }
 

--- a/mythtv/bindings/php/MythBackend.php
+++ b/mythtv/bindings/php/MythBackend.php
@@ -38,7 +38,7 @@ class MythBackend {
             $host = setting('BackendServerAddr',$hostname);
             $port = setting('BackendServerPort',$hostname);
             if (!$host || !$port)
-                trigger_error("MasterServerIP or MasterServerPort not found! You may "
+                trigger_error("BackendServerAddr or BackendServerPort not found! You may "
                             ."need to check your mythweb.conf file or re-run mythtv-setup",
                             FATAL);
         }

--- a/mythtv/bindings/python/MythTV/utility/dicttoxml.py
+++ b/mythtv/bindings/python/MythTV/utility/dicttoxml.py
@@ -14,7 +14,10 @@ __version__ = '1.7.4'
 version = __version__
 
 from random import randint
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import numbers
 import logging
 from xml.dom.minidom import parseString
@@ -95,7 +98,7 @@ def get_xml_type(val):
         return 'null'
     if isinstance(val, dict):
         return 'dict'
-    if isinstance(val, collections.Iterable):
+    if isinstance(val, Iterable):
         return 'list'
     return type(val).__name__
 
@@ -187,7 +190,7 @@ def convert(obj, ids, attr_type, item_func, cdata, parent='root'):
     if isinstance(obj, dict):
         return convert_dict(obj, ids, parent, attr_type, item_func, cdata)
 
-    if isinstance(obj, collections.Iterable):
+    if isinstance(obj, Iterable):
         return convert_list(obj, ids, parent, attr_type, item_func, cdata)
 
     raise TypeError('Unsupported data type: %s (%s)' % (obj, type(obj).__name__))
@@ -231,7 +234,7 @@ def convert_dict(obj, ids, parent, attr_type, item_func, cdata):
                 )
             )
 
-        elif isinstance(val, collections.Iterable):
+        elif isinstance(val, Iterable):
             if attr_type:
                 attr['type'] = get_xml_type(val)
             addline('<%s%s>%s</%s>' % (
@@ -294,7 +297,7 @@ def convert_list(items, ids, parent, attr_type, item_func, cdata):
                     )
                 )
 
-        elif isinstance(item, collections.Iterable):
+        elif isinstance(item, Iterable):
             if not attr_type:
                 addline('<%s %s>%s</%s>' % (
                     item_name, make_attrstring(attr),

--- a/mythtv/bindings/python/tmdb3/tmdb3/pager.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/pager.py
@@ -5,7 +5,10 @@
 # Author: Raymond Wagner
 #-----------------------
 
-from collections import Sequence, Iterator
+try:
+    from collections.abc import Sequence, Iterator
+except ImportError:
+    from collections import Sequence, Iterator
 
 try:
     xrange

--- a/mythtv/libs/libmyth/programinfo.cpp
+++ b/mythtv/libs/libmyth/programinfo.cpp
@@ -3703,14 +3703,14 @@ void ProgramInfo::QueryPositionMap(
 
     if (IsVideo())
     {
-        query.prepare("SELECT mark, offset FROM filemarkup"
+        query.prepare("SELECT mark, `offset` FROM filemarkup"
                       " WHERE filename = :PATH"
                       " AND type = :TYPE ;");
         query.bindValue(":PATH", StorageGroup::GetRelativePathname(m_pathname));
     }
     else if (IsRecording())
     {
-        query.prepare("SELECT mark, offset FROM recordedseek"
+        query.prepare("SELECT mark, `offset` FROM recordedseek"
                       " WHERE chanid = :CHANID"
                       " AND starttime = :STARTTIME"
                       " AND type = :TYPE ;");
@@ -3868,7 +3868,7 @@ void ProgramInfo::SavePositionMap(
     QString qfields;
     if (IsVideo())
     {
-        q << "filemarkup (filename, type, mark, offset)";
+        q << "filemarkup (filename, type, mark, `offset`)";
         qfields = QString("('%1',%2,") .
             // ideally, this should be escaped
             arg(videoPath) .
@@ -3876,7 +3876,7 @@ void ProgramInfo::SavePositionMap(
     }
     else // if (IsRecording())
     {
-        q << "recordedseek (chanid, starttime, type, mark, offset)";
+        q << "recordedseek (chanid, starttime, type, mark, `offset`)";
         qfields = QString("(%1,'%2',%3,") .
             arg(m_chanId) .
             arg(m_recStartTs.toString(Qt::ISODate)) .
@@ -3936,7 +3936,7 @@ void ProgramInfo::SavePositionMapDelta(
     QString qfields;
     if (IsVideo())
     {
-        q << "filemarkup (filename, type, mark, offset)";
+        q << "filemarkup (filename, type, mark, `offset`)";
         qfields = QString("('%1',%2,") .
             // ideally, this should be escaped
             arg(StorageGroup::GetRelativePathname(m_pathname)) .
@@ -3944,7 +3944,7 @@ void ProgramInfo::SavePositionMapDelta(
     }
     else if (IsRecording())
     {
-        q << "recordedseek (chanid, starttime, type, mark, offset)";
+        q << "recordedseek (chanid, starttime, type, mark, `offset`)";
         qfields = QString("(%1,'%2',%3,") .
             arg(m_chanId) .
             arg(m_recStartTs.toString(Qt::ISODate)) .
@@ -3983,56 +3983,56 @@ void ProgramInfo::SavePositionMapDelta(
 }
 
 static const char *from_filemarkup_offset_asc =
-    "SELECT mark, offset FROM filemarkup"
+    "SELECT mark, `offset` FROM filemarkup"
     " WHERE filename = :PATH"
     " AND type = :TYPE"
     " AND mark >= :QUERY_ARG"
     " ORDER BY filename ASC, type ASC, mark ASC LIMIT 1;";
 static const char *from_filemarkup_offset_desc =
-    "SELECT mark, offset FROM filemarkup"
+    "SELECT mark, `offset` FROM filemarkup"
     " WHERE filename = :PATH"
     " AND type = :TYPE"
     " AND mark <= :QUERY_ARG"
     " ORDER BY filename DESC, type DESC, mark DESC LIMIT 1;";
 static const char *from_recordedseek_offset_asc =
-    "SELECT mark, offset FROM recordedseek"
+    "SELECT mark, `offset` FROM recordedseek"
     " WHERE chanid = :CHANID"
     " AND starttime = :STARTTIME"
     " AND type = :TYPE"
     " AND mark >= :QUERY_ARG"
     " ORDER BY chanid ASC, starttime ASC, type ASC, mark ASC LIMIT 1;";
 static const char *from_recordedseek_offset_desc =
-    "SELECT mark, offset FROM recordedseek"
+    "SELECT mark, `offset` FROM recordedseek"
     " WHERE chanid = :CHANID"
     " AND starttime = :STARTTIME"
     " AND type = :TYPE"
     " AND mark <= :QUERY_ARG"
     " ORDER BY chanid DESC, starttime DESC, type DESC, mark DESC LIMIT 1;";
 static const char *from_filemarkup_mark_asc =
-    "SELECT offset,mark FROM filemarkup"
+    "SELECT `offset`,mark FROM filemarkup"
     " WHERE filename = :PATH"
     " AND type = :TYPE"
-    " AND offset >= :QUERY_ARG"
+    " AND `offset` >= :QUERY_ARG"
     " ORDER BY filename ASC, type ASC, mark ASC LIMIT 1;";
 static const char *from_filemarkup_mark_desc =
-    "SELECT offset,mark FROM filemarkup"
+    "SELECT `offset`,mark FROM filemarkup"
     " WHERE filename = :PATH"
     " AND type = :TYPE"
-    " AND offset <= :QUERY_ARG"
+    " AND `offset` <= :QUERY_ARG"
     " ORDER BY filename DESC, type DESC, mark DESC LIMIT 1;";
 static const char *from_recordedseek_mark_asc =
-    "SELECT offset,mark FROM recordedseek"
+    "SELECT `offset`,mark FROM recordedseek"
     " WHERE chanid = :CHANID"
     " AND starttime = :STARTTIME"
     " AND type = :TYPE"
-    " AND offset >= :QUERY_ARG"
+    " AND `offset` >= :QUERY_ARG"
     " ORDER BY chanid ASC, starttime ASC, type ASC, mark ASC LIMIT 1;";
 static const char *from_recordedseek_mark_desc =
-    "SELECT offset,mark FROM recordedseek"
+    "SELECT `offset`,mark FROM recordedseek"
     " WHERE chanid = :CHANID"
     " AND starttime = :STARTTIME"
     " AND type = :TYPE"
-    " AND offset <= :QUERY_ARG"
+    " AND `offset` <= :QUERY_ARG"
     " ORDER BY chanid DESC, starttime DESC, type DESC, mark DESC LIMIT 1;";
 
 bool ProgramInfo::QueryKeyFrameInfo(uint64_t * result,
@@ -4493,7 +4493,7 @@ void ProgramInfo::QueryMarkup(QVector<MarkupEntry> &mapMark,
     // Get the markup
     if (IsVideo())
     {
-        query.prepare("SELECT type, mark, offset FROM filemarkup"
+        query.prepare("SELECT type, mark, `offset` FROM filemarkup"
                       " WHERE filename = :PATH"
                       " AND type NOT IN (:KEYFRAME,:DURATION)"
                       " ORDER BY mark, type;");
@@ -4533,7 +4533,7 @@ void ProgramInfo::QueryMarkup(QVector<MarkupEntry> &mapMark,
     // Get the seektable
     if (IsVideo())
     {
-        query.prepare("SELECT type, mark, offset FROM filemarkup"
+        query.prepare("SELECT type, mark, `offset` FROM filemarkup"
                       " WHERE filename = :PATH"
                       " AND type IN (:KEYFRAME,:DURATION)"
                       " ORDER BY mark, type;");
@@ -4543,7 +4543,7 @@ void ProgramInfo::QueryMarkup(QVector<MarkupEntry> &mapMark,
     }
     else if (IsRecording())
     {
-        query.prepare("SELECT type, mark, offset FROM recordedseek"
+        query.prepare("SELECT type, mark, `offset` FROM recordedseek"
                       " WHERE chanid = :CHANID"
                       " AND STARTTIME = :STARTTIME"
                       " ORDER BY mark, type");
@@ -4606,7 +4606,7 @@ void ProgramInfo::SaveMarkup(const QVector<MarkupEntry> &mapMark,
                 else
                 {
                     query.prepare("INSERT INTO filemarkup"
-                                  " (filename,type,mark,offset)"
+                                  " (filename,type,mark,`offset`)"
                                   " VALUES (:PATH,:TYPE,:MARK,:OFFSET)");
                     query.bindValue(":OFFSET", (quint64)entry.data);
                 }
@@ -4649,7 +4649,7 @@ void ProgramInfo::SaveMarkup(const QVector<MarkupEntry> &mapMark,
                 }
                 const MarkupEntry &entry = mapSeek[i];
                 query.prepare("INSERT INTO filemarkup"
-                              " (filename,type,mark,offset)"
+                              " (filename,type,mark,`offset`)"
                               " VALUES (:PATH,:TYPE,:MARK,:OFFSET)");
                 query.bindValue(":PATH", path);
                 query.bindValue(":TYPE", entry.type);
@@ -4738,7 +4738,7 @@ void ProgramInfo::SaveMarkup(const QVector<MarkupEntry> &mapMark,
                 }
                 const MarkupEntry &entry = mapSeek[i];
                 query.prepare("INSERT INTO recordedseek"
-                              " (chanid,starttime,type,mark,offset)"
+                              " (chanid,starttime,type,mark,`offset`)"
                               " VALUES (:CHANID,:STARTTIME,"
                               "         :TYPE,:MARK,:OFFSET)");
                 query.bindValue(":CHANID", m_chanId);

--- a/mythtv/libs/libmythtv/channelscan/channelimporter.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelimporter.cpp
@@ -39,6 +39,17 @@ static QString map_str(QString str)
     return str;
 }
 
+// Use the service ID as default channel number when there is no
+// DVB logical channel number or ATSC channel number found in the scan.
+//
+static void channum_not_empty(ChannelInsertInfo &chan)
+{
+    if (chan.m_chanNum.isEmpty())
+    {
+        chan.m_chanNum = QString("%1").arg(chan.m_serviceId);
+    }
+}
+
 void ChannelImporter::Process(const ScanDTVTransportList &_transports,
                               int sourceid)
 {
@@ -574,21 +585,7 @@ ScanDTVTransportList ChannelImporter::InsertChannels(
             if (handle)
             {
                 bool conflicting = false;
-
-                if (chan.m_chanNum.isEmpty())
-                {
-                    if ((kATSCNonConflicting == type) ||
-                        (kATSCConflicting    == type))
-                    {
-                        chan.m_chanNum = kATSCChannelFormat
-                            .arg(chan.m_atscMajorChannel)
-                            .arg(chan.m_atscMinorChannel);
-                    }
-                    else
-                    {
-                        chan.m_chanNum = QString("%1").arg(chan.m_serviceId);
-                    }
-                }
+                channum_not_empty(chan);
                 conflicting = ChannelUtil::IsConflicting(
                     chan.m_chanNum, chan.m_sourceId);
 
@@ -768,20 +765,7 @@ ScanDTVTransportList ChannelImporter::UpdateChannels(
                 {
                     ChannelUtil::UpdateChannelNumberFromDB(chan);
                 }
-                if (chan.m_chanNum.isEmpty())
-                {
-                    if ((kATSCNonConflicting == type) ||
-                        (kATSCConflicting    == type))
-                    {
-                        chan.m_chanNum = kATSCChannelFormat
-                            .arg(chan.m_atscMajorChannel)
-                            .arg(chan.m_atscMinorChannel);
-                    }
-                    else
-                    {
-                        chan.m_chanNum = QString("%1").arg(chan.m_serviceId);
-                    }
-                }
+                channum_not_empty(chan);
                 conflicting = ChannelUtil::IsConflicting(
                     chan.m_chanNum, chan.m_sourceId, chan.m_channelId);
 
@@ -1473,7 +1457,6 @@ QString ChannelImporter::SimpleFormatChannel(
 
     if (si_standard == "atsc" || si_standard == "scte")
     {
-
         if (si_standard == "atsc")
         {
             ssMsg << (kATSCChannelFormat

--- a/mythtv/libs/libmythtv/channelscan/channelimporter.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelimporter.cpp
@@ -139,7 +139,6 @@ void ChannelImporter::Process(const ScanDTVTransportList &_transports,
 
     // Pull in DB info in transports
     // Channels not found in scan but only in DB are returned in db_trans
-    sourceid = transports[0].m_channels[0].m_sourceId;
     ScanDTVTransportList db_trans = GetDBTransports(sourceid, transports);
     msg = "";
     ssMsg << QT_ENDL;

--- a/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
@@ -2179,7 +2179,12 @@ bool ChannelScanSM::Tune(const transport_scan_items_it_t transport)
         return channel->TuneMultiplex(item.m_mplexid, m_inputName);
 
     if (item.m_tuning.m_sistandard == "MPEG")
-        return channel->Tune(item.m_iptvTuning, true);
+    {
+        IPTVTuningData tuning = item.m_iptvTuning;
+        if (tuning.GetProtocol() == IPTVTuningData::inValid)
+            tuning.GuessProtocol();
+        return channel->Tune(tuning, true);
+    }
 
     const uint64_t freq = item.freq_offset(transport.offset());
     DTVMultiplex tuning = item.m_tuning;

--- a/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
@@ -88,6 +88,8 @@ QString ChannelScanSM::loc(const ChannelScanSM *siscan)
 
 #define kDecryptionTimeout 4250
 
+static const QString kATSCChannelFormat = "%1_%2";
+
 class ScannedChannelInfo
 {
   public:
@@ -141,20 +143,20 @@ class ScannedChannelInfo
  *
  */
 
-ChannelScanSM::ChannelScanSM(ScanMonitor *_scan_monitor,
-                             const QString &_cardtype, ChannelBase *_channel,
-                             int _sourceID, std::chrono::milliseconds signal_timeout,
-                             std::chrono::milliseconds channel_timeout, QString _inputname,
+ChannelScanSM::ChannelScanSM(ScanMonitor *scan_monitor,
+                             const QString &cardtype, ChannelBase *channel,
+                             int sourceID, std::chrono::milliseconds signal_timeout,
+                             std::chrono::milliseconds channel_timeout, QString inputname,
                              bool test_decryption)
     : // Set in constructor
-      m_scanMonitor(_scan_monitor),
-      m_channel(_channel),
-      m_signalMonitor(SignalMonitor::Init(_cardtype, m_channel->GetInputID(),
-                                          _channel, true)),
-      m_sourceID(_sourceID),
+      m_scanMonitor(scan_monitor),
+      m_channel(channel),
+      m_signalMonitor(SignalMonitor::Init(cardtype, m_channel->GetInputID(),
+                                          channel, true)),
+      m_sourceID(sourceID),
       m_signalTimeout(signal_timeout),
       m_channelTimeout(channel_timeout),
-      m_inputName(std::move(_inputname)),
+      m_inputName(std::move(inputname)),
       m_testDecryption(test_decryption),
       // Misc
       m_analogSignalHandler(new AnalogSignalHandler(this))
@@ -173,7 +175,7 @@ ChannelScanSM::ChannelScanSM(ScanMonitor *_scan_monitor,
                 "SELECT dvb_nit_id, bouquet_id, region_id, lcnoffset "
                 "FROM videosource "
                 "WHERE videosource.sourceid = :SOURCEID");
-        query.bindValue(":SOURCEID", _sourceID);
+        query.bindValue(":SOURCEID", m_sourceID);
         if (!query.exec() || !query.isActive())
         {
             MythDB::DBError("ChannelScanSM", query);
@@ -1055,9 +1057,9 @@ bool ChannelScanSM::UpdateChannelInfo(bool wait_until_complete)
         {
             TransportScanItem &item = *m_current;
             item.m_tuning.m_frequency = item.freq_offset(m_current.offset());
-            item.m_signalStrength = m_signalMonitor->GetSignalStrength();
-            item.m_networkID = dtv_sm->GetNetworkID();
-            item.m_transportID = dtv_sm->GetTransportID();
+            item.m_signalStrength     = m_signalMonitor->GetSignalStrength();
+            item.m_networkID          = dtv_sm->GetNetworkID();
+            item.m_transportID        = dtv_sm->GetTransportID();
 
             if (m_scanDTVTunerType == DTVTunerType::kTunerTypeDVBC)
             {
@@ -1201,7 +1203,7 @@ static void update_info(ChannelInsertInfo &info,
                         const ServiceDescriptionTable *sdt, uint i,
                         const QMap<uint64_t, QString> &defAuthorities)
 {
-    // HACK beg -- special exception for these networks
+    // HACK begin -- special exception for these networks
     // this enables useonairguide by default for all matching channels
     //             (dbver == "1067")
     bool force_guide_present = (
@@ -1448,6 +1450,10 @@ ChannelScanSM::GetChannelList(transport_scan_items_it_t trans_info,
             {
                 info.m_chanNum = QString::number(((info.m_atscMajorChannel & 0x00F) << 10) + info.m_atscMinorChannel);
             }
+            else
+            {
+                info.m_chanNum = kATSCChannelFormat.arg(info.m_atscMajorChannel).arg(info.m_atscMinorChannel);
+            }
         }
     }
 
@@ -1459,6 +1465,7 @@ ChannelScanSM::GetChannelList(transport_scan_items_it_t trans_info,
             uint pnum = tvct->ProgramNumber(i);
             PCM_INFO_INIT("atsc");
             update_info(info, tvct, i);
+            info.m_chanNum = kATSCChannelFormat.arg(info.m_atscMajorChannel).arg(info.m_atscMinorChannel);
         }
     }
 
@@ -1698,23 +1705,6 @@ ChannelScanSM::GetChannelList(transport_scan_items_it_t trans_info,
 
     // ------------------------------------------------------------------------
 
-    // Get IPTV channel numbers
-    for (dbchan_it = pnum_to_dbchan.begin();
-         dbchan_it != pnum_to_dbchan.end(); ++dbchan_it)
-    {
-        ChannelInsertInfo &info = *dbchan_it;
-
-        if (!info.m_chanNum.isEmpty())
-            continue;
-
-        if (!iptv_channel.isEmpty())
-        {
-            info.m_chanNum = iptv_channel;
-            if (info.m_serviceId)
-                info.m_chanNum += "-" + QString::number(info.m_serviceId);
-        }
-    }
-
     // Get DVB Logical Channel Numbers
     for (dbchan_it = pnum_to_dbchan.begin();
          dbchan_it != pnum_to_dbchan.end(); ++dbchan_it)
@@ -1797,6 +1787,23 @@ ChannelScanSM::GetChannelList(transport_scan_items_it_t trans_info,
                     .arg(info.m_freqId)
                     .arg(info.m_serviceId);
             }
+        }
+    }
+
+    // Get IPTV channel numbers
+    for (dbchan_it = pnum_to_dbchan.begin();
+         dbchan_it != pnum_to_dbchan.end(); ++dbchan_it)
+    {
+        ChannelInsertInfo &info = *dbchan_it;
+
+        if (!info.m_chanNum.isEmpty())
+            continue;
+
+        if (!iptv_channel.isEmpty())
+        {
+            info.m_chanNum = iptv_channel;
+            if (info.m_serviceId)
+                info.m_chanNum += "-" + QString::number(info.m_serviceId);
         }
     }
 

--- a/mythtv/libs/libmythtv/channelscan/channelscan_sm.h
+++ b/mythtv/libs/libmythtv/channelscan/channelscan_sm.h
@@ -91,10 +91,10 @@ class ChannelScanSM : public MPEGStreamListener,
     friend class AnalogSignalHandler;
 
   public:
-    ChannelScanSM(ScanMonitor *_scan_monitor,
-                  const QString &_cardtype, ChannelBase* _channel, int _sourceID,
+    ChannelScanSM(ScanMonitor *scan_monitor,
+                  const QString &cardtype, ChannelBase* channel, int sourceID,
                   std::chrono::milliseconds signal_timeout, std::chrono::milliseconds channel_timeout,
-                  QString _inputname, bool test_decryption);
+                  QString inputname, bool test_decryption);
     ~ChannelScanSM() override;
 
     void StartScanner(void);

--- a/mythtv/libs/libmythtv/channelscan/paneatsc.h
+++ b/mythtv/libs/libmythtv/channelscan/paneatsc.h
@@ -30,10 +30,20 @@ class PaneATSC : public GroupSetting
         connect(m_atscModulation, qOverload<const QString&>(&StandardSetting::valueChanged),
                 this,             &PaneATSC::ModulationChanged);
 
-        auto *range = new GroupSetting();
         m_transportStart = new TransMythUIComboBoxSetting();
+        m_transportStart->setLabel(tr("First Channel"));
+        m_transportStart->setHelpText(tr("Start scanning at this channel."));
+
         m_transportEnd   = new TransMythUIComboBoxSetting();
-        m_transportCount = new TransTextEditSetting();
+        m_transportEnd->setLabel(tr("Last Channel"));
+        m_transportEnd->setHelpText(tr("Stop scanning after this channel."));
+
+        m_transportCount = new GroupSetting();
+        m_transportCount->setLabel(tr("Channel Count"));
+        m_transportCount->setHelpText(tr("Total number of channels to scan."));
+        m_transportCount->setReadOnly(true);
+
+        auto *range = new GroupSetting();
         range->setLabel(tr("Scanning Range"));
         range->addChild(m_transportStart);
         range->addChild(m_transportEnd);
@@ -175,7 +185,7 @@ class PaneATSC : public GroupSetting
     ScanATSCModulation         *m_atscModulation  {nullptr};
     TransMythUIComboBoxSetting *m_transportStart  {nullptr};
     TransMythUIComboBoxSetting *m_transportEnd    {nullptr};
-    TransTextEditSetting       *m_transportCount  {nullptr};
+    GroupSetting               *m_transportCount  {nullptr};
     QString                     m_tablesSig;
     freq_table_list_t           m_tables;
 };

--- a/mythtv/libs/libmythtv/frequencytables.cpp
+++ b/mythtv/libs/libmythtv/frequencytables.cpp
@@ -606,27 +606,27 @@ static void init_freq_tables(freq_table_map_t &fmap)
 
     for (uint i = 0; i < 4; i++)
     {
-        // USA Cable, ch 2 to US_MAX_CHAN and T.7 to T.14
-        FREQ(modStr[i], "cable0", desc[i], "Channel %1",
-             2,    57000000,   69000000, 6000000, mod[i]); // 2-4
+        // USA Cable, T13 to T14 and ch 2 to US_MAX_CHAN
+        FREQ(modStr[i], "cable0", desc[i], "Channel T-%1",
+             13,   44750000,   50750000, 6000000, mod[i]); // T13-T14
         FREQ(modStr[i], "cable1", desc[i], "Channel %1",
-             5,    79000000,   85000000, 6000000, mod[i]); // 5-6
+             2,    57000000,   69000000, 6000000, mod[i]); // 2-4
         FREQ(modStr[i], "cable2", desc[i], "Channel %1",
-             7,   177000000,  213000000, 6000000, mod[i]); // 7-13
+             5,    79000000,   85000000, 6000000, mod[i]); // 5-6
         FREQ(modStr[i], "cable3", desc[i], "Channel %1",
-             14,  123000000,  171000000, 6000000, mod[i]); // 14-22
+             7,   177000000,  213000000, 6000000, mod[i]); // 7-13
         FREQ(modStr[i], "cable4", desc[i], "Channel %1",
-             23,  219000000,  645000000, 6000000, mod[i]); // 23-94
+             14,  123000000,  171000000, 6000000, mod[i]); // 14-22
         FREQ(modStr[i], "cable5", desc[i], "Channel %1",
+             23,  219000000,  645000000, 6000000, mod[i]); // 23-94
+        FREQ(modStr[i], "cable6", desc[i], "Channel %1",
              95,   93000000,  117000000, 6000000, mod[i]); // 95-99
         // The center frequency of any EIA-542 std cable channel over 99 is
         // Frequency_MHz = ( 6 * ( 8 + channel_designation ) ) + 3
-        FREQ(modStr[i], "cable6", desc[i], "Channel %1",
-             100, 651000000,
-             EIA_542_FREQUENCY(6000000, 3000000, US_MAX_CHAN),
-             6000000, mod[i]);                             // 100-US_MAX_CHAN
-        FREQ(modStr[i], "cable7", desc[i], "Channel T-%1",
-             7,    8750000,   50750000, 6000000, mod[i]); // T7-14
+        FREQ(modStr[i], "cable7", desc[i], "Channel %1",
+            100, 651000000,
+            EIA_542_FREQUENCY(6000000, 3000000, US_MAX_CHAN),
+            6000000, mod[i]);                             // 100-US_MAX_CHAN
 
         // USA Cable, QAM 256 ch 78 to US_MAX_CHAN
         FREQ(modStr[i], "cablehigh0", desc[i], "Channel %1",

--- a/mythtv/libs/libmythtv/recorders/satiprecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/satiprecorder.cpp
@@ -182,14 +182,3 @@ QString SatIPRecorder::GetSIStandard(void) const
 {
     return m_channel->GetSIStandard();
 }
-
-void SatIPRecorder::SetOptionsFromProfile(RecordingProfile *profile,
-                                          const QString &videodev,
-                                          const QString &/*audiodev*/,
-                                          const QString &/*vbidev*/)
-{
-    // We don't want to call DTVRecorder::SetOptionsFromProfile() since
-    // we do not have a "recordingtype" in our profile.
-    DTVRecorder::SetOption("videodevice", videodev);
-    SetIntOption(profile, "recordmpts");
-}

--- a/mythtv/libs/libmythtv/recorders/satiprecorder.h
+++ b/mythtv/libs/libmythtv/recorders/satiprecorder.h
@@ -24,11 +24,6 @@ class SatIPRecorder : public DTVRecorder
 
     QString GetSIStandard(void) const override; // DTVRecorder
 
-    void SetOptionsFromProfile(RecordingProfile *profile,
-                               const QString &videodev,
-                               const QString &audiodev,
-                               const QString &vbidev) override; // RecorderBase
-
   private:
     bool PauseAndWait(std::chrono::milliseconds timeout = 100ms) override;  // RecorderBase
 

--- a/mythtv/libs/libmythtv/recordinginfo.cpp
+++ b/mythtv/libs/libmythtv/recordinginfo.cpp
@@ -995,7 +995,7 @@ bool RecordingInfo::InsertRecording(const QString &ext, bool force_match)
 #if 1
     if (!dirname.isEmpty())
     {
-        LOG(VB_GENERAL, LOG_WARNING, LOC +
+        LOG(VB_GENERAL, LOG_DEBUG, LOC +
             QString("InsertRecording: m_pathname was '%1'. "
                     "This is usually blank.").arg(dirname));
     }

--- a/mythtv/libs/libmythtv/recordingprofile.cpp
+++ b/mythtv/libs/libmythtv/recordingprofile.cpp
@@ -1631,7 +1631,9 @@ void RecordingProfile::CompleteLoad(int profileId, const QString &type,
                     this,         &RecordingProfile::FiltersChanged);
         }
     }
-    else if (type.toUpper() == "DVB")
+
+    // Cards that can receive additional streams such as EIT and MHEG
+    if (CardUtil::IsEITCapable(type))
     {
         addChild(new RecordingTypeStream(*this));
     }

--- a/mythtv/libs/libmythtv/tv_play.cpp
+++ b/mythtv/libs/libmythtv/tv_play.cpp
@@ -10129,31 +10129,21 @@ OSD *TV::GetOSDL()
     return nullptr;
 }
 
-void TV::ReturnOSDLock()
+void TV::ReturnOSDLock() const
 {
     if (m_player)
         m_player->UnlockOSD();
     m_playerContext.UnlockDeletePlayer(__FILE__, __LINE__);
 }
 
-void TV::GetPlayerWriteLock()
+void TV::GetPlayerWriteLock() const
 {
     m_playerLock.lockForWrite();
-}
-
-void TV::GetPlayerReadLock()
-{
-    m_playerLock.lockForRead();
 }
 
 void TV::GetPlayerReadLock() const
 {
     m_playerLock.lockForRead();
-}
-
-void TV::ReturnPlayerLock()
-{
-    m_playerLock.unlock();
 }
 
 void TV::ReturnPlayerLock() const

--- a/mythtv/libs/libmythtv/tv_play.h
+++ b/mythtv/libs/libmythtv/tv_play.h
@@ -262,11 +262,9 @@ class MTV_PUBLIC TV : public TVPlaybackState, public MythTVMenuItemDisplayer, pu
 
     // Lock handling
     OSD* GetOSDL();
-    void ReturnOSDLock();
-    void GetPlayerWriteLock();
-    void GetPlayerReadLock();
+    void ReturnOSDLock() const;
+    void GetPlayerWriteLock() const;
     void GetPlayerReadLock() const;
-    void ReturnPlayerLock();
     void ReturnPlayerLock() const;
 
     // Other toggles

--- a/mythtv/libs/libmythui/mythdialogbox.cpp
+++ b/mythtv/libs/libmythui/mythdialogbox.cpp
@@ -137,7 +137,7 @@ bool MythDialogBox::Create(void)
         return false;
 
     bool err = false;
-    if (m_titlearea)
+    if (m_fullscreen)
         UIUtilW::Assign(this, m_titlearea, "title");
     UIUtilE::Assign(this, m_textarea, "messagearea", &err);
     UIUtilE::Assign(this, m_buttonList, "list", &err);

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -25,10 +25,6 @@ ExitPrompter::ExitPrompter()
 
 ExitPrompter::~ExitPrompter()
 {
-    // Ensure additional actions are not processed after we are deleted
-    if (m_dialog)
-        m_dialog->SetReturnEvent(nullptr, QString());
-
     if (m_power)
         MythPower::AcquireRelease(this, false);
     LOG(VB_GENERAL, LOG_INFO, "Deleted ExitPrompter");
@@ -36,6 +32,10 @@ ExitPrompter::~ExitPrompter()
 
 void ExitPrompter::DoQuit()
 {
+    // Ensure additional actions are not processed after we are deleted
+    if (m_dialog)
+        m_dialog->SetReturnEvent(nullptr, QString());
+
     qApp->exit();
     deleteLater();
 }


### PR DESCRIPTION
Python 3.10 will finally remove the long deprecated aliases to the
Abstract Base Classes from the collections module.

    https://docs.python.org/3.10/whatsnew/3.10.html#removed

Fixes #374

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

