### PR TITLE
Deinterlacer: Clamp threads

### DIFF
--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -6,6 +6,7 @@
 #include "mythdeinterlacer.h"
 
 #include <algorithm>
+#include <thread>
 
 extern "C" {
 #include "libavfilter/buffersrc.h"
@@ -346,7 +347,7 @@ bool MythDeinterlacer::Initialise(MythVideoFrame *Frame, MythDeintType Deinterla
     uint threads = 1;
     if (Profile)
     {
-        threads = std::clamp(Profile->GetMaxCPUs(), 1U, 8U);
+        threads = std::clamp(Profile->GetMaxCPUs(), 1U, std::max(8U, std::thread::hardware_concurrency()));
     }
 
     AVFilterInOut* inputs = nullptr;

--- a/mythtv/libs/libmythtv/mythdeinterlacer.cpp
+++ b/mythtv/libs/libmythtv/mythdeinterlacer.cpp
@@ -5,6 +5,8 @@
 #include "mythvideoprofile.h"
 #include "mythdeinterlacer.h"
 
+#include <algorithm>
+
 extern "C" {
 #include "libavfilter/buffersrc.h"
 #include "libavfilter/buffersink.h"
@@ -344,9 +346,7 @@ bool MythDeinterlacer::Initialise(MythVideoFrame *Frame, MythDeintType Deinterla
     uint threads = 1;
     if (Profile)
     {
-        threads = Profile->GetMaxCPUs();
-        if (threads < 1 || threads > 8)
-            threads = 1;
+        threads = std::clamp(Profile->GetMaxCPUs(), 1U, 8U);
     }
 
     AVFilterInOut* inputs = nullptr;


### PR DESCRIPTION
Was part of https://github.com/MythTV/mythtv/pull/470

I also added [std::thread::hardware_concurrency()](https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency) as a hint for the maximum number of threads.
