### PR TITLE
goom: re-enable zoom_filter_xmmx.cpp for x86_32

### DIFF
--- a/mythtv/libs/libmythtv/visualisations/goom/zoom_filter_xmmx.cpp
+++ b/mythtv/libs/libmythtv/visualisations/goom/zoom_filter_xmmx.cpp
@@ -1,8 +1,6 @@
-#include "mythconfig.h"
-
 #include "goom/zoom_filters.h"
 
-#if defined(MMX) && !defined(ARCH_X86_64)
+#if defined(MMX) && !(defined(__x86_64) || defined(__x86_64__) || defined(__amd64) || defined(_M_X64))
 /* a definir pour avoir exactement le meme resultat que la fonction C
  * (un chouillat plus lent)
  */


### PR DESCRIPTION
and remove use of ARCH_...

MMX is a CONFIG_DEFINES in configure
https://github.com/MythTV/mythtv/blob/8cbe83862ccf2c467758e87c7d9d100176daf7c6/mythtv/configure#L7899-L7904

mythconfig.h always has ARCH_... defined.

Modified from commit in https://github.com/MythTV/mythtv/pull/470