### PR TITLE
fixup QtEndian template use (s390x)

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -212,9 +212,9 @@ char *AudioOutputUtil::GeneratePinkFrames(char *frames, int channels,
                     static_cast<float>(0x03fffffff);
                 int32_t ires = res;
                 if (bits == 16)
-                    *samp16++ = qToLittleEndian<int16_t>(ires >> 16);
+                    *samp16++ = qToLittleEndian<qint16>(ires >> 16);
                 else
-                    *samp32++ = qToLittleEndian<int32_t>(ires);
+                    *samp32++ = qToLittleEndian<qint32>(ires);
             }
             else
             {

--- a/mythtv/libs/libmyth/audio/eldutils.cpp
+++ b/mythtv/libs/libmyth/audio/eldutils.cpp
@@ -257,11 +257,11 @@ int eld::update_eld(const char *buf, int size)
     m_e.aud_synch_delay = GRAB_BITS(buf, 6, 0, 8) * 2;
     m_e.spk_alloc       = GRAB_BITS(buf, 7, 0, 7);
 
-    m_e.port_id         = qFromLittleEndian<uint64_t>(buf + 8);
+    m_e.port_id         = qFromLittleEndian<quint64>(buf + 8);
 
     /* not specified, but the spec's tendency is little endian */
-    m_e.manufacture_id  = qFromLittleEndian<uint16_t>(buf + 16);
-    m_e.product_id      = qFromLittleEndian<uint16_t>(buf + 18);
+    m_e.manufacture_id  = qFromLittleEndian<quint16>(buf + 16);
+    m_e.product_id      = qFromLittleEndian<quint16>(buf + 18);
 
     if (ELD_FIXED_BYTES + mnl > size)
     {

--- a/mythtv/libs/libmythtv/io/mythavformatwriter.cpp
+++ b/mythtv/libs/libmythtv/io/mythavformatwriter.cpp
@@ -270,7 +270,7 @@ int MythAVFormatWriter::WriteAudioFrame(unsigned char *Buffer, int /*FrameNumber
 #if (Q_BYTE_ORDER == Q_BIG_ENDIAN)
     auto buf16 = reinterpret_cast<uint16_t *>(Buffer);
     for (int i = 0; i < m_audioChannels * m_audioFrameSize; i++)
-        buf16[i] = qFromLittleEndian<uint16_t>(buf16[i]);
+        buf16[i] = qFromLittleEndian<quint16>(buf16[i]);
 #endif
 
     AVCodecContext *avctx   = m_codecMap.GetCodecContext(m_audioStream);

--- a/mythtv/libs/libmythtv/recorders/NuppelVideoRecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/NuppelVideoRecorder.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 
 #include <QStringList>
+#include <QtEndian>
 
 #include <iostream>
 
@@ -2558,7 +2559,7 @@ void NuppelVideoRecorder::WriteAudio(unsigned char *buf, int fnum, std::chrono::
 #if (Q_BYTE_ORDER == Q_BIG_ENDIAN)
         auto buf16 = reinterpret_cast<uint16_t *>(buf);
         for (int i = 0; i < m_audioChannels * sample_cnt; i++)
-            buf16[i] = qToLittleEndian<uint16_t>(buf16[i]);
+            buf16[i] = qToLittleEndian<quint16>(buf16[i]);
 #endif
         if (m_audioChannels == 2)
         {


### PR DESCRIPTION
The error was:
/usr/bin/ld: ../../libs/libmyth/libmyth-32.so: undefined reference to `unsigned long qbswap<unsigned long>(unsigned long)'

This must be from eldutils.cpp: uint64_t is unsigned long, but Qt must
be using quint64 = unsigned long long, which causes the link error.

To fix this, follow the Qt documentation and only use the allowed
types, i.e. quint16, qint16, quint32, qint32, quint64, or qint64.
