### PR TITLE
MacOS Qt6 updates

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutputca.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputca.cpp
@@ -575,7 +575,7 @@ AudioDeviceID CoreAudioData::GetDeviceWithName(const QString &deviceName)
             if (device.GetTotalOutputChannels() == 0)
                 continue;
             QString *name = device.GetName();
-            if (name && name == deviceName)
+            if (name && *name == deviceName)
             {
                 Debug(QString("GetDeviceWithName: Found: %1").arg(*name));
                 deviceID = pDevices[dev];

--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -88,6 +88,12 @@ macx {
     }
 
     LIBS += -liconv
+
+    # Qt6 moved QtGui to use metal, link in QtOpenGL until migrated fully to
+    # Metal per https://doc.qt.io/qt-6/opengl-changes-qt6.html
+    equals(QT_MAJOR_VERSION, 6) {
+        QT += opengl
+    }
 }
 
 cygwin:QMAKE_LFLAGS_SHLIB += -Wl,--noinhibit-exec

--- a/mythtv/libs/libmythui/devices/AppleRemoteListener.cpp
+++ b/mythtv/libs/libmythui/devices/AppleRemoteListener.cpp
@@ -57,8 +57,11 @@ void AppleRemoteListener::appleRemoteButton(AppleRemote::Event button,
     QKeySequence a(code);
     for (int i = 0; i < a.count(); i++)
     {
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+        int keycode = a[i];
+#else
         int keycode = a[i].toCombined();
-
+#endif
         if (pressedDown)
             QCoreApplication::postEvent(mainWindow, new LircKeycodeEvent(
                 QEvent::KeyPress,   keycode, Qt::NoModifier, code, code));

--- a/mythtv/libs/libmythui/devices/AppleRemoteListener.cpp
+++ b/mythtv/libs/libmythui/devices/AppleRemoteListener.cpp
@@ -57,7 +57,7 @@ void AppleRemoteListener::appleRemoteButton(AppleRemote::Event button,
     QKeySequence a(code);
     for (int i = 0; i < a.count(); i++)
     {
-        int keycode = a[i];
+        int keycode = a[i].toCombined();
 
         if (pressedDown)
             QCoreApplication::postEvent(mainWindow, new LircKeycodeEvent(

--- a/mythtv/programs/mythfrontend/globalsettings.h
+++ b/mythtv/programs/mythfrontend/globalsettings.h
@@ -74,15 +74,22 @@ class ChannelGroupSettings
 #if CONFIG_DARWIN
 class MacMainSettings : public GroupSetting
 {
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     Q_OBJECT
-
+#else
+    Q_DECLARE_TR_FUNCTIONS(MacMainSettings);
+#endif
   public:
     MacMainSettings();
 };
 
 class MacFloatSettings : public GroupSetting
 {
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     Q_OBJECT
+#else
+    Q_DECLARE_TR_FUNCTIONS(MacFloatSettings);
+#endif
 
   public:
     MacFloatSettings();
@@ -91,7 +98,11 @@ class MacFloatSettings : public GroupSetting
 
 class MacDockSettings : public GroupSetting
 {
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     Q_OBJECT
+#else
+    Q_DECLARE_TR_FUNCTIONS(MacDockSettings);
+#endif
 
   public:
     MacDockSettings();
@@ -100,7 +111,11 @@ class MacDockSettings : public GroupSetting
 
 class MacDesktopSettings : public GroupSetting
 {
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     Q_OBJECT
+#else
+    Q_DECLARE_TR_FUNCTIONS(MacDesktopSettings);
+#endif
 
   public:
     MacDesktopSettings();


### PR DESCRIPTION
Fixes to get mythtv-master compiling with Qt6 on macOS

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

