### PR TITLE
Un-break build of MythNetVision for Debian/Ubuntu

### DIFF
--- a/mythplugins/configure
+++ b/mythplugins/configure
@@ -466,11 +466,29 @@ check_py_lib(){
     log check_py_lib "$@"
     lib=${1}
     check_cmd $python <<EOF
-from distutils.sysconfig import get_python_lib
 import sys
-for mythroot in '${mythroot}'.split(':'):
-    sys.path.append(get_python_lib(prefix=mythroot +'${prefix}'))
-sys.path.append(get_python_lib(prefix='${sysroot}${prefix}'))
+try:
+    from distutils.sysconfig import get_python_lib
+    for mythroot in '${mythroot}'.split(':'):
+        sys.path.append(get_python_lib(prefix=mythroot +'${prefix}'))
+        sys.path.append(mythroot + get_python_lib(prefix='${prefix}'))
+    sys.path.append(get_python_lib(prefix='${sysroot}${prefix}'))
+except:
+    # python 3.12+
+    from sysconfig import get_path
+    import re
+    for mythroot in '${mythroot}'.split(':'):
+        vars = {'base': mythroot +'${prefix}', 'prefix': '${prefix}'}
+        ps = get_path('purelib', vars=vars, expand=True)
+        sys.path.append(ps)
+        ps1 = re.sub(r'${python}.\d*','${python}', ps)
+        sys.path.append(ps1)
+        ps2 = re.sub(r'site-packages$', 'dist-packages', ps)
+        sys.path.append(ps2)
+        ps3 = re.sub(r'${python}.\d*','${python}', ps2)
+        sys.path.append(ps3)
+    vars = {'base': '${sysroot}${prefix}', 'prefix': '${prefix}'}
+    sys.path.append(get_path('purelib', vars=vars, expand=True))
 try:
     import $lib
 except:


### PR DESCRIPTION
Some background information:
Debian builds their python-only packages ('pure-lib') under
$(builddir)/usr/lib/python3/dist-packages
and installs them under /usr/lib/python3.x/dist-packages.
The packaging scripts from
https://github.com/MythTV/packaging/tree/master/deb
for the MythTV Plugins need to find these intermediate builds to check for
the existance of the MythTV python bindings in advance.

Nevertheless, python3.10 deprecates the 'distutils' package, and python3.12
will remove this package, which provides the correct paths to the python libs.
As of now, there is no alternative module for Debian available, which
provides this information, i.e.: find the path to intermediate python libs.
This implementation provides a - guessed - mix of 'sys.path' entries,
in the hope that one will fit in the future.

Refs #437


##### Checklist

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

