### PR TITLE
replace configure's ARCH... with Q_PROCESSOR_...

### DIFF
--- a/mythplugins/settings.pro
+++ b/mythplugins/settings.pro
@@ -41,11 +41,6 @@ QMAKE_CXXFLAGS += $$CXXFLAGS $$ECXXFLAGS
 profile:!win32:!macx:CONFIG += debug
 
 QMAKE_CXXFLAGS_RELEASE = $$OPTFLAGS -fomit-frame-pointer
-release:contains( TARGET_ARCH_POWERPC, yes ) {
-    QMAKE_CXXFLAGS_RELEASE = $$OPTFLAGS
-    # Auto-inlining causes some Qt moc methods to go missing
-    macx:QMAKE_CXXFLAGS_RELEASE += -fno-inline-functions
-}
 QMAKE_CXXFLAGS_RELEASE += $$PROFILEFLAGS
 
 QMAKE_CFLAGS += $$ARCHFLAGS

--- a/mythtv/libs/libmyth/audio/audioconvert.cpp
+++ b/mythtv/libs/libmyth/audio/audioconvert.cpp
@@ -46,6 +46,9 @@ extern "C" {
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+#ifdef Q_PROCESSOR_X86_64
+    return true;
+#endif
     static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;

--- a/mythtv/libs/libmyth/audio/audioconvert.cpp
+++ b/mythtv/libs/libmyth/audio/audioconvert.cpp
@@ -44,7 +44,7 @@ extern "C" {
 
 #ifdef Q_PROCESSOR_X86
 // Check cpuid for SSE2 support on x86 / x86_64
-static inline bool sse_check()
+static inline bool sse2_check()
 {
 #ifdef Q_PROCESSOR_X86_64
     return true;
@@ -99,7 +99,7 @@ static int toFloat8(float* out, const uchar* in, int len)
     float f = 1.0F / ((1<<7));
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -174,7 +174,7 @@ static int fromFloat8(uchar* out, const float* in, int len)
     float f = (1<<7);
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -226,7 +226,7 @@ static int toFloat16(float* out, const short* in, int len)
     float f = 1.0F / ((1<<15));
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -288,7 +288,7 @@ static int fromFloat16(short* out, const float* in, int len)
     float f = (1<<15);
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -340,7 +340,7 @@ static int toFloat32(AudioFormat format, float* out, const int* in, int len)
         shift = 0;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -397,7 +397,7 @@ static int fromFloat32(AudioFormat format, int* out, const float* in, int len)
         shift = 0;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         float o = 0.99999995;
         float mo = -1;
@@ -479,7 +479,7 @@ static int fromFloatFLT(float* out, const float* in, int len)
     int i = 0;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         float o = 1;

--- a/mythtv/libs/libmyth/audio/audioconvert.cpp
+++ b/mythtv/libs/libmyth/audio/audioconvert.cpp
@@ -43,11 +43,10 @@ extern "C" {
 #define ISALIGN(x) (((unsigned long)(x) & 0xf) == 0)
 
 #ifdef Q_PROCESSOR_X86
-static int has_sse2 = -1;
-
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+    static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;
     __asm__(

--- a/mythtv/libs/libmyth/audio/audiooutputbase.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputbase.cpp
@@ -8,6 +8,7 @@
 #include <sys/time.h>
 
 // Qt headers
+#include <QtGlobal>
 #include <QMutexLocker>
 
 // MythTV headers
@@ -318,7 +319,7 @@ void AudioOutputBase::SetStretchFactorLocked(float lstretchfactor)
         m_pSoundStretch->setSampleRate(m_sampleRate);
         m_pSoundStretch->setChannels(channels);
         m_pSoundStretch->setTempo(m_stretchFactor);
-#if ARCH_ARM || defined(Q_OS_ANDROID)
+#if defined(Q_PROCESSOR_ARM) || defined(Q_OS_ANDROID)
         // use less demanding settings for Raspberry pi
         m_pSoundStretch->setSetting(SETTING_SEQUENCE_MS, 82);
         m_pSoundStretch->setSetting(SETTING_USE_AA_FILTER, 0);

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -4,9 +4,9 @@
 #include <cmath>
 #include <sys/types.h>
 
+#include <QtGlobal>
 #include <QtEndian>
 
-#include "mythconfig.h"
 #include "mythlogging.h"
 #include "audioconvert.h"
 #include "mythaverror.h"
@@ -20,7 +20,7 @@ extern "C" {
 
 #define ISALIGN(x) (((unsigned long)(x) & 0xf) == 0)
 
-#if ARCH_X86
+#ifdef Q_PROCESSOR_X86
 static int has_sse2 = -1;
 
 // Check cpuid for SSE2 support on x86 / x86_64
@@ -30,7 +30,7 @@ static inline bool sse_check()
         return (bool)has_sse2;
     __asm__(
         // -fPIC - we may not clobber ebx/rbx
-#if ARCH_X86_64
+#ifdef Q_PROCESSOR_X86_64
         "push       %%rbx               \n\t"
 #else
         "push       %%ebx               \n\t"
@@ -39,7 +39,7 @@ static inline bool sse_check()
         "cpuid                          \n\t"
         "and        $0x4000000, %%edx   \n\t"
         "shr        $26, %%edx          \n\t"
-#if ARCH_X86_64
+#ifdef Q_PROCESSOR_X86_64
         "pop        %%rbx               \n\t"
 #else
         "pop        %%ebx               \n\t"
@@ -49,7 +49,7 @@ static inline bool sse_check()
     );
     return (bool)has_sse2;
 }
-#endif //ARCH_x86
+#endif //Q_PROCESSOR_X86
 
 /**
  * Returns true if platform has an FPU.
@@ -57,7 +57,7 @@ static inline bool sse_check()
  */
 bool AudioOutputUtil::has_hardware_fpu()
 {
-#if ARCH_X86
+#ifdef Q_PROCESSOR_X86
     return sse_check();
 #else
     return false;
@@ -122,7 +122,7 @@ void AudioOutputUtil::AdjustVolume(void *buf, int len, int volume,
     if (g == 1.0F)
         return;
 
-#if ARCH_X86
+#ifdef Q_PROCESSOR_X86
     if (sse_check() && samples >= 16)
     {
         int loops = samples >> 4;
@@ -153,7 +153,7 @@ void AudioOutputUtil::AdjustVolume(void *buf, int len, int volume,
             :"xmm0","xmm1","xmm2","xmm3","xmm4"
         );
     }
-#endif //ARCH_X86
+#endif //Q_PROCESSOR_X86
     for (; i < samples; i++)
         *fptr++ *= g;
 }

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -54,10 +54,10 @@ static inline bool sse2_check()
 #endif //Q_PROCESSOR_X86
 
 /**
- * Returns true if platform has an FPU.
- * for the time being, this test is limited to testing if SSE2 is supported
+ * Returns true if the processor supports MythTV's optimized SIMD for AudioOutputUtil/AudioConvert.
+ * Currently, only SSE2 is implemented.
  */
-bool AudioOutputUtil::has_hardware_fpu()
+bool AudioOutputUtil::has_optimized_SIMD()
 {
 #ifdef Q_PROCESSOR_X86
     return sse2_check();

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -22,7 +22,7 @@ extern "C" {
 
 #ifdef Q_PROCESSOR_X86
 // Check cpuid for SSE2 support on x86 / x86_64
-static inline bool sse_check()
+static inline bool sse2_check()
 {
 #ifdef Q_PROCESSOR_X86_64
     return true;
@@ -60,7 +60,7 @@ static inline bool sse_check()
 bool AudioOutputUtil::has_hardware_fpu()
 {
 #ifdef Q_PROCESSOR_X86
-    return sse_check();
+    return sse2_check();
 #else
     return false;
 #endif
@@ -125,7 +125,7 @@ void AudioOutputUtil::AdjustVolume(void *buf, int len, int volume,
         return;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && samples >= 16)
+    if (sse2_check() && samples >= 16)
     {
         int loops = samples >> 4;
         i = loops << 4;

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -21,11 +21,10 @@ extern "C" {
 #define ISALIGN(x) (((unsigned long)(x) & 0xf) == 0)
 
 #ifdef Q_PROCESSOR_X86
-static int has_sse2 = -1;
-
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+    static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;
     __asm__(

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -24,6 +24,9 @@ extern "C" {
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+#ifdef Q_PROCESSOR_X86_64
+    return true;
+#endif
     static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;

--- a/mythtv/libs/libmyth/audio/audiooutpututil.h
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.h
@@ -12,7 +12,7 @@
 class MPUBLIC AudioOutputUtil
 {
  public:
-    static bool has_hardware_fpu();
+    static bool has_optimized_SIMD();
     static void AdjustVolume(void *buffer, int len, int volume,
                              bool music, bool upmix);
     static void MuteChannel(int obits, int channels, int ch,

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -5240,8 +5240,8 @@ void AvFormatDecoder::ForceSetupAudioStream(void)
 inline bool AvFormatDecoder::DecoderWillDownmix(const AVCodecContext *ctx)
 {
     // Until ffmpeg properly implements dialnorm
-    // use Myth internal downmixer if machines has FPU/SSE
-    if (m_audio->CanDownmix() && AudioOutputUtil::has_hardware_fpu())
+    // use Myth internal downmixer if machine has SSE2
+    if (m_audio->CanDownmix() && AudioOutputUtil::has_optimized_SIMD())
         return false;
     if (!m_audio->CanDownmix())
         return true;

--- a/mythtv/libs/libmythtv/mythavutil.cpp
+++ b/mythtv/libs/libmythtv/mythavutil.cpp
@@ -7,6 +7,7 @@
 //
 
 // Qt
+#include <QtGlobal>
 #include <QMutexLocker>
 #include <QFile>
 
@@ -201,7 +202,11 @@ int MythAVCopy::Copy(AVFrame* To, AVPixelFormat ToFmt, const AVFrame* From, AVPi
                      int Width, int Height)
 {
     int newwidth = Width;
-#if ARCH_ARM
+#ifdef Q_PROCESSOR_ARM
+    // references https://code.mythtv.org/trac/ticket/12888 and
+    // https://trac.ffmpeg.org/ticket/6192
+    // TODO: This is from 2017-02-17 and probably needs to be tested again.
+
     // The ARM build of FFMPEG has a bug that if sws_scale is
     // called with source and dest sizes the same, and
     // formats as shown below, it causes a bus error and the

--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -10,22 +10,17 @@
 extern "C" {
 #include "libavfilter/buffersrc.h"
 #include "libavfilter/buffersink.h"
+#include "libavutil/cpu.h"
 }
 
 #include <QtGlobal>
 
 #ifdef Q_PROCESSOR_X86_64
-#   include "libavutil/x86/cpu.h"
 #   include <emmintrin.h>
 static const bool s_haveSIMD = true;
 #elif HAVE_INTRINSICS_NEON
-#   if defined(__aarch64__) || defined(_M_ARM64) || defined(Q_PROCESSOR_ARM_64)
-#       include "libavutil/aarch64/cpu.h"
-#   elif defined(Q_PROCESSOR_ARM)
-#       include "libavutil/arm/cpu.h"
-#   endif
 #   include <arm_neon.h>
-static const bool s_haveSIMD = have_neon(av_get_cpu_flags());
+static const bool s_haveSIMD = av_get_cpu_flags() & AV_CPU_FLAG_NEON;
 #endif
 
 #define LOC QString("MythDeint: ")

--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -5,6 +5,8 @@
 #include "mythvideoprofile.h"
 #include "mythdeinterlacer.h"
 
+#include <algorithm>
+
 extern "C" {
 #include "libavfilter/buffersrc.h"
 #include "libavfilter/buffersink.h"
@@ -344,9 +346,7 @@ bool MythDeinterlacer::Initialise(MythVideoFrame *Frame, MythDeintType Deinterla
     uint threads = 1;
     if (Profile)
     {
-        threads = Profile->GetMaxCPUs();
-        if (threads < 1 || threads > 8)
-            threads = 1;
+        threads = std::clamp(Profile->GetMaxCPUs(), 1U, 8U);
     }
 
     AVFilterInOut* inputs = nullptr;

--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -1,5 +1,4 @@
 // MythTV
-#include "config.h"
 #include "mythlogging.h"
 #include "mythavutil.h"
 #include "mythvideoprofile.h"
@@ -14,6 +13,12 @@ extern "C" {
 }
 
 #include <QtGlobal>
+
+#if defined(Q_PROCESSOR_ARM) && __has_include(<arm_neon.h>)
+#define HAVE_INTRINSICS_NEON 1
+#else
+#define HAVE_INTRINSICS_NEON 0
+#endif
 
 #ifdef Q_PROCESSOR_X86_64
 #   include <emmintrin.h>

--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -15,7 +15,7 @@ extern "C" {
 #if ARCH_X86_64
 #   include "libavutil/x86/cpu.h"
 #   include <emmintrin.h>
-bool MythDeinterlacer::s_haveSIMD = true;
+static const bool s_haveSIMD = true;
 #elif HAVE_INTRINSICS_NEON
 #   if ARCH_AARCH64
 #       include "libavutil/aarch64/cpu.h"
@@ -23,9 +23,7 @@ bool MythDeinterlacer::s_haveSIMD = true;
 #       include "libavutil/arm/cpu.h"
 #   endif
 #   include <arm_neon.h>
-bool MythDeinterlacer::s_haveSIMD = have_neon(av_get_cpu_flags());
-#else
-bool MythDeinterlacer::s_haveSIMD = false;
+static const bool s_haveSIMD = have_neon(av_get_cpu_flags());
 #endif
 
 #define LOC QString("MythDeint: ")

--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -11,16 +11,16 @@ extern "C" {
 }
 
 #if (HAVE_SSE2 && ARCH_X86_64)
-#include "libavutil/x86/cpu.h"
-#include <emmintrin.h>
+#   include "libavutil/x86/cpu.h"
+#   include <emmintrin.h>
 bool MythDeinterlacer::s_haveSIMD = av_get_cpu_flags() & AV_CPU_FLAG_SSE2;
 #elif HAVE_INTRINSICS_NEON
-#if ARCH_AARCH64
-#include "libavutil/aarch64/cpu.h"
-#elif ARCH_ARM
-#include "libavutil/arm/cpu.h"
-#endif
-#include <arm_neon.h>
+#   if ARCH_AARCH64
+#       include "libavutil/aarch64/cpu.h"
+#   elif ARCH_ARM
+#       include "libavutil/arm/cpu.h"
+#   endif
+#   include <arm_neon.h>
 bool MythDeinterlacer::s_haveSIMD = have_neon(av_get_cpu_flags());
 #else
 bool MythDeinterlacer::s_haveSIMD = false;

--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -12,14 +12,16 @@ extern "C" {
 #include "libavfilter/buffersink.h"
 }
 
-#if ARCH_X86_64
+#include <QtGlobal>
+
+#ifdef Q_PROCESSOR_X86_64
 #   include "libavutil/x86/cpu.h"
 #   include <emmintrin.h>
 static const bool s_haveSIMD = true;
 #elif HAVE_INTRINSICS_NEON
-#   if ARCH_AARCH64
+#   if defined(__aarch64__) || defined(_M_ARM64) || defined(Q_PROCESSOR_ARM_64)
 #       include "libavutil/aarch64/cpu.h"
-#   elif ARCH_ARM
+#   elif defined(Q_PROCESSOR_ARM)
 #       include "libavutil/arm/cpu.h"
 #   endif
 #   include <arm_neon.h>
@@ -512,7 +514,7 @@ static inline void BlendC4x4(unsigned char *Src, int Width, int FirstRow, int La
     }
 }
 
-#if ARCH_X86_64 || HAVE_INTRINSICS_NEON
+#if defined(Q_PROCESSOR_X86_64) || HAVE_INTRINSICS_NEON
 // SIMD optimised version with 16x4 alignment
 static inline void BlendSIMD16x4(unsigned char *Src, int Width, int FirstRow, int LastRow, int Pitch,
                                  unsigned char *Dst, int DstPitch, bool Second)
@@ -545,7 +547,7 @@ static inline void BlendSIMD16x4(unsigned char *Src, int Width, int FirstRow, in
         }
         for (int col = 0; col < Width; col += 16)
         {
-#if ARCH_X86_64
+#if defined(Q_PROCESSOR_X86_64)
             __m128i mid = *reinterpret_cast<__m128i*>(&middle[col]);
             *reinterpret_cast<__m128i*>(&dest1[col]) =
                     _mm_avg_epu8(*reinterpret_cast<__m128i*>(&above[col]), mid);
@@ -600,7 +602,7 @@ static inline void BlendSIMD8x4(unsigned char *Src, int Width, int FirstRow, int
         }
         for (int col = 0; col < Width; col += 16)
         {
-#if ARCH_X86_64
+#if defined(Q_PROCESSOR_X86_64)
             __m128i mid = *reinterpret_cast<__m128i*>(&middle[col]);
             *reinterpret_cast<__m128i*>(&dest1[col]) =
                     _mm_avg_epu16(*reinterpret_cast<__m128i*>(&above[col]), mid);
@@ -655,7 +657,7 @@ void MythDeinterlacer::Blend(MythVideoFrame *Frame, FrameScanType Scan)
         bool width4  = (src->m_pitches[plane] % 4) == 0;
         // N.B. all frames allocated by MythTV should have 16 byte alignment
         // for all planes
-#if ARCH_X86_64 || HAVE_INTRINSICS_NEON
+#if defined(Q_PROCESSOR_X86_64) || HAVE_INTRINSICS_NEON
         bool width16 = (src->m_pitches[plane] % 16) == 0;
         // profiling SSE2 suggests it is usually 4x faster - as expected
         if (s_haveSIMD && height4 && width16)

--- a/mythtv/libs/libmythtv/mythdeinterlacer.h
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.h
@@ -47,7 +47,6 @@ class MythDeinterlacer
     uint64_t         m_discontinuityCounter { 0 };
     bool             m_autoFieldOrder  { false };
     uint64_t         m_lastFieldChange { 0 };
-    static bool      s_haveSIMD;
 };
 
 #endif

--- a/mythtv/libs/libmythtv/visualisations/goom/zoom_filter_xmmx.cpp
+++ b/mythtv/libs/libmythtv/visualisations/goom/zoom_filter_xmmx.cpp
@@ -1,8 +1,6 @@
-#include "mythconfig.h"
-
 #include "goom/zoom_filters.h"
 
-#if defined(MMX) && !defined(ARCH_X86_64)
+#if 0 && defined(MMX) && !(defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64))
 /* a definir pour avoir exactement le meme resultat que la fonction C
  * (un chouillat plus lent)
  */

--- a/mythtv/settings.pro
+++ b/mythtv/settings.pro
@@ -283,11 +283,6 @@ macx {
 
 profile:!win32:!macx:CONFIG += debug
 
-release:contains( ARCH_POWERPC, yes ) {
-    # Auto-inlining causes some Qt moc methods to go missing
-    macx:QMAKE_CXXFLAGS_RELEASE += -fno-inline-functions
-}
-
 # figure out defines
 DEFINES += $$CONFIG_DEFINES
 DEFINES += _GNU_SOURCE


### PR DESCRIPTION
This redoes part of https://github.com/MythTV/mythtv/pull/443 , so I will rebase that on top of this.

In mythdeinterlacer.cpp: x86_64 assumes <emmintrin.h> exists; however, I'm not sure if it would also be acceptable
to assume <arm_neon.h> exists when compiling for ARM, i.e. replace `HAVE_INTRINSICS_NEON` with `defined(Q_PROCESSOR_ARM)`.

It needs further investigation, but AudioOutputUtil::has_hardware_fpu()/has_optimized_SIMD() may no longer be necessary.  It is from https://github.com/MythTV/mythtv/commit/c0fc09267318eb8400e7d809c6ab698c5c325507 which reverts https://github.com/MythTV/mythtv/commit/2d67f9f5a384fab8aced0e3ed9f82065864f758d in 2010 (and references https://code.mythtv.org/trac/ticket/6569 ).

FFmpeg appears to have implemented [dialnorm](https://en.wikipedia.org/wiki/Dialnorm) in 2014 for [AC3](https://github.com/FFmpeg/FFmpeg/commit/12df9b9a151026c4b382df8852fad38165b49f95) and in 2016 for [EAC3](https://github.com/FFmpeg/FFmpeg/commit/96cd6f672e5d8c5d49b06de4f24376f36880fea8).
