### PR TITLE
Use GiantBomb HTTPS API

### DIFF
--- a/mythplugins/mythgame/mythgame/scripts/giantbomb.py
+++ b/mythplugins/mythgame/mythgame/scripts/giantbomb.py
@@ -6,15 +6,15 @@
 # Author: R.D. Vaughan
 # Purpose:
 #   This python script is intended to perform Game data lookups
-#   based on information found on the http://www.giantbomb.com/ website. It
+#   based on information found on the https://www.giantbomb.com website. It
 #   follows the MythTV Univeral standards set for grabbers
-#   http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
+#   https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
 #   This script uses the python module giantbomb_api.py which should be included
 #   with this script.
 #   The giantbomb_api.py module uses the full access XML api published by
-#   api.giantbomb.com see: http://api.giantbomb.com/documentation/
+#   api.giantbomb.com see: https://www.giantbomb.com/api/documentation/
 #   Users of this script are encouraged to populate www.giantbomb.com with Game
-#   informationand images. The richer the source the more
+#   information and images. The richer the source the more
 #   valuable the script.
 # Command example:
 # See help (-u and -h) options
@@ -26,7 +26,7 @@
 #
 #
 # License:Creative Commons GNU GPL v2
-# (http://creativecommons.org/licenses/GPL/2.0/)
+# (https://creativecommons.org/licenses/GPL/2.0/)
 #-------------------------------------
 __title__ ="GiantBomb Query";
 __author__="R.D. Vaughan"
@@ -179,7 +179,7 @@ if isinstance(sys.stdout, stdio_type):
 
 
 # Check that the lxml library is current enough
-# From the lxml documents it states: (http://codespeak.net/lxml/installation.html)
+# From the lxml documents it states: (https://lxml.de/installation.html)
 # "If you want to use XPath, do not use libxml2 2.6.27. We recommend libxml2 2.7.2 or later"
 # Testing was performed with the Ubuntu 9.10 "python-lxml" version "2.1.5-1ubuntu2" repository package
 version = ''
@@ -218,7 +218,7 @@ def main():
     # api.giantbomb.com api key provided for Mythtv
     apikey = "b5883a902a8ed88b15ce21d07787c94fd6ad9f33"
 
-    parser = OptionParser(usage=u"%prog usage: giantbomb -hdluvMD [parameters]\n <game name or gameid number>\n\nFor details on using giantbomb from the command execute './giantbomb.py -u'. For details on the meaning of the XML element tags see the wiki page at:\nhttp://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format")
+    parser = OptionParser(usage=u"%prog usage: giantbomb -hdluvMD [parameters]\n <game name or gameid number>\n\nFor details on using giantbomb from the command execute './giantbomb.py -u'. For details on the meaning of the XML element tags see the wiki page at:\nhttps://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format")
 
     parser.add_option(  "-d", "--debug", action="store_true", default=False, dest="debug",
                         help=u"Show debugging info")

--- a/mythplugins/mythgame/mythgame/scripts/giantbomb/XSLT/giantbombGame.xsl
+++ b/mythplugins/mythgame/mythgame/scripts/giantbomb/XSLT/giantbombGame.xsl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     api.giantbomb.com Game data conversion to MythTV Universal Metadata Format
-    See: http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
+    See: https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
 -->
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:gamebombXpath="http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format">
+    xmlns:gamebombXpath="https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format">
 
     <xsl:output method="xml" indent="yes" version="1.0" encoding="UTF-8" omit-xml-declaration="yes"/>
 

--- a/mythplugins/mythgame/mythgame/scripts/giantbomb/XSLT/giantbombQuery.xsl
+++ b/mythplugins/mythgame/mythgame/scripts/giantbomb/XSLT/giantbombQuery.xsl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     api.giantbomb.com Game query result conversion to MythTV Universal Metadata Format
-    See: http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
+    See: https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
 -->
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:gamebombXpath="http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format">
+    xmlns:gamebombXpath="https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format">
 
     <xsl:output method="xml" indent="yes" version="1.0" encoding="UTF-8" omit-xml-declaration="yes"/>
 

--- a/mythplugins/mythgame/mythgame/scripts/giantbomb/giantbomb_api.py
+++ b/mythplugins/mythgame/mythgame/scripts/giantbomb/giantbomb_api.py
@@ -7,10 +7,10 @@
 # Purpose:  This python script is intended to perform a variety of utility functions to search and
 #           access text metadata and image URLs from GiantBomb. These routines are based on the
 #           GiantBomb api. Specifications for this api are published at:
-#           http://api.giantbomb.com/documentation/
+#           https://www.giantbomb.com/api/documentation/
 #
 # License:Creative Commons GNU GPL v2
-# (http://creativecommons.org/licenses/GPL/2.0/)
+# (https://creativecommons.org/licenses/GPL/2.0/)
 #-------------------------------------
 __title__ ="giantbomb_api - Simple-to-use Python interface to The GiantBomb's API (www.giantbomb.com/api)";
 __author__="R.D. Vaughan"
@@ -72,7 +72,7 @@ except Exception as e:
     sys.exit(1)
 
 # Check that the lxml library is current enough
-# From the lxml documents it states: (http://codespeak.net/lxml/installation.html)
+# From the lxml documents it states: (https://lxml.de/installation.html)
 # "If you want to use XPath, do not use libxml2 2.6.27. We recommend libxml2 2.7.2 or later"
 # Testing was performed with the Ubuntu 9.10 "python-lxml" version "2.1.5-1ubuntu2" repository package
 version = ''
@@ -97,7 +97,7 @@ class gamedbQueries():
                 ):
         """apikey (str/unicode):
             Specify the api.giantbomb.com API key. Applications need their own key.
-            See http://api.giantbomb.com to get your own API key
+            See https://www.giantbomb.com/api/ to get your own API key
 
         debug (True/False):
              shows verbose debugging information
@@ -106,8 +106,8 @@ class gamedbQueries():
 
         self.config['apikey'] = apikey
         self.config['debug'] = debug
-        self.config['searchURL'] = u'http://www.giantbomb.com/api/search'
-        self.config['dataURL'] = u'http://www.giantbomb.com/api/game/%s'
+        self.config['searchURL'] = u'https://www.giantbomb.com/api/search'
+        self.config['dataURL'] = u'https://www.giantbomb.com/api/game/%s'
         # giantbomb.com now requires a unique 'User-Agent':
         self.config['headers'] = {"User-Agent": 'MythTV giantbomb grabber 0.2'}
 
@@ -408,7 +408,7 @@ class gamedbQueries():
 
     def gameSearch(self, gameTitle):
         """Display a Game query in XML format:
-        http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
+        https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
         Returns nothing
         """
         with requests.Session() as ReqSession:
@@ -432,7 +432,7 @@ class gamedbQueries():
             sys.exit(1)
 
         queryXslt = etree.XSLT(etree.parse(u'%s/XSLT/giantbombQuery.xsl' % self.baseProcessingDir))
-        gamebombXpath = etree.FunctionNamespace('http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format')
+        gamebombXpath = etree.FunctionNamespace('https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format')
         gamebombXpath.prefix = 'gamebombXpath'
         self.buildFuncDict()
         for key in list(self.FuncDict.keys()):
@@ -448,7 +448,7 @@ class gamedbQueries():
 
     def gameData(self, gameId):
         """Display a Game details in XML format:
-        http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
+        https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format
         Returns nothing
         """
         with requests.Session() as ReqSession:
@@ -469,7 +469,7 @@ class gamedbQueries():
             sys.exit(1)
 
         gameXslt = etree.XSLT(etree.parse(u'%s/XSLT/giantbombGame.xsl' % self.baseProcessingDir))
-        gamebombXpath = etree.FunctionNamespace('http://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format')
+        gamebombXpath = etree.FunctionNamespace('https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format')
         gamebombXpath.prefix = 'gamebombXpath'
         self.buildFuncDict()
         for key in list(self.FuncDict.keys()):

--- a/mythplugins/mythgame/mythgame/scripts/giantbomb/giantbomb_exceptions.py
+++ b/mythplugins/mythgame/mythgame/scripts/giantbomb/giantbomb_exceptions.py
@@ -7,7 +7,7 @@
 # Purpose:  Custom exceptions used or raised by giantbomb_api
 #
 # License:Creative Commons GNU GPL v2
-# (http://creativecommons.org/licenses/GPL/2.0/)
+# (https://creativecommons.org/licenses/GPL/2.0/)
 #-------------------------------------
 __title__ ="giantbomb_exceptions - Custom exceptions used or raised by giantbomb_api";
 __author__="R.D. Vaughan"


### PR DESCRIPTION
A huge thanks to @rcrdnalor for updating this to Python 3.

The motivation behind my change is to reduce the load on the GiantBomb servers by going directly to their HTTPS end point rather then making them 301 redirect us each time.

I've also updated the links to documentation throughout the code which were missing (lxml) or redirecting back to home pages (GiantBomb API).

I didn't update the large XML reply examples as I didn't want to flood the diff but happy to do that.

I wasn't sure if changing the namespace of the XSLT transforms in mythplugins/mythgame/mythgame/scripts/giantbomb/XSLT was appropriate. It didn't seem to be used outside of the giantbomb scripts but happy to revert if they should remain as http which would be similar to how w3.org namespaces remain at http.

##### Checklist
- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

