### PR TITLE
httprequest.cpp: remove unused USE_SETSOCKOPT code

### DIFF
--- a/mythtv/libs/libmythupnp/httprequest.cpp
+++ b/mythtv/libs/libmythupnp/httprequest.cpp
@@ -20,11 +20,6 @@
 #include <QDateTime>
 #include <Qt>
 
-#include "mythconfig.h"
-#if !( CONFIG_DARWIN || CONFIG_CYGWIN || defined(__FreeBSD__) || defined(_WIN32))
-#define USE_SETSOCKOPT
-#include <sys/sendfile.h>
-#endif
 #include <cerrno>
 #include <cstdlib>
 #include <fcntl.h>
@@ -150,11 +145,6 @@ static QString StaticPage =
       "</HEAD>"
       "<BODY><H1>%2.</H1></BODY>"
     "</HTML>";
-
-#ifdef USE_SETSOCKOPT
-//static const int g_on          = 1;
-//static const int g_off         = 0;
-#endif
 
 const char *HTTPRequest::s_szServerHeaders = "Accept-Ranges: bytes\r\n";
 
@@ -361,23 +351,6 @@ qint64 HTTPRequest::SendResponse( void )
                   QString::number(m_eResponseType)));
 
     // ----------------------------------------------------------------------
-    // Make it so the header is sent with the data
-    // ----------------------------------------------------------------------
-
-#ifdef USE_SETSOCKOPT
-//     // Never send out partially complete segments
-//     if (setsockopt(getSocketHandle(), SOL_TCP, TCP_CORK,
-//                    &g_on, sizeof( g_on )) < 0)
-//     {
-//         LOG(VB_HTTP, LOG_INFO,
-//             QString("HTTPRequest::SendResponse(xml/html) "
-//                     "setsockopt error setting TCP_CORK on ") + ENO);
-//     }
-#endif
-
-
-
-    // ----------------------------------------------------------------------
     // Check for ETag match...
     // ----------------------------------------------------------------------
 
@@ -471,20 +444,6 @@ qint64 HTTPRequest::SendResponse( void )
             nBytes += bytesWritten;
     }
 
-    // ----------------------------------------------------------------------
-    // Turn off the option so any small remaining packets will be sent
-    // ----------------------------------------------------------------------
-
-#ifdef USE_SETSOCKOPT
-//     if (setsockopt(getSocketHandle(), SOL_TCP, TCP_CORK,
-//                    &g_off, sizeof( g_off )) < 0)
-//     {
-//         LOG(VB_HTTP, LOG_INFO,
-//             QString("HTTPRequest::SendResponse(xml/html) "
-//                     "setsockopt error setting TCP_CORK off ") + ENO);
-//     }
-#endif
-
     return( nBytes );
 }
 
@@ -503,22 +462,6 @@ qint64 HTTPRequest::SendResponseFile( const QString& sFileName )
 
     m_eResponseType     = ResponseTypeOther;
     m_sResponseTypeText = "text/plain";
-
-    // ----------------------------------------------------------------------
-    // Make it so the header is sent with the data
-    // ----------------------------------------------------------------------
-
-#ifdef USE_SETSOCKOPT
-//     // Never send out partially complete segments
-//     if (setsockopt(getSocketHandle(), SOL_TCP, TCP_CORK,
-//                    &g_on, sizeof( g_on )) < 0)
-//     {
-//         LOG(VB_HTTP, LOG_INFO,
-//             QString("HTTPRequest::SendResponseFile(%1) "
-//                     "setsockopt error setting TCP_CORK on " ).arg(sFileName) +
-//             ENO);
-//     }
-#endif
 
     QFile tmpFile( sFileName );
     if (tmpFile.exists( ) && tmpFile.open( QIODevice::ReadOnly ))
@@ -640,21 +583,6 @@ qint64 HTTPRequest::SendResponseFile( const QString& sFileName )
             nBytes = -1;
         }
     }
-
-    // ----------------------------------------------------------------------
-    // Turn off the option so any small remaining packets will be sent
-    // ----------------------------------------------------------------------
-
-#ifdef USE_SETSOCKOPT
-//     if (setsockopt(getSocketHandle(), SOL_TCP, TCP_CORK,
-//                    &g_off, sizeof( g_off )) < 0)
-//     {
-//         LOG(VB_HTTP, LOG_INFO,
-//             QString("HTTPRequest::SendResponseFile(%1) "
-//                     "setsockopt error setting TCP_CORK off ").arg(sFileName) +
-//             ENO);
-//     }
-#endif
 
     // -=>TODO: Only returns header length...
     //          should we change to return total bytes?


### PR DESCRIPTION
The lines were commented out by 9846f8f6e3eddcbf1e5d74c50d5f994bbe162a66 in 2014.

No functional change.

@linuxdude42 requested this be separated from https://github.com/MythTV/mythtv/pull/442

