### PR TITLE
Python: Switch from distutils to setuptools

### DIFF
--- a/mythtv/bindings/python/Makefile
+++ b/mythtv/bindings/python/Makefile
@@ -24,12 +24,7 @@ python_build: setup.py
 install: setup.py
 	$(PYTHON) setup.py install --skip-build $(ROOT_FLAGS) $(PREFIX_FLAGS)
 
-ifdef INSTALL_ROOT
 uninstall:
-	$(warning make -C bindings/python uninstall is not supported with $$(INSTALL_ROOT))
-else
-uninstall: setup.py
-	$(PYTHON) setup.py uninstall $(PREFIX_FLAGS)
-endif
+	$(warning make -C bindings/python uninstall is not supported for python bindings)
 
 .PHONY: all clean distclean install python_build uninstall

--- a/mythtv/bindings/python/setup.cfg
+++ b/mythtv/bindings/python/setup.cfg
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+[metadata]
+name = MythTV
+version = 32.0.-1
+description = MythTV Python bindings.
+long_description = Provides canned database and protocol access to the MythTV database, mythproto, mythxml, services_api and frontend remote control.
+url = https://mythtv.org
+
+
+[options]
+include_package_data = True
+
+packages=
+  MythTV
+  MythTV/tmdb3
+  MythTV/ttvdb
+  MythTV/tvmaze
+  MythTV/ttvdbv4
+  MythTV/wikiscripts
+  MythTV/utility
+  MythTV/services_api
+
+package_dir =
+   MythTV/tmdb3 = ./tmdb3/tmdb3
+   MythTV/tvmaze = ./tvmaze
+   MythTV/ttvdbv4 = ./ttvdbv4
+
+scripts =
+  scripts/mythpython
+  scripts/mythwikiscripts
+
+python_requires = >=3.6
+
+install_requires =
+  MySQLdb > 1.3.0
+  lxml > 4.2.1
+
+
+[options.package_data]
+* = ttvdb/XSLT/*
+
+
+[install]
+single_version_externally_managed = 1


### PR DESCRIPTION
for package creation.

In Python 3.10 and 3.11, distutils will be formally marked as deprecated.
See https://www.python.org/dev/peps/pep-0632/
Albeit setuptools uses distutils internally, this will continue to work
in the future, because setuptools includes its own version of distutils.
See https://setuptools.pypa.io/en/latest/deprecated/index.html
Tested on python 3.6+.

Note: Each distribution patches heavily setuptools and distutils, the
package maintainers should check correctness of the new builds.

Although python PEP 518 proposes a new format to specify the build system
for python packages (pyproject.toml), this is not fully implemented in
python3.6 and can't be used.

Fixes #392


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

