### PR TITLE
Remove reference to no longer existing mythffserver

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -1449,7 +1449,6 @@ LICENSE_LIST="
 
 PROGRAM_LIST="
     ffprobe
-    ffserver
     ffmpeg
     ffplay
 "
@@ -2609,8 +2608,6 @@ ffmpeg_select="aformat_filter anull_filter atrim_filter format_filter
                null_filter
                trim_filter"
 ffprobe_deps="avcodec avformat"
-ffserver_deps="avformat fork sarestart"
-ffserver_select="ffm_muxer rtp_protocol rtsp_demuxer"
 
 # mythtv dependencies
 audio_oss_deps_any="soundcard_h sys_soundcard_h"
@@ -4811,7 +4808,6 @@ case $target_os in
         enable  windows
         disable x11
         disable qtdbus
-        disable ffserver
         ###### Standard ffmpeg configure stuff follows:
         if test $target_os = "mingw32ce"; then
             disable network
@@ -4907,7 +4903,6 @@ case $target_os in
         enabled shared && ! enabled small && check_cmd $windres --version && enable gnu_windres
         ;;
     *-dos|freedos|opendos)
-        disable ffserver
         disable $INDEV_LIST $OUTDEV_LIST
         network_extralibs="-lsocket"
         objformat="coff"
@@ -7681,7 +7676,6 @@ CXXPPFLAGS=$CXXPPFLAGS
 ECXXFLAGS=$ECXXFLAGS
 DOXYGEN=$doxygen
 LDFLAGS=$LDFLAGS
-LDFLAGS-ffserver=$FFSERVERLDFLAGS
 LDEXEFLAGS=$LDEXEFLAGS
 LDLIBFLAGS=$LDLIBFLAGS
 ASMSTRIPFLAGS=$ASMSTRIPFLAGS

--- a/mythtv/external/.gitignore
+++ b/mythtv/external/.gitignore
@@ -16,5 +16,4 @@ ffplay_g
 mythffplay
 FFmpeg.old
 mythffprobe
-mythffserver
 nv-codec-headers/install

--- a/mythtv/external/FFmpeg/fftools/Makefile
+++ b/mythtv/external/FFmpeg/fftools/Makefile
@@ -43,9 +43,6 @@ mythffmpeg:
 mythffprobe:
 	cp ffprobe_g mythffprobe
 
-mythffserver:
-	cp ffserver_g mythffserver
-
 mythffplay:
 	cp ffplay_g mythffplay
 


### PR DESCRIPTION
`ffserver` got removed with [ffmpeg 4.0](https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/6b35a83214f1bc3fb38c9ea9c2cd3676f28709fa), so no more `mythffserver` also; remove remaining fragments.

##### Checklist
- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
  `cp -f` as used in `programs/scripts/Makefile` fails to create target directory.
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)