### PR TITLE
Fix QString arguments when searching for remote coverart files

### DIFF
--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -191,8 +191,10 @@ namespace
                 }
                 else
                 {
-                sfn += hntm.arg(base_name + "_%1", suffix, ext);
-                sfn += hntm.arg(video_uid + "_%1", suffix, ext);
+                sfn += hntm.arg(base_name + QString("_%1").arg(suffix),
+                                ext);
+                sfn += hntm.arg(video_uid + QString("_%1").arg(suffix),
+                                ext);
                 }
 
                 for (const auto & str : qAsConst(sfn))


### PR DESCRIPTION
Results in warning "Qt: QString::arg: 1 argument(s) missing in %2.%3"
and failure to retrieve coverart files

Fixes #378

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

