### PR TITLE
fix video hanging at EOF

### DIFF
--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -254,6 +254,8 @@ class AvFormatDecoder : public DecoderBase
 
     virtual int ReadPacket(AVFormatContext *ctx, AVPacket *pkt, bool &storePacket);
 
+    bool FlagIsSet(PlayerFlags arg) { return m_playerFlags & arg; }
+
     bool               m_isDbIgnored;
 
     AVCParser         *m_avcParser                    {nullptr};

--- a/mythtv/libs/libmythtv/mythplayer.cpp
+++ b/mythtv/libs/libmythtv/mythplayer.cpp
@@ -661,16 +661,13 @@ void MythPlayer::DiscardVideoFrames(bool KeyFrame, bool Flushed)
 
 bool MythPlayer::HasReachedEof(void) const
 {
-    EofState eof = GetEof();
-    if (eof != kEofStateNone && !m_allPaused)
-        return true;
     if (GetEditMode())
         return false;
     if (m_liveTV)
         return false;
     if (!m_deleteMap.IsEmpty() && m_framesPlayed >= m_deleteMap.GetLastFrame())
         return true;
-    return false;
+    return (GetEof() != kEofStateNone && !m_allPaused);
 }
 
 void MythPlayer::DeLimboFrame(MythVideoFrame *frame)

--- a/mythtv/libs/libmythtv/mythplayer.h
+++ b/mythtv/libs/libmythtv/mythplayer.h
@@ -77,8 +77,6 @@ enum PlayerFlags
     kMusicChoice          = 0x040000,
 };
 
-#define FlagIsSet(arg) (m_playerFlags & (arg))
-
 // Padding between class members reduced from 113 to 73 bytes, but its
 // still higher than the default warning threshhold of 24 bytes.
 //
@@ -318,6 +316,8 @@ class MTV_PUBLIC MythPlayer : public QObject
     // Edit mode stuff
     bool GetEditMode(void) const { return m_deleteMap.IsEditing(); }
     bool IsInDelete(uint64_t frame);
+
+    bool FlagIsSet(PlayerFlags arg) { return m_playerFlags & arg; }
 
   protected:
     // Private Sets

--- a/mythtv/libs/libmythtv/mythplayerui.cpp
+++ b/mythtv/libs/libmythtv/mythplayerui.cpp
@@ -226,7 +226,6 @@ void MythPlayerUI::EventLoop()
     }
 
     // Handle end of file
-    EofState eof = GetEof();
     if (HasReachedEof())
     {
 #ifdef USING_MHEG
@@ -257,7 +256,7 @@ void MythPlayerUI::EventLoop()
             // exit when all video frames are played
             drained = m_videoOutput && m_videoOutput->ValidVideoFrames() < 1;
         }
-        if (eof != kEofStateDelayed || (drained))
+        if (EofState eof = GetEof(); eof != kEofStateDelayed || (drained))
         {
             if (eof == kEofStateDelayed)
             {

--- a/mythtv/libs/libmythtv/mythplayerui.cpp
+++ b/mythtv/libs/libmythtv/mythplayerui.cpp
@@ -243,13 +243,21 @@ void MythPlayerUI::EventLoop()
             return;
         }
 
-        bool videoDrained =
-            m_videoOutput && m_videoOutput->ValidVideoFrames() < 1;
-        bool audioDrained =
-            !m_audio.GetAudioOutput() ||
-            m_audio.IsPaused() ||
-            m_audio.GetAudioOutput()->GetAudioBufferedTime() < 100ms;
-        if (eof != kEofStateDelayed || (videoDrained && audioDrained))
+        bool drained = false;
+        if (FlagIsSet(kVideoIsNull) || FlagIsSet(kMusicChoice))
+        {
+            // Audio only
+            drained =
+                !m_audio.GetAudioOutput() ||
+                m_audio.IsPaused() ||
+                m_audio.GetAudioOutput()->GetAudioBufferedTime() < 100ms;
+        }
+        else
+        {
+            // exit when all video frames are played
+            drained = m_videoOutput && m_videoOutput->ValidVideoFrames() < 1;
+        }
+        if (eof != kEofStateDelayed || (drained))
         {
             if (eof == kEofStateDelayed)
             {


### PR DESCRIPTION
@gigem Slightly more refined fix for https://github.com/MythTV/mythtv/issues/511 with a few other tangential fixes.

However, I'm not sure the audio only path is necessary (maybe only for Music Choice?) since MythTV synthesizes video frames.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

