### PR TITLE
configure: fix --cpu=host for Intel Celeron and Pentium

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -3405,7 +3405,7 @@ if test "$cpu" = host; then
     esac
 
     if test "${cpu:-host}" != host ; then
-        cpuflags_native="-march=native"
+        cpuflags_native="-march=native -mtune=native"
     else
         enable proc_opt_old
         cpu="$arch"

--- a/mythtv/configure
+++ b/mythtv/configure
@@ -6382,6 +6382,7 @@ ffmpeg_optenableif() {
 }
 
 if [ -n "$cpuflags_native" ]; then
+    cpu_detected="$cpu"
     cpu="host"
 fi
 
@@ -6485,7 +6486,14 @@ echo "install prefix            $prefix"
 echo "runtime prefix            $runprefix"
 echo
 if enabled cpu_override && test x"$cpu" != x"generic"; then
-    echo "CPU override              $arch $subarch ($cpu)"
+    if [ -n "$cpuflags_native" ]; then
+        echo "CPU override              $arch $subarch (cpu=host (native) is $cpu_detected)"
+        if test x"$processor" != x"" ; then
+            echo "                          [$processor]"
+        fi
+    else
+        echo "CPU override              $arch $subarch ($cpu)"
+    fi
 elif test x"$processor" != x"" ; then
     echo "CPU                       $arch $subarch ($processor)"
 else

--- a/mythtv/configure
+++ b/mythtv/configure
@@ -3404,7 +3404,9 @@ if test "$cpu" = host; then
         ;;
     esac
 
-    if test "${cpu:-host}" = host ; then
+    if test "${cpu:-host}" != host ; then
+        cpuflags_native="-march=native"
+    else
         enable proc_opt_old
         cpu="$arch"
     fi
@@ -3947,6 +3949,9 @@ elif enabled x86; then
 
 fi
 
+if [ -n "$cpuflags_native" ]; then
+    cpuflags="$cpuflags_native"
+fi
 
 # if architecture specific flags don't work blank them
 if test -n "$cpuflags"; then
@@ -6375,6 +6380,10 @@ ffmpeg_optenableif() {
         shift
     done
 }
+
+if [ -n "$cpuflags_native" ]; then
+    cpu="host"
+fi
 
 ffopts=
 ffmpeg_optset arch cross_prefix sysroot sysinclude cc cxx ld cpu

--- a/mythtv/external/FFmpeg/configure
+++ b/mythtv/external/FFmpeg/configure
@@ -5241,7 +5241,7 @@ if test "$cpu" = host; then
     esac
 
     if test "${cpu:-host}" != host ; then
-        cpuflags_native="-march=native"
+        cpuflags_native="-march=native -mtune=native"
     fi
 
     test "${cpu:-host}" = host &&

--- a/mythtv/external/FFmpeg/configure
+++ b/mythtv/external/FFmpeg/configure
@@ -5240,6 +5240,10 @@ if test "$cpu" = host; then
         ;;
     esac
 
+    if test "${cpu:-host}" != host ; then
+        cpuflags_native="-march=native"
+    fi
+
     test "${cpu:-host}" = host &&
         die "--cpu=host not supported with compiler $cc"
 fi
@@ -5604,6 +5608,10 @@ else
         enable fast_64bit
     fi
 
+fi
+
+if [ -n "$cpuflags_native" ]; then
+    cpuflags="$cpuflags_native"
 fi
 
 if [ "$cpu" != generic ]; then


### PR DESCRIPTION
class processors.

This is necessary because they don't support AVX, but e.g. gcc's
-march=haswell enables AVX instructions; however, the Haswell
Pentium G3258 does not support AVX, which -march=native correctly
selects.

cpu cannot be set to native, since then the conditional checks,
for e.g. fast cmov, are not executed.

This should fix https://github.com/MythTV/mythtv/issues/505 in master and can be cherry-picked cleanly into fixes/31 and fixes/31.
