### PR TITLE
enable -Wundef for C++ code

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -6278,6 +6278,7 @@ EOF
 check_cxxflags -Wall
 check_cxxflags -Wextra
 check_cxxflags -Wpointer-arith
+check_cxxflags -Wundef
 if disabled deprecation_warnings; then
     check_cxxflags -Wno-deprecated-declarations
 fi

--- a/mythtv/external/libexiv2/libexiv2.pro
+++ b/mythtv/external/libexiv2/libexiv2.pro
@@ -18,6 +18,7 @@ contains(CC, gcc) {
 }
 QMAKE_CXXFLAGS += -Wno-missing-declarations -Wno-shadow
 QMAKE_CXXFLAGS += -Wno-zero-as-null-pointer-constant -Wno-double-promotion
+QMAKE_CXXFLAGS += -Wno-undef
 
 DEFINES += exiv2lib_EXPORTS
 

--- a/mythtv/libs/libmyth/audio/audiooutputbase.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputbase.cpp
@@ -2,11 +2,17 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
-#include <SoundTouch.h>
 
 // POSIX headers
 #include <unistd.h>
 #include <sys/time.h>
+
+// SoundTouch
+#if __has_include(<soundtouch/SoundTouch.h>)
+#include <soundtouch/SoundTouch.h>
+#else
+#include <SoundTouch.h>
+#endif
 
 // Qt headers
 #include <QtGlobal>

--- a/mythtv/libs/libmyth/mediamonitor-unix.cpp
+++ b/mythtv/libs/libmyth/mediamonitor-unix.cpp
@@ -18,6 +18,8 @@
 #include <sys/wait.h>
 #include <sys/param.h>
 
+#include "libmythbase/mythconfig.h"
+
 // Qt headers
 #include <QtGlobal>
 #if CONFIG_QTDBUS
@@ -33,7 +35,6 @@
 // MythTV headers
 #include "libmythbase/exitcodes.h"
 #include "libmythbase/mythcdrom.h"
-#include "libmythbase/mythconfig.h"
 #include "libmythbase/mythcorecontext.h"
 #include "libmythbase/mythhdd.h"
 #include "libmythbase/mythlogging.h"

--- a/mythtv/libs/libmyth/schemawizard.cpp
+++ b/mythtv/libs/libmyth/schemawizard.cpp
@@ -38,7 +38,7 @@ SchemaUpgradeWizard::SchemaUpgradeWizard(QString DBSchemaSetting,
     switch (gCoreContext->GetNumSetting("DBSchemaAutoUpgrade"))
     {
         case  1: m_autoUpgrade = true; break;
-#if ENABLE_SCHEMA_DEVELOPER_MODE
+#if defined(ENABLE_SCHEMA_DEVELOPER_MODE) && ENABLE_SCHEMA_DEVELOPER_MODE
         case -1: m_expertMode  = true; break;
 #endif
         default: break;
@@ -119,7 +119,7 @@ int SchemaUpgradeWizard::Compare(void)
                      .arg(m_schemaName, m_schemaSetting, m_DBver));
     }
 
-#if TESTING
+#if defined(TESTING) && TESTING
     //m_DBver = "9" + m_DBver + "-testing";
     m_DBver += "-testing";
     return 0;
@@ -240,7 +240,7 @@ SchemaUpgradeWizard::PromptForUpgrade(const char *name,
     if (m_versionsBehind == -1)
         Compare();
 
-#if minDBMS_is_only_for_schema_upgrades
+#if defined(minDBMS_is_only_for_schema_upgrades) && minDBMS_is_only_for_schema_upgrades
     if (m_versionsBehind == 0)              // Why was this method even called?
         return MYTH_SCHEMA_USE_EXISTING;
 #endif

--- a/mythtv/libs/libmythbase/mythdb.cpp
+++ b/mythtv/libs/libmythbase/mythdb.cpp
@@ -64,7 +64,7 @@ MythDB *GetMythTestDB(const QString& testname)
     DatabaseParams params {};
     params.m_dbHostName = "localhost";
     params.m_dbHostPing = false;
-#if CONFIG_DEBUGTYPE
+#ifndef NDEBUG
     params.m_dbName =
         QStandardPaths::writableLocation(QStandardPaths::TempLocation) +
         QDir::separator() +

--- a/mythtv/libs/libmythtv/captions/cc708decoder.cpp
+++ b/mythtv/libs/libmythtv/captions/cc708decoder.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_CAPTIONS         0
 #define DEBUG_CC_SERVICE       0
 #define DEBUG_CC_SERVICE_2     0
+#define DEBUG_CC_SERVICE_BLOCK 0
 #define DEBUG_CC_RAWPACKET     0
 #define DEBUG_CC_VALIDPACKET   0
 #define DEBUG_CC_DECODE        0

--- a/mythtv/libs/libmythtv/channelscan/channelscanner_cli.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner_cli.cpp
@@ -77,7 +77,7 @@ void ChannelScannerCLI::HandleEvent(const ScannerEvent *scanEvent)
         m_statusLock = scanEvent->boolValue();
     else if (scanEvent->type() == ScannerEvent::SetStatusSignalToNoise)
         m_statusSnr = scanEvent->intValue() / 65535.0;
-#if THESE_ARE_CURRENTLY_IGNORED
+#if 0 // THESE_ARE_CURRENTLY_IGNORED
     else if (scanEvent->type() == ScannerEvent::SetStatusTitleText)
         ;
     else if (scanEvent->type() == ScannerEvent::SetStatusRotorPosition)

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -274,7 +274,6 @@ class AvFormatDecoder : public DecoderBase
     struct SwsContext *m_swsCtx                       {nullptr};
     bool               m_directRendering              {false};
 
-    bool               m_noDtsHack                    {false};
     bool               m_doRewind                     {false};
 
     bool               m_gopSet                       {false};

--- a/mythtv/libs/libmythtv/recorders/dvbdev/dvbci.h
+++ b/mythtv/libs/libmythtv/recorders/dvbdev/dvbci.h
@@ -27,10 +27,7 @@
 #ifndef DVBCI_H
 #define DVBCI_H
 
-#if HAVE_STDINT_H
 #include <cstdint>
-#endif 
-
 #include <cstdio>
 #include <vector>
 

--- a/mythtv/libs/libmythtv/recorders/firewirechannel.cpp
+++ b/mythtv/libs/libmythtv/recorders/firewirechannel.cpp
@@ -11,7 +11,7 @@
 #include "libmythbase/mythlogging.h"
 #include "tv_rec.h"
 #include "linuxfirewiredevice.h"
-#if USING_OSX_FIREWIRE
+#ifdef USING_OSX_FIREWIRE
 #include "darwinfirewiredevice.h"
 #endif
 #include "firewirechannel.h"

--- a/mythtv/libs/libmythtv/recorders/firewiredevice.cpp
+++ b/mythtv/libs/libmythtv/recorders/firewiredevice.cpp
@@ -16,7 +16,7 @@
 #include "libmythbase/mythlogging.h"
 
 #include "linuxfirewiredevice.h"
-#if USING_OSX_FIREWIRE
+#ifdef USING_OSX_FIREWIRE
 #include "darwinfirewiredevice.h"
 #endif
 #include "mpeg/mpegtables.h"
@@ -366,7 +366,7 @@ std::vector<AVCInfo> FirewireDevice::GetSTBList(void)
 
 #ifdef USING_LINUX_FIREWIRE
     list = LinuxFirewireDevice::GetSTBList();
-#elif USING_OSX_FIREWIRE
+#elif defined(USING_OSX_FIREWIRE)
     list = DarwinFirewireDevice::GetSTBList();
 #endif
 

--- a/mythtv/libs/libmythtv/recorders/vbitext/cc.cpp
+++ b/mythtv/libs/libmythtv/recorders/vbitext/cc.cpp
@@ -29,9 +29,6 @@
 #include <cerrno>
 #include <fcntl.h>
 #include <sys/types.h>
-#if HAVE_GETOPT_H
-# include <getopt.h>
-#endif
 
 #include "cc.h"
 

--- a/mythtv/programs/mythbackend/mediaserver.cpp
+++ b/mythtv/programs/mythbackend/mediaserver.cpp
@@ -8,6 +8,8 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
+#include "libmythbase/mythconfig.h"
+
 // Qt
 #include <QNetworkInterface>
 #include <QNetworkProxy>
@@ -19,7 +21,6 @@
 #ifdef USING_LIBDNS_SD
 #include "libmythbase/bonjourregister.h"
 #endif
-#include "libmythbase/mythconfig.h"
 #include "libmythbase/mythdb.h"
 #include "libmythbase/mythdirs.h"
 #include "libmythupnp/htmlserver.h"

--- a/mythtv/programs/mythbackend/services/image.cpp
+++ b/mythtv/programs/mythbackend/services/image.cpp
@@ -116,7 +116,7 @@ DTC::ImageMetadataInfoList* Image::GetImageInfoList(int id)
         imInfo->setLabel(parts[1]);
         imInfo->setValue(parts[2]);
 
-#if DUMP_METADATA_TAGS
+#if defined(DUMP_METADATA_TAGS) && DUMP_METADATA_TAGS
         LOG(VB_FILE, LOG_DEBUG, LOC +
             QString("Metadata %1 : %2 : '%3'").arg(parts[0], parts[1], parts[2]));
 #endif

--- a/mythtv/programs/mythtranscode/mpeg2fix.cpp
+++ b/mythtv/programs/mythtranscode/mpeg2fix.cpp
@@ -1898,7 +1898,7 @@ int MPEG2fixup::InsertFrame(int frameNum, int64_t deltaPTS,
 
     {
         QString fname;
-#if SPEW_FILES
+#ifdef SPEW_FILES
         static int ins_count = 0;
         fname = (VERBOSE_LEVEL_CHECK(VB_PROCESS, LOG_ANY) ?
                 (QString("ins%1").arg(ins_count++)) : QString());


### PR DESCRIPTION
Disable -Wundef for external/libexiv2/ because of noise from `xmpsdk/include/*`.

See individual commits for details.
