### PR TITLE
configure: echo ffopts

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -7298,18 +7298,12 @@ if test "$ID" = "raspbian"; then
     esac
 fi
 
-## Call FFmpeg configure here
-echo
-echo '#### FFmpeg CONFIGURATION ####'
-currentpwd="$PWD"
-cd external/FFmpeg
-eval ./configure \
-$ffopts \
---extra-cflags='"$ffmpeg_extra_cflags"' \
---extra-ldflags='"$ffmpeg_extra_ldflags"' \
---extra-libs='"$ffmpeg_extra_ldflags"' \
+append ffopts \
+--extra-cflags=\'"$ffmpeg_extra_cflags"\' \
+--extra-ldflags=\'"$ffmpeg_extra_ldflags"\' \
+--extra-libs=\'"$ffmpeg_extra_ldflags"\' \
 --enable-stripping \
---strip='"echo skipping strip"' \
+--strip=\'"echo skipping strip"\' \
 --disable-manpages  \
 --disable-podpages  \
 --disable-doc \
@@ -7320,6 +7314,14 @@ $ffopts \
 --enable-pic \
 --disable-demuxer=mpegtsraw \
 --disable-indev=dshow
+echo
+echo "ffopts = $ffopts"
+## Call FFmpeg configure here
+echo
+echo '#### FFmpeg CONFIGURATION ####'
+currentpwd="$PWD"
+cd external/FFmpeg
+eval ./configure $ffopts
 rc=$?
 if [ $rc != 0 ] ; then
     echo "ERROR FFmpeg configure failed"

--- a/mythtv/external/FFmpeg/configure
+++ b/mythtv/external/FFmpeg/configure
@@ -5264,6 +5264,7 @@ if test "$?" != 0; then
         echo "If $cc is a cross-compiler, use the --enable-cross-compile option."
         echo "Only do this if you know what cross compiling means."
     fi
+    cat $logfile
     die "C compiler test failed."
 fi
 


### PR DESCRIPTION
for debugging failing launchpad armhf build

The compile check succeeds in mythtv/configure but fails in FFmpeg/configure.  This should help identify the cause and is good info to print regardless.
