### PR TITLE
Perl bindings: Fix videoproperties after schema change to 1362, add additional videoprop flags

### DIFF
--- a/mythtv/bindings/perl/MythTV/Program.pm
+++ b/mythtv/bindings/perl/MythTV/Program.pm
@@ -119,8 +119,19 @@ package MythTV::Program;
         $self->{'mono'}           = $self->{'audio_props'}   & 0x02;
         $self->{'surround'}       = $self->{'audio_props'}   & 0x04;
         $self->{'dolby'}          = $self->{'audio_props'}   & 0x08;
-        $self->{'hdtv'}           = $self->{'video_props'}   & 0x01;
-        $self->{'widescreen'}     = $self->{'video_props'}   & 0x02;
+
+        $self->{'widescreen'}     = $self->{'video_props'}   & 0x0001;
+        $self->{'hdtv'}           = $self->{'video_props'}   & 0x0002;
+        $self->{'mpeg2'}          = $self->{'video_props'}   & 0x0004;
+        $self->{'avc'}            = $self->{'video_props'}   & 0x0008;
+        $self->{'hevc'}           = $self->{'video_props'}   & 0x0010;
+        $self->{'720'}            = $self->{'video_props'}   & 0x0020;
+        $self->{'1080'}           = $self->{'video_props'}   & 0x0040;
+        $self->{'4k'}             = $self->{'video_props'}   & 0x0080;
+        $self->{'3dtv'}           = $self->{'video_props'}   & 0x0100;
+        $self->{'progressive'}    = $self->{'video_props'}   & 0x0200;
+        $self->{'damaged'}        = $self->{'video_props'}   & 0x0400;
+
         $self->{'closecaptioned'} = $self->{'subtitle_type'} & 0x01;
         $self->{'has_subtitles'}  = $self->{'subtitle_type'} & 0x02;
         $self->{'subtitled'}      = $self->{'subtitle_type'} & 0x04;


### PR DESCRIPTION
Fix videoproperties which were wrong after the schema change to 1362 in commit e79b8fc.
Add additional videoprop flags.


Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

