### PR TITLE
libmythfreesuround cleanup (remove internal FFmpeg header fft.h)

### DIFF
--- a/mythtv/libs/libmythfreesurround/el_processor.cpp
+++ b/mythtv/libs/libmythfreesurround/el_processor.cpp
@@ -216,11 +216,11 @@ public:
 
 private:
     // polar <-> cartesian coodinates conversion
-    static inline float amplitude(const float *cf) { return std::sqrt(cf[0]*cf[0] + cf[1]*cf[1]); }
+    static inline float amplitude(const float *cf) { return std::hypot(cf[0], cf[1]); }
     static inline float phase(const float *cf) { return std::atan2(cf[1],cf[0]); }
     static inline cfloat polar(float a, float p) { return {static_cast<float>(a*std::cos(p)),static_cast<float>(a*std::sin(p))}; }
 #ifndef USE_FFTW3
-    static inline float amplitude(FFTComplex z) { return std::sqrt(z.re * z.re + z.im * z.im); }
+    static inline float amplitude(FFTComplex z) { return std::hypot(z.re, z.im); }
     static inline float phase(FFTComplex z) { return std::atan2(z.im, z.re); }
 #endif
     static inline float sqr(float x) { return x*x; }

--- a/mythtv/libs/libmythfreesurround/el_processor.cpp
+++ b/mythtv/libs/libmythfreesurround/el_processor.cpp
@@ -48,11 +48,11 @@ static const float epsilon = 0.000001;
 static const float center_level = 0.5*sqrt(0.5);
 
 // private implementation of the surround decoder
-class decoder_impl {
+class fsurround_decoder::Impl {
 public:
     // create an instance of the decoder
     //  blocksize is fixed over the lifetime of this object for performance reasons
-    explicit decoder_impl(unsigned blocksize=8192): m_n(blocksize), m_halfN(blocksize/2) {
+    explicit Impl(unsigned blocksize=8192): m_n(blocksize), m_halfN(blocksize/2) {
 #ifdef USE_FFTW3
         // create FFTW buffers
         m_lt = (float*)fftwf_malloc(sizeof(float)*m_n);
@@ -105,7 +105,7 @@ public:
     }
 
     // destructor
-    ~decoder_impl() {
+    ~Impl() {
 #ifdef USE_FFTW3
         // clean up the FFTW stuff
         fftwf_destroy_plan(m_store);
@@ -534,14 +534,12 @@ private:
     int m_currentBuf;                    // specifies which buffer is 2nd half of input sliding buffer
     InputBufs  m_inbufs     {};          // for passing back to driver
     OutputBufs m_outbufs    {};          // for passing back to driver
-
-    friend class fsurround_decoder;
 };
 
 
 // implementation of the shell class
 
-fsurround_decoder::fsurround_decoder(unsigned blocksize): m_impl(new decoder_impl(blocksize)) { }
+fsurround_decoder::fsurround_decoder(unsigned blocksize): m_impl(new Impl(blocksize)) { }
 
 fsurround_decoder::~fsurround_decoder() { delete m_impl; }
 

--- a/mythtv/libs/libmythfreesurround/el_processor.cpp
+++ b/mythtv/libs/libmythfreesurround/el_processor.cpp
@@ -244,22 +244,18 @@ private:
         // 1. scale the input by the window function; this serves a dual purpose:
         // - first it improves the FFT resolution b/c boundary discontinuities (and their frequencies) get removed
         // - second it allows for smooth blending of varying filters between the blocks
+
+        // the window also includes 1.0/sqrt(n) normalization
+        // concatenate copies of input1 and input2 for some undetermined reason
+        // input1 is in the rising half of the window
+        // input2 is in the falling half of the window
+        for (unsigned k = 0; k < m_halfN; k++)
         {
-            float* pWnd = &m_wnd[0];
-            float* pLt =  &m_lt[0];
-            float* pRt =  &m_rt[0];
-            float* pIn0 = input1[0];
-            float* pIn1 = input1[1];
-            for (unsigned k=0;k<m_halfN;k++) {
-                *pLt++ = *pIn0++ * *pWnd;
-                *pRt++ = *pIn1++ * *pWnd++;
-            }
-            pIn0 = input2[0];
-            pIn1 = input2[1];
-            for (unsigned k=0;k<m_halfN;k++) {
-                *pLt++ = *pIn0++ * *pWnd;
-                *pRt++ = *pIn1++ * *pWnd++;
-            }
+            m_lt[k]             = input1[0][k] * m_wnd[k];
+            m_rt[k]             = input1[1][k] * m_wnd[k];
+
+            m_lt[k + m_halfN]   = input2[0][k] * m_wnd[k + m_halfN];
+            m_rt[k + m_halfN]   = input2[1][k] * m_wnd[k + m_halfN];
         }
 
 #ifdef USE_FFTW3

--- a/mythtv/libs/libmythfreesurround/el_processor.cpp
+++ b/mythtv/libs/libmythfreesurround/el_processor.cpp
@@ -445,7 +445,15 @@ private:
 #endif
     }
 
-    // filter the complex source signal and add it to target
+    /**
+    @brief Filter the complex source signal in the frequency domain and add it
+           to the time domain target signal.
+
+    @param[in]  signal  The signal, in the frequency domain, to be filtered.
+    @param[in]  flt     The filter, in the frequency domain, to be applied.
+    @param[out] target  The signal, in the time domain, to which the filtered signal
+                        is added
+    */
     void apply_filter(cfloat *signal, const float *flt, float *target) {
 #ifdef USE_FFTW3
         // filter the signal
@@ -507,10 +515,10 @@ private:
 #else
     FFTContext *m_fftContextForward {nullptr};
     FFTContext *m_fftContextReverse {nullptr};
-    // intermediate arrays (FFTs of lt & rt, processing source)
+    // FFTs are computed in-place in these buffers on copies of the input
     FFTComplex *m_dftL {nullptr};
     FFTComplex *m_dftR {nullptr};
-    FFTComplex *m_src  {nullptr};
+    FFTComplex *m_src  {nullptr}; ///< Used only in apply_filter
 #endif
     // buffers
     std::vector<cfloat> m_frontL,m_frontR,m_avg,m_surL,m_surR; // the signal (phase-corrected) in the frequency domain

--- a/mythtv/libs/libmythfreesurround/el_processor.cpp
+++ b/mythtv/libs/libmythfreesurround/el_processor.cpp
@@ -225,7 +225,8 @@ private:
 #endif
     static inline float sqr(float x) { return x*x; }
 
-    static inline float clamp(float x) { return std::clamp(x, -1.0F, 1.0F); }
+    /// Clamp the input to the interval [-1, 1], i.e. clamp the magnitude to the unit interval [0, 1]
+    static inline float clamp_unit_mag(float x) { return std::clamp(x, -1.0F, 1.0F); }
 
     // handle the output buffering for overlapped calls of block_decode
     void add_output(InputBufs input1, InputBufs input2, float center_width, float dimension, float adaption_rate, bool /*result*/=false) {
@@ -288,7 +289,7 @@ private:
 //              continue;       
 
             // calculate the amplitude/phase difference
-            float ampDiff = clamp((ampL+ampR < epsilon) ? 0 : (ampR-ampL) / (ampR+ampL));
+            float ampDiff = clamp_unit_mag((ampL+ampR < epsilon) ? 0 : (ampR-ampL) / (ampR+ampL));
             float phaseDiff = phaseL - phaseR;
             if (phaseDiff < -PI) phaseDiff += 2*PI;
             if (phaseDiff > PI) phaseDiff -= 2*PI;
@@ -302,10 +303,10 @@ private:
                 m_xFs[f] = get_xfs(ampDiff,m_yFs[f]);
 
                 // add dimension control
-                m_yFs[f] = clamp(m_yFs[f] - dimension);
+                m_yFs[f] = clamp_unit_mag(m_yFs[f] - dimension);
 
                 // add crossfeed control
-                m_xFs[f] = clamp(m_xFs[f] * (m_frontSeparation*(1+m_yFs[f])/2 + m_rearSeparation*(1-m_yFs[f])/2));
+                m_xFs[f] = clamp_unit_mag(m_xFs[f] * (m_frontSeparation*(1+m_yFs[f])/2 + m_rearSeparation*(1-m_yFs[f])/2));
 
                 // 3. generate frequency filters for each output channel
                 float left = (1-m_xFs[f])/2;
@@ -329,7 +330,7 @@ private:
                 // --- this is the old & simple steering mode ---
 
                 // calculate the amplitude/phase difference
-                float ampDiff = clamp((ampL+ampR < epsilon) ? 0 : (ampR-ampL) / (ampR+ampL));
+                float ampDiff = clamp_unit_mag((ampL+ampR < epsilon) ? 0 : (ampR-ampL) / (ampR+ampL));
                 float phaseDiff = phaseL - phaseR;
                 if (phaseDiff < -PI) phaseDiff += 2*PI;
                 if (phaseDiff > PI) phaseDiff -= 2*PI;
@@ -349,10 +350,10 @@ private:
                 }
 
                 // add dimension control
-                m_yFs[f] = clamp(m_yFs[f] - dimension);
+                m_yFs[f] = clamp_unit_mag(m_yFs[f] - dimension);
 
                 // add crossfeed control
-                m_xFs[f] = clamp(m_xFs[f] * (m_frontSeparation*(1+m_yFs[f])/2 + m_rearSeparation*(1-m_yFs[f])/2));
+                m_xFs[f] = clamp_unit_mag(m_xFs[f] * (m_frontSeparation*(1+m_yFs[f])/2 + m_rearSeparation*(1-m_yFs[f])/2));
 
                 // 3. generate frequency filters for each output channel, according to the signal position
                 // the sum of all channel volumes must be 1.0

--- a/mythtv/libs/libmythfreesurround/el_processor.h
+++ b/mythtv/libs/libmythfreesurround/el_processor.h
@@ -67,7 +67,8 @@ public:
     void sample_rate(unsigned int samplerate);
 
 private:
-    class decoder_impl *m_impl; // private implementation (details hidden)
+    class Impl;
+    Impl *m_impl; // private implementation (details hidden)
 };
 
 

--- a/mythtv/libs/libmythfreesurround/el_processor.h
+++ b/mythtv/libs/libmythfreesurround/el_processor.h
@@ -22,52 +22,52 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 // the Free Surround decoder
 class fsurround_decoder {
 public:
-	// create an instance of the decoder
-	//  blocksize is fixed over the lifetime of this object for performance reasons
-	explicit fsurround_decoder(unsigned blocksize=8192);
-	// destructor
-	~fsurround_decoder();
-	
+    // create an instance of the decoder
+    //  blocksize is fixed over the lifetime of this object for performance reasons
+    explicit fsurround_decoder(unsigned blocksize=8192);
+    // destructor
+    ~fsurround_decoder();
+    
     float ** getInputBuffers();
     float ** getOutputBuffers();
 
-	// decode a chunk of stereo sound, has to contain exactly blocksize samples
-	//  center_width [0..1] distributes the center information towards the front left/right channels, 1=full distribution, 0=no distribution
-	//  dimension [0..1] moves the soundfield backwards, 0=front, 1=side
-	//  adaption_rate [0..1] determines how fast the steering gets adapted, 1=instantaneous, 0.1 = very slow adaption
-	//void decode(float *input[2], float *output[6], float center_width=1, float dimension=0, float adaption_rate=1);	
-	void decode(float center_width=1, float dimension=0, float adaption_rate=1);	
-	
-	// flush the internal buffers
-	void flush();
+    // decode a chunk of stereo sound, has to contain exactly blocksize samples
+    //  center_width [0..1] distributes the center information towards the front left/right channels, 1=full distribution, 0=no distribution
+    //  dimension [0..1] moves the soundfield backwards, 0=front, 1=side
+    //  adaption_rate [0..1] determines how fast the steering gets adapted, 1=instantaneous, 0.1 = very slow adaption
+    //void decode(float *input[2], float *output[6], float center_width=1, float dimension=0, float adaption_rate=1);   
+    void decode(float center_width=1, float dimension=0, float adaption_rate=1);
+    
+    // flush the internal buffers
+    void flush();
 
-	// --- advanced configuration ---
+    // --- advanced configuration ---
 
-	// override the surround coefficients
-	//  a is the coefficient of left rear in left total, b is the coefficient of left rear in right total; the same is true for right.
-	void surround_coefficients(float a, float b);
+    // override the surround coefficients
+    //  a is the coefficient of left rear in left total, b is the coefficient of left rear in right total; the same is true for right.
+    void surround_coefficients(float a, float b);
 
-	// set the phase shifting mode for decoding
-	// 0 = (+0ﾰ,+0ﾰ)   - music mode
-	// 1 = (+0ﾰ,+180ﾰ) - PowerDVD compatibility
-	// 2 = (+180ﾰ,+0ﾰ) - BeSweet compatibility
-	// 3 = (-90ﾰ,+90ﾰ) - This seems to work. I just don't know why.
-	void phase_mode(unsigned mode);
+    // set the phase shifting mode for decoding
+    // 0 = (+0°,+0°)   - music mode
+    // 1 = (+0°,+180°) - PowerDVD compatibility
+    // 2 = (+180°,+0°) - BeSweet compatibility
+    // 3 = (-90°,+90°) - This seems to work. I just don't know why.
+    void phase_mode(unsigned mode);
 
-	// override the steering mode
-	//  false = simple non-linear steering (old)
-	//  true  = advanced linear steering (new)
-	void steering_mode(bool mode);
+    // override the steering mode
+    //  false = simple non-linear steering (old)
+    //  true  = advanced linear steering (new)
+    void steering_mode(bool mode);
 
-	// set front/rear stereo separation
-	//  1.0 is default, 0.0 is mono
-	void separation(float front,float rear);
+    // set front/rear stereo separation
+    //  1.0 is default, 0.0 is mono
+    void separation(float front,float rear);
 
     // set samplerate for lfe filter
     void sample_rate(unsigned int samplerate);
 
 private:
-	class decoder_impl *m_impl; // private implementation (details hidden)
+    class decoder_impl *m_impl; // private implementation (details hidden)
 };
 
 


### PR DESCRIPTION
This was originally part of https://github.com/MythTV/mythtv/pull/416 .  However, it stands on its own, so I have split it off.

This is motivated by https://github.com/MythTV/mythtv/issues/428 enable use of system FFmpeg.

Note: for testing most of the changes, `./configure --disable-fftw3`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

