### PR TITLE
Rename/minor changes to audio functions using SSE2

### DIFF
--- a/mythtv/libs/libmyth/audio/audioconvert.cpp
+++ b/mythtv/libs/libmyth/audio/audioconvert.cpp
@@ -46,6 +46,9 @@ extern "C" {
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+#ifdef Q_PROCESSOR_X86_64
+    return true;
+#endif
     static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;

--- a/mythtv/libs/libmyth/audio/audioconvert.cpp
+++ b/mythtv/libs/libmyth/audio/audioconvert.cpp
@@ -44,7 +44,7 @@ extern "C" {
 
 #ifdef Q_PROCESSOR_X86
 // Check cpuid for SSE2 support on x86 / x86_64
-static inline bool sse_check()
+static inline bool sse2_check()
 {
 #ifdef Q_PROCESSOR_X86_64
     return true;
@@ -99,7 +99,7 @@ static int toFloat8(float* out, const uchar* in, int len)
     float f = 1.0F / ((1<<7));
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -174,7 +174,7 @@ static int fromFloat8(uchar* out, const float* in, int len)
     float f = (1<<7);
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -226,7 +226,7 @@ static int toFloat16(float* out, const short* in, int len)
     float f = 1.0F / ((1<<15));
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -288,7 +288,7 @@ static int fromFloat16(short* out, const float* in, int len)
     float f = (1<<15);
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -340,7 +340,7 @@ static int toFloat32(AudioFormat format, float* out, const int* in, int len)
         shift = 0;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         i = loops << 4;
@@ -397,7 +397,7 @@ static int fromFloat32(AudioFormat format, int* out, const float* in, int len)
         shift = 0;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         float o = 0.99999995;
         float mo = -1;
@@ -479,7 +479,7 @@ static int fromFloatFLT(float* out, const float* in, int len)
     int i = 0;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && len >= 16)
+    if (sse2_check() && len >= 16)
     {
         int loops = len >> 4;
         float o = 1;

--- a/mythtv/libs/libmyth/audio/audioconvert.cpp
+++ b/mythtv/libs/libmyth/audio/audioconvert.cpp
@@ -43,11 +43,10 @@ extern "C" {
 #define ISALIGN(x) (((unsigned long)(x) & 0xf) == 0)
 
 #ifdef Q_PROCESSOR_X86
-static int has_sse2 = -1;
-
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+    static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;
     __asm__(

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -54,10 +54,10 @@ static inline bool sse2_check()
 #endif //Q_PROCESSOR_X86
 
 /**
- * Returns true if platform has an FPU.
- * for the time being, this test is limited to testing if SSE2 is supported
+ * Returns true if the processor supports MythTV's optimized SIMD for AudioOutputUtil/AudioConvert.
+ * Currently, only SSE2 is implemented.
  */
-bool AudioOutputUtil::has_hardware_fpu()
+bool AudioOutputUtil::has_optimized_SIMD()
 {
 #ifdef Q_PROCESSOR_X86
     return sse2_check();

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -22,7 +22,7 @@ extern "C" {
 
 #ifdef Q_PROCESSOR_X86
 // Check cpuid for SSE2 support on x86 / x86_64
-static inline bool sse_check()
+static inline bool sse2_check()
 {
 #ifdef Q_PROCESSOR_X86_64
     return true;
@@ -60,7 +60,7 @@ static inline bool sse_check()
 bool AudioOutputUtil::has_hardware_fpu()
 {
 #ifdef Q_PROCESSOR_X86
-    return sse_check();
+    return sse2_check();
 #else
     return false;
 #endif
@@ -125,7 +125,7 @@ void AudioOutputUtil::AdjustVolume(void *buf, int len, int volume,
         return;
 
 #ifdef Q_PROCESSOR_X86
-    if (sse_check() && samples >= 16)
+    if (sse2_check() && samples >= 16)
     {
         int loops = samples >> 4;
         i = loops << 4;

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -21,11 +21,10 @@ extern "C" {
 #define ISALIGN(x) (((unsigned long)(x) & 0xf) == 0)
 
 #ifdef Q_PROCESSOR_X86
-static int has_sse2 = -1;
-
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+    static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;
     __asm__(

--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -24,6 +24,9 @@ extern "C" {
 // Check cpuid for SSE2 support on x86 / x86_64
 static inline bool sse_check()
 {
+#ifdef Q_PROCESSOR_X86_64
+    return true;
+#endif
     static int has_sse2 = -1;
     if (has_sse2 != -1)
         return (bool)has_sse2;

--- a/mythtv/libs/libmyth/audio/audiooutpututil.h
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.h
@@ -12,7 +12,7 @@
 class MPUBLIC AudioOutputUtil
 {
  public:
-    static bool has_hardware_fpu();
+    static bool has_optimized_SIMD();
     static void AdjustVolume(void *buffer, int len, int volume,
                              bool music, bool upmix);
     static void MuteChannel(int obits, int channels, int ch,

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -5240,8 +5240,8 @@ void AvFormatDecoder::ForceSetupAudioStream(void)
 inline bool AvFormatDecoder::DecoderWillDownmix(const AVCodecContext *ctx)
 {
     // Until ffmpeg properly implements dialnorm
-    // use Myth internal downmixer if machines has FPU/SSE
-    if (m_audio->CanDownmix() && AudioOutputUtil::has_hardware_fpu())
+    // use Myth internal downmixer if machine has SSE2
+    if (m_audio->CanDownmix() && AudioOutputUtil::has_optimized_SIMD())
         return false;
     if (!m_audio->CanDownmix())
         return true;


### PR DESCRIPTION
Was in https://github.com/MythTV/mythtv/pull/470

x86_64 requires SSE2, so just return true for the SSE2 check in that case.

The new function names better represent what they do.


