### PR TITLE
configure: Rename lib…_external to system_lib…

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -2001,9 +2001,9 @@ MYTHTV_CONFIG_LIST='
     v4l2prime
     valgrind
     x11
-    libexiv2_external
-    libbluray_external
-    libudfread_external
+    system_libexiv2
+    system_libbluray
+    system_libudfread
     systemd_notify
     systemd_journal
     drm
@@ -2799,9 +2799,9 @@ enable libfftw3
 enable taglib
 enable systemd_notify
 enable systemd_journal
-enable libexiv2_external
-enable libbluray_external
-enable libudfread_external
+enable system_libexiv2
+enable system_libbluray
+enable system_libudfread
 enable waylandextras
 
 # mythtv paths
@@ -5877,11 +5877,11 @@ fi
 enabled libudev && check_lib udev libudev.h udev_new -ludev || disable libudev
 
 # libexiv2
-if enabled libexiv2_external ; then
+if enabled system_libexiv2 ; then
     if $(pkg-config --atleast-version="0.27.99" exiv2); then
         use_pkg_config exiv2 exiv2 exiv2/exiv2.hpp versionNumber
     elif [ $target_os != "android" ] ; then
-        disable libexiv2_external
+        disable system_libexiv2
     fi
 fi
 
@@ -5899,16 +5899,16 @@ if [ $target_os = "linux" ] ; then
 fi
 
 # libudfread
-if enabled libudfread_external ; then
+if enabled system_libudfread ; then
     if $(pkg-config --atleast-version="1.1.1" libudfread); then
         use_pkg_config libudfread libudfread udfread/udfread.h udfread_init
     else
-        disable libudfread_external
+        disable system_libudfread
     fi
 fi
 
 # libmythbluray!
-if enabled libbluray_external; then
+if enabled system_libbluray; then
     if $(pkg-config --atleast-version="0.9.3" libbluray); then
         use_pkg_config libbluray libbluray libbluray/bluray.h bd_open
     else
@@ -5941,7 +5941,7 @@ if enabled libbluray_external; then
                         die "ERROR: can not find libbluray."
                         ;;
                 esac
-                disable libbluray_external
+                disable system_libbluray
                 ;;
             *)
                 # FreeBSD provides libbluray 1.0.2
@@ -6457,7 +6457,7 @@ if enabled systemd_journal ; then
 fi
 
 # Check that all MythTV build "requirements" are met:
-if enabled libexiv2_external ; then
+if enabled system_libexiv2 ; then
     if ! $(pkg-config --exists exiv2) ; then
        die "ERROR! You must have the Exiv2 image tag reader library installed to compile MythTV."
     fi
@@ -7538,17 +7538,17 @@ fi
 echo "libdns_sd (Bonjour)       ${libdns_sd-no}"
 echo "libcrypto                 ${libcrypto-no}"
 echo "gnutls                    ${gnutls-no}"
-if enabled libexiv2_external; then
+if enabled system_libexiv2; then
     echo "exiv2 support             yes (system)"
 else
     echo "exiv2 support             yes (internal)"
 fi
-if enabled libudfread_external; then
+if enabled system_libudfread; then
     echo "udfread support           yes (system)"
 else
     echo "udfread support           yes (internal)"
 fi
-if enabled libbluray_external; then
+if enabled system_libbluray; then
     echo "bluray support            yes (system)"
 else
     echo "bluray support            yes (internal)"
@@ -7797,7 +7797,7 @@ if enabled waylandextras; then
     echo "LIBWAYLAND_CFLAGS=$($pkg_config --cflags $pkg_config_flags wayland-client)" >> $TMPMAK
 fi
 
-if enabled libudfread_external; then
+if enabled system_libudfread; then
     # from check_pkg_config via use_pkg_config above
     echo "LIBUDFREAD_CFLAGS=$libudfread_cflags" >> $TMPMAK
     echo "LIBUDFREAD_LIBS=$libudfread_extralibs" >> $TMPMAK
@@ -8021,17 +8021,17 @@ if [ -e libs/libmyth/mythconfig.h ] ; then
     rm -f libs/libmyth/mythconfig.h
 fi
 
-if ! enabled libudfread_external; then
+if ! enabled system_libudfread; then
     echo "Configuring libudfread..."
     (cd external/libudfread ; \
            ${qmakeconf} -o Makefile)
 fi
-if ! enabled libbluray_external; then
+if ! enabled system_libbluray; then
     echo "Configuring libmythbluray..."
     (cd external/libmythbluray ; \
            ${qmakeconf} -o Makefile)
 fi
-if ! enabled libexiv2_external; then
+if ! enabled system_libexiv2; then
     echo "Configuring libexiv2..."
     (cd external/libexiv2 ; \
            ${qmakeconf} -o Makefile)

--- a/mythtv/external/Makefile
+++ b/mythtv/external/Makefile
@@ -2,15 +2,15 @@ include ../config.mak
 
 SUBDIRS = FFmpeg libmythdvdnav
 
-ifneq ($(CONFIG_LIBEXIV2_EXTERNAL),yes)
+ifneq ($(CONFIG_SYSTEM_LIBEXIV2),yes)
     SUBDIRS += libexiv2
 endif
 
-ifneq ($(CONFIG_LIBBLURAY_EXTERNAL),yes)
+ifneq ($(CONFIG_SYSTEM_LIBBLURAY),yes)
     SUBDIRS += libmythbluray
 endif
 
-ifneq ($(CONFIG_LIBUDFREAD_EXTERNAL),yes)
+ifneq ($(CONFIG_SYSTEM_LIBUDFREAD),yes)
     SUBDIRS += libudfread
 endif
 

--- a/mythtv/external/external.pro
+++ b/mythtv/external/external.pro
@@ -6,9 +6,9 @@ win32-msvc* {
 
 # Libraries without dependencies
 
-!using_exiv2_external: SUBDIRS += libexiv2
-!using_libbluray_external: SUBDIRS += libmythbluray
+!using_system_exiv2: SUBDIRS += libexiv2
+!using_system_libbluray: SUBDIRS += libmythbluray
 SUBDIRS += libmythdvdnav
-!using_libudfread_external: SUBDIRS += libudfread
+!using_system_libudfread: SUBDIRS += libudfread
 
 }

--- a/mythtv/external/libmythbluray/libmythbluray.pro
+++ b/mythtv/external/libmythbluray/libmythbluray.pro
@@ -14,7 +14,7 @@ INCLUDEPATH += ./src
 INCLUDEPATH += ./src/libbluray
 INCLUDEPATH += ./src/libbluray/bdnav
 
-using_libudfread_external: {
+using_system_libudfread: {
     DEFINES += HAVE_LIBUDFREAD
     QMAKE_CFLAGS += $$LIBUDFREAD_CFLAGS
     LIBS         += $$LIBUDFREAD_LIBS

--- a/mythtv/libs/libmyth/libmyth.pro
+++ b/mythtv/libs/libmyth/libmyth.pro
@@ -110,14 +110,14 @@ LIBS += -L../../external/FFmpeg/libavutil  -lmythavutil
 LIBS += -L../../external/FFmpeg/libavcodec -lmythavcodec
 LIBS += -L../../external/FFmpeg/libavformat  -lmythavformat
 LIBS += -L../libmythservicecontracts         -lmythservicecontracts-$${LIBVERSION}
-!using_libbluray_external {
+!using_system_libbluray {
     #INCLUDEPATH += ../../external/libmythbluray/src
     DEPENDPATH += ../../external/libmythbluray
     #LIBS += -L../../external/libmythbluray     -lmythbluray-$${LIBVERSION}
 }
 
 !win32-msvc* {
-    !using_libbluray_external:POST_TARGETDEPS += ../../external/libmythbluray/libmythbluray-$${MYTH_LIB_EXT}
+    !using_system_libbluray:POST_TARGETDEPS += ../../external/libmythbluray/libmythbluray-$${MYTH_LIB_EXT}
     POST_TARGETDEPS += ../../external/FFmpeg/libswresample/$$avLibName(swresample)
     POST_TARGETDEPS += ../../external/FFmpeg/libavutil/$$avLibName(avutil)
     POST_TARGETDEPS += ../../external/FFmpeg/libavcodec/$$avLibName(avcodec)

--- a/mythtv/libs/libmythbase/libmythbase.pro
+++ b/mythtv/libs/libmythbase/libmythbase.pro
@@ -246,7 +246,7 @@ QT += xml sql network widgets
 
 include ( ../libs-targetfix.pro )
 
-using_libudfread_external: {
+using_system_libudfread: {
     DEFINES += HAVE_LIBUDFREAD
     QMAKE_CXXFLAGS += $$LIBUDFREAD_CFLAGS
     LIBS           += $$LIBUDFREAD_LIBS

--- a/mythtv/libs/libmythmetadata/bluraymetadata.cpp
+++ b/mythtv/libs/libmythmetadata/bluraymetadata.cpp
@@ -1,12 +1,10 @@
-#include "config.h"
-
 // Qt headers
 #include <QHash>
 #include <QCoreApplication>
 #include <QStringList>
 
-#if CONFIG_LIBBLURAY_EXTERNAL
-#include "libbluray/meta_data.h"
+#ifdef HAVE_LIBBLURAY
+#include <libbluray/meta_data.h>
 #else
 #include "libbluray/bdnav/meta_data.h"
 #endif

--- a/mythtv/libs/libmythmetadata/bluraymetadata.h
+++ b/mythtv/libs/libmythmetadata/bluraymetadata.h
@@ -3,7 +3,14 @@
 
 #include <utility>
 
+#ifdef HAVE_LIBBLURAY
+#include <libbluray/bluray.h>
+#else
+#include "libbluray/bluray.h"
+#endif
+
 // Qt headers
+#include <QCoreApplication> // for Q_DECLARE_TR_FUNCTIONS
 #include <QList>
 #include <QPair>
 #include <QString>
@@ -11,7 +18,6 @@
 // MythTV headers
 #include "mythtypes.h"
 #include "mythmetaexp.h"
-#include "libbluray/bluray.h"
 
 using BlurayTitles = QList< QPair < uint,QString > >;
 

--- a/mythtv/libs/libmythmetadata/libmythmetadata.pro
+++ b/mythtv/libs/libmythmetadata/libmythmetadata.pro
@@ -62,7 +62,7 @@ LIBS += -L../libmyth              -lmyth-$${LIBVERSION}
 LIBS += -L../libmythtv              -lmythtv-$${LIBVERSION}
 LIBS += -L../../external/FFmpeg/libswscale -lmythswscale
 
-!using_libexiv2_external {
+!using_system_libexiv2 {
     darwin {
         QMAKE_CXXFLAGS = "-I../../external/libexiv2/include" $${QMAKE_CXXFLAGS}
     } else {
@@ -72,13 +72,15 @@ LIBS += -L../../external/FFmpeg/libswscale -lmythswscale
     LIBS += -L../../external/libexiv2 -lmythexiv2-0.28
 }
 
-!using_libbluray_external {
+!using_system_libbluray {
     INCLUDEPATH += ../../external/libmythbluray/src
     DEPENDPATH += ../../external/libmythbluray
     LIBS += -L../../external/libmythbluray     -lmythbluray-$${LIBVERSION}
+} else {
+    DEFINES += HAVE_LIBBLURAY
 }
 
-using_libbluray_external:android {
+using_system_libbluray:android {
     LIBS += -lbluray -lxml2
 }
 
@@ -143,7 +145,7 @@ INCLUDEPATH += $$POSTINC
 include ( ../libs-targetfix.pro )
 
 LIBS += $$EXTRA_LIBS $$LATE_LIBS
-using_libexiv2_external {
+using_system_libexiv2 {
     LIBS += -lexiv2
 }
 

--- a/mythtv/libs/libmythmetadata/test/test_lyrics/test_lyrics.pro
+++ b/mythtv/libs/libmythmetadata/test/test_lyrics/test_lyrics.pro
@@ -28,7 +28,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_exiv2_external {
+using_system_exiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_metadatagrabber/test_metadatagrabber.pro
+++ b/mythtv/libs/libmythmetadata/test/test_metadatagrabber/test_metadatagrabber.pro
@@ -28,7 +28,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_exiv2_external {
+using_system_exiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_musicmetadata/test_musicmetadata.pro
+++ b/mythtv/libs/libmythmetadata/test/test_musicmetadata/test_musicmetadata.pro
@@ -26,7 +26,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_exiv2_external {
+using_system_exiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_musicutils/test_musicutils.pro
+++ b/mythtv/libs/libmythmetadata/test/test_musicutils/test_musicutils.pro
@@ -28,7 +28,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_exiv2_external {
+using_system_exiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.pro
+++ b/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.pro
@@ -44,7 +44,7 @@ QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../libmythservicecontracts
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../libmythtv
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../libmythfreemheg
 
-!using_libexiv_external {
+!using_system_libexiv {
     LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28
     QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/libexiv2 -lexpat
     freebsd: LIBS += -lprocstat -liconv

--- a/mythtv/libs/libmythtv/Bluray/mythbdbuffer.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdbuffer.cpp
@@ -26,16 +26,17 @@
 #include <fcntl.h>
 
 // BluRay
-#if CONFIG_LIBBLURAY_EXTERNAL
-#include "libbluray/log_control.h"
-#include "libbluray/meta_data.h"
-#include "libbluray/overlay.h"
+#ifdef HAVE_LIBBLURAY
+#include <libbluray/log_control.h>
+#include <libbluray/meta_data.h>
+#include <libbluray/overlay.h>
+#include <libbluray/keys.h>
 #else
 #include "util/log_control.h"
 #include "libbluray/bdnav/meta_data.h"
 #include "libbluray/decoders/overlay.h"
-#endif
 #include "libbluray/keys.h"
+#endif
 
 #define LOC QString("BDBuffer: ")
 

--- a/mythtv/libs/libmythtv/Bluray/mythbdinfo.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdinfo.cpp
@@ -3,7 +3,6 @@
 #include <QCryptographicHash>
 
 // MythTV
-#include "mythconfig.h"
 #include "mythlogging.h"
 #include "mythdirs.h"
 #include "mythcdrom.h"
@@ -15,11 +14,12 @@
 #include <fcntl.h>
 
 // BluRay
-#include "libbluray/bluray.h"
-#if CONFIG_LIBBLURAY_EXTERNAL
-#include "libbluray/log_control.h"
-#include "libbluray/meta_data.h"
+#ifdef HAVE_LIBBLURAY
+#include <libbluray/bluray.h>
+#include <libbluray/log_control.h>
+#include <libbluray/meta_data.h>
 #else
+#include "libbluray/bluray.h"
 #include "util/log_control.h"
 #include "libbluray/bdnav/meta_data.h"
 #endif

--- a/mythtv/libs/libmythtv/Bluray/mythbdinfo.h
+++ b/mythtv/libs/libmythtv/Bluray/mythbdinfo.h
@@ -1,14 +1,17 @@
 #ifndef MYTHBDINFO_H
 #define MYTHBDINFO_H
 
+#ifdef HAVE_LIBBLURAY
+#include <libbluray/bluray.h>
+#else
+#include "libbluray/bluray.h"
+#endif
+
 // Qt
 #include <QCoreApplication>
 
 // MythTV
 #include "mythtvexp.h"
-
-// BluRay
-#include "libbluray/bluray.h"
 
 class MTV_PUBLIC MythBDInfo
 {

--- a/mythtv/libs/libmythtv/Bluray/mythbdiowrapper.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdiowrapper.cpp
@@ -1,5 +1,3 @@
-// Qt
-#include "mythconfig.h"
 #include "mythlogging.h"
 #include "io/mythiowrapper.h"
 #include "Bluray/mythbdiowrapper.h"
@@ -12,8 +10,8 @@
 #include <sys/types.h>
 
 // Bluray
-#if CONFIG_LIBBLURAY_EXTERNAL
-#include "libbluray/filesystem.h"
+#ifdef HAVE_LIBBLURAY
+#include <libbluray/filesystem.h>
 #else
 #include "file/filesystem.h"
 #endif

--- a/mythtv/libs/libmythtv/Bluray/mythbdoverlay.h
+++ b/mythtv/libs/libmythtv/Bluray/mythbdoverlay.h
@@ -4,14 +4,12 @@
 // Qt
 #include <QImage>
 
-// MythTV
-#include "mythconfig.h"
-
 // BluRay
-#include "libbluray/bluray.h"
-#if CONFIG_LIBBLURAY_EXTERNAL
-#include "libbluray/overlay.h"
+#ifdef HAVE_LIBBLURAY
+#include <libbluray/bluray.h>
+#include <libbluray/overlay.h>
 #else
+#include "libbluray/bluray.h"
 #include "libbluray/decoders/overlay.h"
 #endif
 

--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -354,17 +354,19 @@ using_frontend {
     HEADERS += Bluray/mythbdoverlayscreen.h
     SOURCES += Bluray/mythbdoverlayscreen.cpp
 }
-!using_libbluray_external {
+!using_system_libbluray {
     INCLUDEPATH += ../../external/libmythbluray/src
     DEPENDPATH += ../../external/libmythbluray
     LIBS += -L../../external/libmythbluray     -lmythbluray-$${LIBVERSION}
     !win32-msvc*:POST_TARGETDEPS += ../../external/libmythbluray/libmythbluray-$${MYTH_LIB_EXT}
+} else {
+    DEFINES += HAVE_LIBBLURAY
 }
-using_libbluray_external:mingw {
+using_system_libbluray:mingw {
     LIBS += -lbluray
 }
 
-using_libbluray_external:android {
+using_system_libbluray:android {
     LIBS += -lbluray -lxml2
 }
 

--- a/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.pro
+++ b/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.pro
@@ -52,7 +52,7 @@ QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libpostproc
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libswresample
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../
 
-!using_libexiv_external {
+!using_system_libexiv {
     LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28
     QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/libexiv2 -lexpat
     freebsd: LIBS += -lprocstat -liconv

--- a/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.pro
+++ b/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.pro
@@ -52,7 +52,7 @@ QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libpostproc
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libswresample
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../
 
-!using_libexiv_external {
+!using_system_libexiv {
     LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28
     QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/libexiv2 -lexpat
     freebsd: LIBS += -lprocstat -liconv

--- a/mythtv/programs/programs-libs.pro
+++ b/mythtv/programs/programs-libs.pro
@@ -16,7 +16,7 @@ win32-msvc* {
   INCLUDEPATH += ../../external/libmythdvdnav/dvdread
 }
 
-!using_libbluray_external:INCLUDEPATH += ../../external/libmythbluray/src
+!using_system_libbluray:INCLUDEPATH += ../../external/libmythbluray/src
 INCLUDEPATH += ../../libs/libmythtv/mpeg
 INCLUDEPATH += ../../libs/libmythtv/vbitext
 INCLUDEPATH += ../../libs/libmythservicecontracts
@@ -67,7 +67,8 @@ using_mheg:LIBS += -L../../libs/libmythfreemheg -lmythfreemheg-$$LIBVERSION
 using_hdhomerun:LIBS += -lhdhomerun
 using_taglib: LIBS += $$CONFIG_TAGLIB_LIBS
 
-!using_libexiv2_external {
+using_system_libbluray: DEFINES += HAVE_LIBBLURAY
+!using_system_libexiv2 {
     LIBS += -L../../external/libexiv2 -lmythexiv2-0.28 -lexpat
     freebsd: LIBS += -lprocstat -liconv
     darwin: LIBS += -liconv -lz


### PR DESCRIPTION
This also renames using_lib…_external to using_system_lib… and
CONFIG_LIB…_EXTERNAL to CONFIG_SYSTEM_LIB…

Added define HAVE_LIBBLURAY to make the code independent from any such further changes,
and removed the now unused mythconfig.h includes.

This naming is clearer since the code is in the external/ directory.  This prevents confusion between what these settings/flags actually do and the code being under external/.
