### PR TITLE
Use C++ <random> instead of Qt or POSIX

### DIFF
--- a/mythplugins/mythmusic/mythmusic/bumpscope.cpp
+++ b/mythplugins/mythmusic/mythmusic/bumpscope.cpp
@@ -3,6 +3,7 @@
 
 #include <compat.h>
 #include <mythlogging.h>
+#include <mythrandom.h>
 
 // This was:
 // Bump Scope - Visualization Plugin for XMMS
@@ -409,7 +410,7 @@ bool BumpScope::draw(QPainter *p, const QColor &back)
         if (m_ixo > ((int)m_width / 2) || m_ixo < -((int)m_width / 2))
         {
             m_ixo = (m_ixo > 0) ? (m_width / 2) : -(m_width / 2);
-            if (random() & 1)
+            if (rand_bool())
             {
                 m_ixd = (m_ixd > 0) ? -1 : 1;
                 m_iyd = 0;
@@ -425,7 +426,7 @@ bool BumpScope::draw(QPainter *p, const QColor &back)
         if (m_iyo > ((int)m_height / 2) || m_iyo < -((int)m_height / 2))
         {
             m_iyo = (m_iyo > 0) ? (m_height / 2) : -(m_height / 2);
-            if (random() & 1)
+            if (rand_bool())
             {
                 m_ixd = (m_ixd > 0) ? -1 : 1;
                 m_iyd = 0;
@@ -445,14 +446,14 @@ bool BumpScope::draw(QPainter *p, const QColor &back)
             rgb_to_hsv(m_color, &m_ih, &m_is, &m_iv);
             m_wasColor = 1;
 
-            if (random() & 1)
+            if (rand_bool())
             {
-                m_ihd = (random() & 1) * 2 - 1;
+                m_ihd = rand_bool() ? -1 : 1;
                 m_isd = 0;
             }
             else
             {
-                m_isd = 0.01 * ((random() & 1) * 2 - 1);
+                m_isd = rand_bool() ? -0.01 : 0.01;
                 m_ihd = 0;
             }
         }
@@ -468,16 +469,16 @@ bool BumpScope::draw(QPainter *p, const QColor &back)
                 m_ih = 0;
             if (m_ih < 0)
                 m_ih = 359;
-            if ((random() % 150) == 0)
+            if (rand_bool(150))
             {
-                if (random() & 1)
+                if (rand_bool())
                 {
-                    m_ihd = (random() & 1) * 2 - 1;
+                    m_ihd = rand_bool() ? -1 : 1;
                     m_isd = 0;
                 }
                 else
                 {
-                    m_isd = 0.01 * ((random() & 1) * 2 - 1);
+                    m_isd = rand_bool() ? -0.01 : 0.01;
                     m_ihd = 0;
                 }
             }
@@ -494,19 +495,19 @@ bool BumpScope::draw(QPainter *p, const QColor &back)
                     m_isd = -0.01;
                 else if (m_is == 0)
                 {
-                    m_ihd = random() % 360;
+                    m_ihd = MythRandom(0, 360 - 1);
                     m_isd = 0.01;
                 }
                 else
                 {
-                    if (random() & 1)
+                    if (rand_bool())
                     {
-                        m_ihd = (random() & 1) * 2 - 1;
+                        m_ihd = rand_bool() ? -1 : 1;
                         m_isd = 0;
                     }
                     else
                     {
-                        m_isd = 0.01 * ((random() & 1) * 2 - 1);
+                        m_isd = rand_bool() ? -0.01 : 0.01;
                         m_ihd = 0;
                     }
                 }

--- a/mythplugins/mythmusic/mythmusic/decoderhandler.cpp
+++ b/mythplugins/mythmusic/mythmusic/decoderhandler.cpp
@@ -12,7 +12,7 @@
 #include <mythdownloadmanager.h>
 #include <mythdirs.h>
 #include <mythlogging.h>
-#include <compat.h> // For random() on MINGW32
+#include <mythrandom.h>
 #include <remotefile.h>
 #include <mythcorecontext.h>
 #include <musicmetadata.h>
@@ -142,7 +142,7 @@ bool DecoderHandler::next(void)
 
     if (m_meta.Format() == "cast")
     {
-        m_playlistPos = random() % m_playlist.size();
+        m_playlistPos = MythRandom(0, m_playlist.size() - 1);
     }
     else
     {

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -25,6 +25,7 @@
 #include <lcddevice.h>
 #include <musicmetadata.h>
 #include <mythdate.h>
+#include <mythrandom.h>
 
 // MythMusic includes
 #include "musicdata.h"
@@ -1003,7 +1004,7 @@ void MusicCommon::cycleVisualizer(void)
 
             //Find a visual thats not like the previous visual
             do
-                next_visualizer = random() % m_visualModes.count();
+                next_visualizer = MythRandom(0, m_visualModes.count() - 1);
             while (next_visualizer == m_currentVisual);
             m_currentVisual = next_visualizer;
         }

--- a/mythplugins/mythmusic/mythmusic/vorbisencoder.cpp
+++ b/mythplugins/mythmusic/mythmusic/vorbisencoder.cpp
@@ -12,7 +12,7 @@
 
 // MythTV
 #include <mythcontext.h>
-#include <compat.h> // For random() on MINGW32
+#include <mythrandom.h>
 #include <musicmetadata.h>
 
 // MythMusic
@@ -59,7 +59,7 @@ VorbisEncoder::VorbisEncoder(const QString &outfile, int qualitylevel,
     vorbis_analysis_init(&m_vd, &m_vi);
     vorbis_block_init(&m_vd, &m_vb);
 
-    ogg_stream_init(&m_os, random());
+    ogg_stream_init(&m_os, MythRandom());
 
     ogg_packet header_main;
     ogg_packet header_comments;

--- a/mythtv/libs/libmythbase/bonjourregister.cpp
+++ b/mythtv/libs/libmythbase/bonjourregister.cpp
@@ -135,11 +135,7 @@ QByteArray BonjourRegister::RandomizeData(void)
 
     data.append(7);
     data.append("_rnd=");
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    rnd.append((MythRandom() % 80) + 33);
-#else
     rnd.append(MythRandom(33, 33 + 80 - 1));
-#endif
     data.append(rnd.toHex());
 
     return data;

--- a/mythtv/libs/libmythbase/http/mythwebsocket.cpp
+++ b/mythtv/libs/libmythbase/http/mythwebsocket.cpp
@@ -586,7 +586,7 @@ void MythWebSocket::SendFrame(WSOpCode Code, const DataPayloads& Payloads)
 #if QT_VERSION < QT_VERSION_CHECK(5,10,0)
             mask->data()[i] = static_cast<int8_t>(MythRandom() % 0x100);
 #else
-            mask->data()[i] = (int8_t)MythRandom(INT8_MIN, INT8_MAX);
+            mask->data()[i] = (int8_t)MythRandomInt(INT8_MIN, INT8_MAX);
 #endif
         }
         header->data()[1] |= 0x80;

--- a/mythtv/libs/libmythbase/http/mythwebsocket.cpp
+++ b/mythtv/libs/libmythbase/http/mythwebsocket.cpp
@@ -583,11 +583,7 @@ void MythWebSocket::SendFrame(WSOpCode Code, const DataPayloads& Payloads)
         mask = MythSharedData::CreatePayload(4);
         for (int i = 0; i < 4; ++i)
         {
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-            mask->data()[i] = static_cast<int8_t>(MythRandom() % 0x100);
-#else
             mask->data()[i] = (int8_t)MythRandomInt(INT8_MIN, INT8_MAX);
-#endif
         }
         header->data()[1] |= 0x80;
     }

--- a/mythtv/libs/libmythbase/mythcorecontext.cpp
+++ b/mythtv/libs/libmythbase/mythcorecontext.cpp
@@ -155,9 +155,6 @@ MythCoreContextPrivate::MythCoreContextPrivate(MythCoreContext *lparent,
       m_power(nullptr)
 {
     MThread::ThreadSetup("CoreContext");
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    srandom(MythDate::current().toSecsSinceEpoch() ^ QTime::currentTime().msec());
-#endif
 }
 
 static void delete_sock(

--- a/mythtv/libs/libmythbase/mythdbcon.cpp
+++ b/mythtv/libs/libmythbase/mythdbcon.cpp
@@ -27,6 +27,7 @@
 #include "mythdate.h"
 #include "portchecker.h"
 #include "mythmiscutil.h"
+#include "mythrandom.h"
 
 #define DEBUG_RECONNECT 0
 #if DEBUG_RECONNECT
@@ -620,7 +621,7 @@ bool MSqlQuery::exec()
     }
 
 #if DEBUG_RECONNECT
-    if (random() < RAND_MAX / 50)
+    if (rand_bool(50))
     {
         LOG(VB_GENERAL, LOG_INFO,
             "MSqlQuery disconnecting DB to test reconnection logic");

--- a/mythtv/libs/libmythbase/mythrandom.cpp
+++ b/mythtv/libs/libmythbase/mythrandom.cpp
@@ -1,2 +1,2 @@
-#include "mythmiscutil.h"
-// ensure header compiles
+#include "mythrandom.h"
+// ensure header is self sufficient and compiles standalone

--- a/mythtv/libs/libmythbase/mythrandom.h
+++ b/mythtv/libs/libmythbase/mythrandom.h
@@ -8,54 +8,6 @@ Convenience inline random number generator functions
 #include <cstdint>
 #include <random>
 
-#include <QtGlobal>
-
-#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
-#include <QRandomGenerator>
-#endif
-
-namespace MythRandomQt
-{
-/**
-@brief generate 32 random bits
-*/
-inline uint32_t MythRandom()
-{
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    return static_cast<uint32_t>(qrand());
-#else
-    return QRandomGenerator::global()->generate();
-#endif
-}
-
-#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
-/**
-@brief generate 64 random bits
-*/
-inline uint64_t MythRandom64()
-{
-    return QRandomGenerator::global()->generate64();
-}
-
-/**
-@brief generate a random uint32_t in the range [min, max]
-*/
-inline uint32_t MythRandom(uint32_t min, uint32_t max)
-{
-    return QRandomGenerator::global()->bounded(min, max);
-}
-
-/**
-@brief generate a random signed int in the range [min, max]
-*/
-inline int MythRandomInt(int min, int max)
-{
-    return QRandomGenerator::global()->bounded(min, max);
-}
-
-#endif
-} // namespace MythRandomQt
-
 inline namespace MythRandomStd
 {
 

--- a/mythtv/libs/libmythbase/mythrandom.h
+++ b/mythtv/libs/libmythbase/mythrandom.h
@@ -14,8 +14,6 @@ Convenience inline random number generator functions
 #include <QRandomGenerator>
 #endif
 
-#include "mythbaseexp.h"
-
 inline namespace MythRandomQt
 {
 /**

--- a/mythtv/libs/libmythbase/mythrandom.h
+++ b/mythtv/libs/libmythbase/mythrandom.h
@@ -14,7 +14,7 @@ Convenience inline random number generator functions
 #include <QRandomGenerator>
 #endif
 
-inline namespace MythRandomQt
+namespace MythRandomQt
 {
 /**
 @brief generate 32 random bits
@@ -56,7 +56,7 @@ inline int MythRandomInt(int min, int max)
 #endif
 } // namespace MythRandomQt
 
-namespace MythRandomStd
+inline namespace MythRandomStd
 {
 
 using MythRandomGenerator_32 = std::mt19937;

--- a/mythtv/libs/libmythbase/mythrandom.h
+++ b/mythtv/libs/libmythbase/mythrandom.h
@@ -8,9 +8,9 @@ Convenience inline random number generator functions
 #include <cstdint>
 //#include <random> // could be used instead of Qt
 
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
 #include <QtGlobal>
-#else
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
 #include <QRandomGenerator>
 #endif
 

--- a/mythtv/libs/libmythbase/mythrandom.h
+++ b/mythtv/libs/libmythbase/mythrandom.h
@@ -48,7 +48,7 @@ inline uint32_t MythRandom(uint32_t min, uint32_t max)
 /**
 @brief generate a random signed int in the range [min, max]
 */
-inline int MythRandom(int min, int max)
+inline int MythRandomInt(int min, int max)
 {
     return QRandomGenerator::global()->bounded(min, max);
 }

--- a/mythtv/libs/libmythbase/mythrandom.h
+++ b/mythtv/libs/libmythbase/mythrandom.h
@@ -6,7 +6,7 @@ Convenience inline random number generator functions
 */
 
 #include <cstdint>
-//#include <random> // could be used instead of Qt
+#include <random>
 
 #include <QtGlobal>
 
@@ -57,5 +57,80 @@ inline int MythRandom(int min, int max)
 
 #endif
 } // namespace MythRandomQt
+
+namespace MythRandomStd
+{
+
+using MythRandomGenerator_32 = std::mt19937;
+using MythRandomGenerator_64 = std::mt19937_64;
+
+/**
+@brief generate 32 random bits
+*/
+inline uint32_t MythRandom()
+{
+    static std::random_device rd;
+    static MythRandomGenerator_32 generator(rd());
+    return generator();
+
+}
+
+/**
+@brief generate 64 random bits
+*/
+inline uint64_t MythRandom64()
+{
+    static std::random_device rd;
+    static MythRandomGenerator_64 generator(rd());
+    return generator();
+}
+
+/**
+@brief generate a uniformly distributed random uint32_t in the closed interval [min, max].
+
+The behavior is undefined if \f$min > max\f$.
+
+An alternate name would be MythRandomU32.
+*/
+inline uint32_t MythRandom(uint32_t min, uint32_t max)
+{
+    static std::random_device rd;
+    static MythRandomGenerator_32 generator(rd());
+    std::uniform_int_distribution<uint32_t> distrib(min, max);
+    return distrib(generator);
+}
+
+/**
+@brief generate a uniformly distributed random signed int in the closed interval [min, max].
+
+The behavior is undefined if \f$min > max\f$.
+*/
+inline int MythRandomInt(int min, int max)
+{
+    static std::random_device rd;
+    static MythRandomGenerator_32 generator(rd());
+    std::uniform_int_distribution<int> distrib(min, max);
+    return distrib(generator);
+}
+
+/**
+@brief return a random bool with P(true) = 1/chance
+
+An input less than 2 always returns true:
+ - for chance = 1: range is [0, 0], i.e. always 0
+ - for chance = 0: range is [0, -1], unsigned integer underflow! (or just undefined behavior if signed)
+
+This is a Bernoulli distribution with \f$p = 1 / chance\f$.
+*/
+inline bool rand_bool(uint32_t chance = 2)
+{
+    if (chance < 2)
+    {
+        return true;
+    }
+    return MythRandom(0U, chance - 1) == 0U;
+}
+
+} // namespace MythRandomStd
 
 #endif // MYTH_RANDOM_H_

--- a/mythtv/libs/libmythbase/mythrandom.h
+++ b/mythtv/libs/libmythbase/mythrandom.h
@@ -16,6 +16,8 @@ Convenience inline random number generator functions
 
 #include "mythbaseexp.h"
 
+inline namespace MythRandomQt
+{
 /**
 @brief generate 32 random bits
 */
@@ -54,6 +56,6 @@ inline int MythRandom(int min, int max)
 }
 
 #endif
-
+} // namespace MythRandomQt
 
 #endif // MYTH_RANDOM_H_

--- a/mythtv/libs/libmythfreemheg/Programs.cpp
+++ b/mythtv/libs/libmythfreemheg/Programs.cpp
@@ -297,14 +297,10 @@ void MHResidentProgram::CallProgram(bool fIsFork, const MHObjectRef &success, co
             {
                 int nLimit = GetInt(args.GetAt(0), engine);
                 MHParameter *pResInt = args.GetAt(1);
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-                int r = static_cast<int>(MythRandom() % (nLimit + 1));
-#else
+                // ETSI ES 202 184 V2.4.1 (2016-06) §11.10.5 Random number function
+                // specifies "The returned value is undefined if the num parameter < 1."
+                // so this is fine.
                 int r = MythRandom(0, nLimit);
-/* note: undefined behavior if nLimit is negative, but the above % statement
-would also be incorrect in that case
-*/
-#endif
                 engine->FindObject(
                     *(pResInt->GetReference()))->SetVariableValue(r);
                 SetSuccessFlag(success, true, engine);

--- a/mythtv/libs/libmythtv/AirPlay/mythairplayserver.cpp
+++ b/mythtv/libs/libmythtv/AirPlay/mythairplayserver.cpp
@@ -137,11 +137,7 @@ QString AirPlayHardwareId()
         QByteArray ba;
         for (int i = 0; i < AIRPLAY_HARDWARE_ID_SIZE; i++)
         {
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-            ba.append((MythRandom() % 80) + 33);
-#else
             ba.append(MythRandom(33, 33 + 80 - 1));
-#endif
         }
         id = ba.toHex();
     }
@@ -153,16 +149,12 @@ QString AirPlayHardwareId()
 
 QString GenerateNonce(void)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(5,10,0)
-    auto *randgen = QRandomGenerator::global();
     std::array<uint32_t,4> nonceParts {
-        randgen->generate(), randgen->generate(),
-        randgen->generate(), randgen->generate() };
-#else
-    std::srand(std::time(nullptr));
-    std::array<int32_t,4> nonceParts {
-        std::rand(), std::rand(), std::rand(), std::rand() };
-#endif
+        MythRandom(),
+        MythRandom(),
+        MythRandom(),
+        MythRandom()
+    };
 
     QString nonce;
     nonce =  QString::number(nonceParts[0], 16).toUpper();

--- a/mythtv/libs/libmythtv/eitscanner.cpp
+++ b/mythtv/libs/libmythtv/eitscanner.cpp
@@ -34,6 +34,7 @@
 EITScanner::EITScanner(uint cardnum)
     : m_eitHelper(new EITHelper(cardnum)),
       m_eventThread(new MThread("EIT", this)),
+      m_activeScanNextChanIndex(MythRandom()),
       m_cardnum(cardnum)
 {
     QStringList langPref = iso639_get_language_list();

--- a/mythtv/libs/libmythtv/eitscanner.cpp
+++ b/mythtv/libs/libmythtv/eitscanner.cpp
@@ -289,11 +289,7 @@ void EITScanner::StartActiveScan(TVRec *rec, std::chrono::seconds max_seconds_pe
         m_activeScanTrigTime = max_seconds_per_source;
         // Add a little randomness to trigger time so multiple
         // cards will have a staggered channel changing time.
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-        m_activeScanTrigTime += std::chrono::seconds(MythRandom() % 29);
-#else
         m_activeScanTrigTime += std::chrono::seconds(MythRandom(0, 28));
-#endif
 
         m_activeScanStopped = false;
         m_activeScan = true;

--- a/mythtv/libs/libmythtv/eitscanner.h
+++ b/mythtv/libs/libmythtv/eitscanner.h
@@ -9,9 +9,6 @@
 #include <QRunnable>
 #include <QMutex>
 
-// MythTV
-#include "mythrandom.h"
-
 class TVRec;
 class MThread;
 class ChannelBase;
@@ -65,7 +62,7 @@ class EITScanner : public QRunnable
     std::chrono::seconds  m_activeScanTrigTime      {0s};
     QStringList           m_activeScanChannels;
     QStringList::iterator m_activeScanNextChan;
-    uint                  m_activeScanNextChanIndex {MythRandom()};
+    uint                  m_activeScanNextChanIndex {0};
 
     uint                  m_cardnum;
 

--- a/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.cpp
+++ b/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.cpp
@@ -4,8 +4,7 @@
  * Distributed as part of MythTV under GPL v2 and later.
  */
 
-// POSIX headers
-#include <cstdlib> // for random
+#include <cstdint>
 
 // MythTV headers
 #include "packetbuffer.h"

--- a/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.cpp
+++ b/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.cpp
@@ -12,7 +12,7 @@
 
 PacketBuffer::PacketBuffer(unsigned int bitrate) :
     m_bitrate(bitrate),
-    m_next_empty_packet_key(MythRandom64())
+    m_next_empty_packet_key(MythRandom() << 32)
 {
 }
 
@@ -48,7 +48,8 @@ UDPPacket PacketBuffer::GetEmptyPacket(void)
 
 void PacketBuffer::FreePacket(const UDPPacket &packet)
 {
-    uint64_t top = packet.GetKey() & (0xFFFFFFFFULL<<32);
-    if (top == (m_next_empty_packet_key & (0xFFFFFFFFULL<<32)))
+    static constexpr uint64_t k_mask_upper_32 = ~((UINT64_C(1) << (64 - 32)) - 1);
+    uint64_t top = packet.GetKey() & k_mask_upper_32;
+    if (top == (m_next_empty_packet_key & k_mask_upper_32))
         m_empty_packets[packet.GetKey()] = packet;
 }

--- a/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.cpp
+++ b/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.cpp
@@ -12,21 +12,9 @@
 
 PacketBuffer::PacketBuffer(unsigned int bitrate) :
     m_bitrate(bitrate),
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    m_next_empty_packet_key(0ULL)
-{
-    while (!m_next_empty_packet_key)
-    {
-        m_next_empty_packet_key =
-            (MythRandom() << 24) ^ (MythRandom() << 16) ^
-            (MythRandom() << 8) ^ MythRandom();
-    }
-}
-#else
     m_next_empty_packet_key(MythRandom64())
 {
 }
-#endif
 
 bool PacketBuffer::HasAvailablePacket(void) const
 {

--- a/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.h
+++ b/mythtv/libs/libmythtv/recorders/rtp/packetbuffer.h
@@ -43,7 +43,9 @@ class PacketBuffer
   protected:
     uint m_bitrate;
 
-    /// Packets key to use for next empty packet
+    /** @brief Packets key to use for next empty packet.
+    The upper 32 bits are random and the lower 32 bits are incremented from 0.
+    */
     uint64_t m_next_empty_packet_key;
     
     /// Packets ready for reuse

--- a/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.cpp
+++ b/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.cpp
@@ -101,11 +101,7 @@ static uint64_t FillRandom(MythVideoFrame* Frame)
         int offset = Frame->m_offsets[plane];
         for (int i = 0; i < width; ++i)
         {
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-            unsigned char val = MythRandom() & 0xFF;
-#else
             unsigned char val = MythRandom(0, UCHAR_MAX);
-#endif
             Frame->m_buffer[offset++] = val;
             sum += val;
             counts++;

--- a/mythtv/libs/libmythtv/tv_rec.cpp
+++ b/mythtv/libs/libmythtv/tv_rec.cpp
@@ -1276,11 +1276,7 @@ static int num_inputs(void)
 static std::chrono::seconds eit_start_rand(uint inputId, std::chrono::seconds eitTransportTimeout)
 {
     // Randomize start time a bit
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    auto timeout = std::chrono::seconds(MythRandom()) % (eitTransportTimeout.count() / 3);
-#else
     auto timeout = std::chrono::seconds(MythRandom(0, eitTransportTimeout.count() / 3));
-#endif
 
     // Get the number of inputs and the position of the current input
     // to distribute the scan start evenly over eitTransportTimeout

--- a/mythtv/libs/libmythui/mythuitype.cpp
+++ b/mythtv/libs/libmythui/mythuitype.cpp
@@ -58,12 +58,8 @@ MythUIType::MythUIType(QObject *parent, const QString &name)
 
     m_fonts = new FontMap();
 
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    m_borderColor = QColor(MythRandom() % 255, MythRandom()  % 255, MythRandom()  % 255);
-#else
     // for debugging/theming
     m_borderColor = QColor(MythRandom(0, 255), MythRandom(0, 255), MythRandom(0, 255));
-#endif
 }
 
 MythUIType::~MythUIType()

--- a/mythtv/libs/libmythupnp/mmulticastsocketdevice.cpp
+++ b/mythtv/libs/libmythupnp/mmulticastsocketdevice.cpp
@@ -117,11 +117,7 @@ qint64 MMulticastSocketDevice::writeBlock(
             LOG(VB_GENERAL, LOG_DEBUG, LOC + QString("writeBlock on %1 %2")
                     .arg((*it).toString()).arg((retx==(int)len)?"ok":"err"));
 #endif
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-            std::this_thread::sleep_for(std::chrono::milliseconds(5 + (MythRandom() % 5)));
-#else
             std::this_thread::sleep_for(std::chrono::milliseconds(MythRandom(5, 9)));
-#endif
         }
         return retx;
     }

--- a/mythtv/libs/libmythupnp/ssdp.cpp
+++ b/mythtv/libs/libmythupnp/ssdp.cpp
@@ -231,11 +231,7 @@ void SSDP::PerformSearch(const QString &sST, std::chrono::seconds timeout)
         LOG(VB_GENERAL, LOG_INFO,
             "SSDP::PerformSearch - did not write entire buffer.");
 
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    std::this_thread::sleep_for(std::chrono::milliseconds(MythRandom() % 250));
-#else
     std::this_thread::sleep_for(std::chrono::milliseconds(MythRandom(0, 250)));
-#endif
 
     if ( pSocket->writeBlock( sRequest.data(),
                               sRequest.size(), address, SSDP_PORT ) != nSize)
@@ -547,11 +543,7 @@ bool SSDP::ProcessSearchRequest( const QStringMap &sHeaders,
 
     nMX = std::clamp(nMX, 0s, 120s);
 
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    auto nNewMX = std::chrono::milliseconds(MythRandom()) % nMX;
-#else
     auto nNewMX = std::chrono::milliseconds(MythRandom(0, (duration_cast<std::chrono::milliseconds>(nMX)).count()));
-#endif
 
     // ----------------------------------------------------------------------
     // See what they are looking for...

--- a/mythtv/libs/libmythupnp/upnptasknotify.cpp
+++ b/mythtv/libs/libmythupnp/upnptasknotify.cpp
@@ -128,11 +128,8 @@ void UPnpNotifyTask::SendNotifyMsg( MSocketDevice *pSocket,
                              pSocket->address(), pSocket->port() );
         if (m_eNTS != NTS_byebye)
         {
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-            std::this_thread::sleep_for(std::chrono::milliseconds(MythRandom() % 250));
-#else
             std::this_thread::sleep_for(std::chrono::milliseconds(MythRandom(0, 250)));
-#endif
+
             pSocket->writeBlock( scPacket, scPacket.length(),
                                 pSocket->address(), pSocket->port() );
         }

--- a/mythtv/libs/libmythupnp/upnptasksearch.cpp
+++ b/mythtv/libs/libmythupnp/upnptasksearch.cpp
@@ -145,11 +145,9 @@ void UPnpSearchTask::SendMsg( MSocketDevice  *pSocket,
 
                 pSocket->writeBlock( scPacket, scPacket.length(), m_peerAddress,
                                     m_nPeerPort );
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-                std::this_thread::sleep_for( std::chrono::milliseconds( MythRandom() % 250 ));
-#else
+
                 std::this_thread::sleep_for(std::chrono::milliseconds(MythRandom(0, 250)));
-#endif
+
                 pSocket->writeBlock( scPacket, scPacket.length(), m_peerAddress,
                                     m_nPeerPort );
             }

--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -2394,7 +2394,7 @@ void MainServer::DoDeleteThread(DeleteStruct *ds)
         .arg(ds->m_chanid)
         .arg(ds->m_recstartts.toString(Qt::ISODate));
 
-    QString name = QString("deleteThread%1%2").arg(getpid()).arg(random());
+    QString name = QString("deleteThread%1%2").arg(getpid()).arg(MythRandom());
 #endif
     QFile checkFile(ds->m_filename);
 

--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -2384,12 +2384,7 @@ void MainServer::DoDeleteThread(DeleteStruct *ds)
 {
     // sleep a little to let frontends reload the recordings list
     // after deleting a recording, then we can hammer the DB and filesystem
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-    std::this_thread::sleep_for(3s);
-    std::this_thread::sleep_for(std::chrono::milliseconds(MythRandom()%2));
-#else
     std::this_thread::sleep_for(3s + std::chrono::microseconds(MythRandom(0, 2000)));
-#endif
 
     m_deletelock.lock();
 

--- a/mythtv/programs/mythfrontend/playbackbox.cpp
+++ b/mythtv/programs/mythfrontend/playbackbox.cpp
@@ -2267,11 +2267,7 @@ void PlaybackBox::playSelectedPlaylist(bool Random)
         QList<uint> tmp = m_playList;
         while (!tmp.isEmpty())
         {
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-            uint i = MythRandom() % tmp.size();
-#else
             unsigned int i = MythRandom(0, tmp.size() - 1);
-#endif
             m_playListPlay.append(tmp[i]);
             tmp.removeAll(tmp[i]);
         }

--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -3071,11 +3071,7 @@ void VideoDialog::playVideoWithTrailers()
     while (!trailers.isEmpty() && i < trailersToPlay)
     {
         ++i;
-#if QT_VERSION < QT_VERSION_CHECK(5,10,0)
-        QString trailer = trailers.takeAt(static_cast<int>(MythRandom() % trailers.size()));
-#else
         QString trailer = trailers.takeAt(MythRandom(0, trailers.size() - 1));
-#endif
 
         LOG(VB_GENERAL, LOG_DEBUG,
             QString("Random trailer to play will be: %1").arg(trailer));


### PR DESCRIPTION
This also removes the conditional compilation due to the Qt random number generator functions added in 5.10.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

