### PR TITLE
settings.pro: remove 17 year old stale ARCH conditions

### DIFF
--- a/mythplugins/settings.pro
+++ b/mythplugins/settings.pro
@@ -41,11 +41,6 @@ QMAKE_CXXFLAGS += $$CXXFLAGS $$ECXXFLAGS
 profile:!win32:!macx:CONFIG += debug
 
 QMAKE_CXXFLAGS_RELEASE = $$OPTFLAGS -fomit-frame-pointer
-release:contains( TARGET_ARCH_POWERPC, yes ) {
-    QMAKE_CXXFLAGS_RELEASE = $$OPTFLAGS
-    # Auto-inlining causes some Qt moc methods to go missing
-    macx:QMAKE_CXXFLAGS_RELEASE += -fno-inline-functions
-}
 QMAKE_CXXFLAGS_RELEASE += $$PROFILEFLAGS
 
 QMAKE_CFLAGS += $$ARCHFLAGS

--- a/mythtv/settings.pro
+++ b/mythtv/settings.pro
@@ -283,11 +283,6 @@ macx {
 
 profile:!win32:!macx:CONFIG += debug
 
-release:contains( ARCH_POWERPC, yes ) {
-    # Auto-inlining causes some Qt moc methods to go missing
-    macx:QMAKE_CXXFLAGS_RELEASE += -fno-inline-functions
-}
-
 # figure out defines
 DEFINES += $$CONFIG_DEFINES
 DEFINES += _GNU_SOURCE


### PR DESCRIPTION
ARCH_POWERPC is not set anymore, neither is any TARGET_ARCH_...

This should have no functional change.  Also, the purported reason is probably
no longer valid.

ARCH_POWERPC is now ARCH_PPC(64).