### PR TITLE
de-duplicate signal handler code

### DIFF
--- a/mythtv/libs/libmythbase/signalhandling.cpp
+++ b/mythtv/libs/libmythbase/signalhandling.cpp
@@ -17,6 +17,7 @@
 
 #include "compat.h"
 #include "mythlogging.h"
+#include "loggingserver.h"
 #include "exitcodes.h"
 #include "signalhandling.h"
 
@@ -77,6 +78,7 @@ SignalHandler::SignalHandler(QObject *parent) :
     {
         SetHandlerPrivate(signum, nullptr);
     }
+    SetHandlerPrivate(SIGHUP, logSigHup);
 #endif // _WIN32
 }
 

--- a/mythtv/libs/libmythbase/signalhandling.h
+++ b/mythtv/libs/libmythbase/signalhandling.h
@@ -28,7 +28,7 @@ class MBASE_PUBLIC SignalHandler: public QObject
     Q_OBJECT
 
   public:
-    static void Init(QList<int> &signallist, QObject *parent = nullptr);
+    static void Init(QObject *parent = nullptr);
     static void Done(void);
 
     static void SetHandler(int signum, SigHandlerFunc handler);
@@ -44,7 +44,7 @@ class MBASE_PUBLIC SignalHandler: public QObject
     void handleSignal(void);
 
   private:
-    SignalHandler(QList<int> &signallist, QObject *parent);
+    explicit SignalHandler(QObject *parent);
     ~SignalHandler() override;
     void SetHandlerPrivate(int signum, SigHandlerFunc handler);
 
@@ -55,7 +55,24 @@ class MBASE_PUBLIC SignalHandler: public QObject
 
     QMutex m_sigMapLock;
     QMap<int, SigHandlerFunc> m_sigMap;
-    static QList<int> s_defaultHandlerList;
+
+    const std::array<const int, 6
+#ifndef _WIN32
+        + 1
+#ifndef Q_OS_DARWIN
+        + 1
+#endif // Q_OS_DARWIN
+#endif // _WIN32
+    > k_defaultSignalList
+    {
+        SIGINT, SIGTERM, SIGSEGV, SIGABRT, SIGFPE, SIGILL,
+#ifndef _WIN32
+        SIGBUS,
+#ifndef Q_OS_DARWIN
+        SIGRTMIN, // not necessarily constexpr
+#endif // Q_OS_DARWIN
+#endif // _WIN32
+    };
 
     static QMutex s_singletonLock;
     static SignalHandler *s_singleton;

--- a/mythtv/programs/mythavtest/main.cpp
+++ b/mythtv/programs/mythavtest/main.cpp
@@ -251,7 +251,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    signal(SIGHUP, SIG_IGN);
 #endif
 
     if (cmdline.toBool("test"))

--- a/mythtv/programs/mythavtest/main.cpp
+++ b/mythtv/programs/mythavtest/main.cpp
@@ -250,13 +250,7 @@ int main(int argc, char *argv[])
     mainWindow->Init();
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     signal(SIGHUP, SIG_IGN);
 #endif
 

--- a/mythtv/programs/mythbackend/main.cpp
+++ b/mythtv/programs/mythbackend/main.cpp
@@ -120,13 +120,7 @@ int main(int argc, char **argv)
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythbackend/main.cpp
+++ b/mythtv/programs/mythbackend/main.cpp
@@ -33,7 +33,6 @@
 #include "mythmiscutil.h"
 #include "storagegroup.h"
 #include "mediaserver.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "mythversion.h"
 #include "programinfo.h"
@@ -121,7 +120,6 @@ int main(int argc, char **argv)
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
 #if CONFIG_SYSTEMD_NOTIFY

--- a/mythtv/programs/mythccextractor/main.cpp
+++ b/mythtv/programs/mythccextractor/main.cpp
@@ -19,7 +19,6 @@
 #include "io/mythmediabuffer.h"
 #include "exitcodes.h"
 #include "signalhandling.h"
-#include "loggingserver.h"
 #include "cleanupguard.h"
 
 namespace {
@@ -135,7 +134,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION);

--- a/mythtv/programs/mythccextractor/main.cpp
+++ b/mythtv/programs/mythccextractor/main.cpp
@@ -134,13 +134,7 @@ int main(int argc, char *argv[])
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythcommflag/main.cpp
+++ b/mythtv/programs/mythcommflag/main.cpp
@@ -43,7 +43,6 @@
 #include "io/mythmediabuffer.h"
 #include "commandlineparser.h"
 #include "mythtranslation.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "signalhandling.h"
 #include "cleanupguard.h"
@@ -1145,7 +1144,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION);

--- a/mythtv/programs/mythcommflag/main.cpp
+++ b/mythtv/programs/mythcommflag/main.cpp
@@ -1144,13 +1144,7 @@ int main(int argc, char *argv[])
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythfilldatabase/main.cpp
+++ b/mythtv/programs/mythfilldatabase/main.cpp
@@ -250,13 +250,7 @@ int main(int argc, char *argv[])
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythfilldatabase/main.cpp
+++ b/mythtv/programs/mythfilldatabase/main.cpp
@@ -27,7 +27,6 @@
 #include "videosource.h" // for is_grabber..
 #include "dbcheck.h"
 #include "mythsystemevent.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "signalhandling.h"
 #include "cleanupguard.h"
@@ -251,7 +250,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION);

--- a/mythtv/programs/mythfrontend/main.cpp
+++ b/mythtv/programs/mythfrontend/main.cpp
@@ -52,7 +52,6 @@
 #include "mythsystemevent.h"
 #include "hardwareprofile.h"
 #include "signalhandling.h"
-#include "loggingserver.h"
 
 #include "compat.h"  // For SIG* on MinGW
 #include "exitcodes.h"
@@ -1891,7 +1890,6 @@ int main(int argc, char **argv)
     SignalHandler::Init();
     SignalHandler::SetHandler(SIGUSR1, handleSIGUSR1);
     SignalHandler::SetHandler(SIGUSR2, handleSIGUSR2);
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     int retval = cmdline.ConfigureLogging();

--- a/mythtv/programs/mythfrontend/main.cpp
+++ b/mythtv/programs/mythfrontend/main.cpp
@@ -1888,13 +1888,7 @@ int main(int argc, char **argv)
 #endif
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGUSR1, handleSIGUSR1);
     SignalHandler::SetHandler(SIGUSR2, handleSIGUSR2);
     SignalHandler::SetHandler(SIGHUP, logSigHup);

--- a/mythtv/programs/mythjobqueue/main.cpp
+++ b/mythtv/programs/mythjobqueue/main.cpp
@@ -25,7 +25,6 @@
 #include "commandlineparser.h"
 #include "compat.h"
 #include "mythsystemevent.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "signalhandling.h"
 #include "housekeeper.h"
@@ -91,7 +90,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION);

--- a/mythtv/programs/mythjobqueue/main.cpp
+++ b/mythtv/programs/mythjobqueue/main.cpp
@@ -90,13 +90,7 @@ int main(int argc, char *argv[])
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythlcdserver/main.cpp
+++ b/mythtv/programs/mythlcdserver/main.cpp
@@ -17,7 +17,6 @@
 #include "exitcodes.h"
 #include "mythcontext.h"
 #include "mythdbcon.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "mythversion.h"
 #include "tv_play.h"
@@ -100,7 +99,6 @@ int main(int argc, char **argv)
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     //  Get the MythTV context and db hooks

--- a/mythtv/programs/mythlcdserver/main.cpp
+++ b/mythtv/programs/mythlcdserver/main.cpp
@@ -99,13 +99,7 @@ int main(int argc, char **argv)
     }
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythmediaserver/main.cpp
+++ b/mythtv/programs/mythmediaserver/main.cpp
@@ -94,13 +94,7 @@ int main(int argc, char *argv[])
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythmediaserver/main.cpp
+++ b/mythtv/programs/mythmediaserver/main.cpp
@@ -17,7 +17,6 @@
 #include "exitcodes.h"
 #include "dbcheck.h"
 #include "mythdbcon.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "mythversion.h"
 #include "mythsystemevent.h"
@@ -95,7 +94,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     ms_sd_notify("STATUS=Connecting to database.");

--- a/mythtv/programs/mythmetadatalookup/main.cpp
+++ b/mythtv/programs/mythmetadatalookup/main.cpp
@@ -23,7 +23,6 @@
 #include "mythtranslation.h"
 #include "mythconfig.h"
 #include "commandlineparser.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "signalhandling.h"
 #include "cleanupguard.h"
@@ -88,7 +87,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION);

--- a/mythtv/programs/mythmetadatalookup/main.cpp
+++ b/mythtv/programs/mythmetadatalookup/main.cpp
@@ -87,13 +87,7 @@ int main(int argc, char *argv[])
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythpreviewgen/main.cpp
+++ b/mythtv/programs/mythpreviewgen/main.cpp
@@ -35,7 +35,6 @@
 #include "previewgenerator.h"
 #include "commandlineparser.h"
 #include "mythsystemevent.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "signalhandling.h"
 #include "cleanupguard.h"
@@ -179,7 +178,6 @@ int main(int argc, char **argv)
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)

--- a/mythtv/programs/mythpreviewgen/main.cpp
+++ b/mythtv/programs/mythpreviewgen/main.cpp
@@ -178,13 +178,7 @@ int main(int argc, char **argv)
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythscreenwizard/main.cpp
+++ b/mythtv/programs/mythscreenwizard/main.cpp
@@ -127,13 +127,7 @@ int main(int argc, char **argv)
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     signal(SIGHUP, SIG_IGN);
 #endif
 

--- a/mythtv/programs/mythscreenwizard/main.cpp
+++ b/mythtv/programs/mythscreenwizard/main.cpp
@@ -128,7 +128,6 @@ int main(int argc, char **argv)
 
 #ifndef _WIN32
     SignalHandler::Init();
-    signal(SIGHUP, SIG_IGN);
 #endif
 
 

--- a/mythtv/programs/mythshutdown/main.cpp
+++ b/mythtv/programs/mythshutdown/main.cpp
@@ -18,7 +18,6 @@
 #include "remoteutil.h"
 #include "tvremoteutil.h"
 #include "compat.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "commandlineparser.h"
 #include "programinfo.h"
@@ -843,7 +842,6 @@ int main(int argc, char **argv)
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION);

--- a/mythtv/programs/mythshutdown/main.cpp
+++ b/mythtv/programs/mythshutdown/main.cpp
@@ -842,13 +842,7 @@ int main(int argc, char **argv)
         return retval;
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythtranscode/main.cpp
+++ b/mythtv/programs/mythtranscode/main.cpp
@@ -380,13 +380,7 @@ int main(int argc, char *argv[])
     CleanupGuard callCleanup(cleanup);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythtranscode/main.cpp
+++ b/mythtv/programs/mythtranscode/main.cpp
@@ -23,7 +23,6 @@
 #include "mpeg2fix.h"
 #include "remotefile.h"
 #include "mythtranslation.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "commandlineparser.h"
 #include "recordinginfo.h"
@@ -381,7 +380,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     //  Load the context

--- a/mythtv/programs/mythtv-setup/main.cpp
+++ b/mythtv/programs/mythtv-setup/main.cpp
@@ -15,7 +15,6 @@
 #include "mythcontext.h"
 #include "mythdbcon.h"
 #include "dbutil.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "mythversion.h"
 #include "langsettings.h"
@@ -299,7 +298,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     if (cmdline.toBool("geometry"))

--- a/mythtv/programs/mythtv-setup/main.cpp
+++ b/mythtv/programs/mythtv-setup/main.cpp
@@ -298,13 +298,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName(MYTH_APPNAME_MYTHTV_SETUP);
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythutil/main.cpp
+++ b/mythtv/programs/mythutil/main.cpp
@@ -83,13 +83,7 @@ int main(int argc, char *argv[])
         logLevel = defaultLevel;
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 

--- a/mythtv/programs/mythutil/main.cpp
+++ b/mythtv/programs/mythutil/main.cpp
@@ -11,7 +11,6 @@
 #include "exitcodes.h"
 #include "mythcontext.h"
 #include "mythversion.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 
 // Local includes
@@ -84,7 +83,6 @@ int main(int argc, char *argv[])
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION);

--- a/mythtv/programs/mythwelcome/main.cpp
+++ b/mythtv/programs/mythwelcome/main.cpp
@@ -10,7 +10,6 @@
 #include "compat.h"
 #include "lcddevice.h"
 #include "commandlineparser.h"
-#include "loggingserver.h"
 #include "mythlogging.h"
 #include "signalhandling.h"
 #include "mythdisplay.h"
@@ -80,7 +79,6 @@ int main(int argc, char **argv)
 
 #ifndef _WIN32
     SignalHandler::Init();
-    SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 
     gContext = new MythContext(MYTH_BINARY_VERSION, true);

--- a/mythtv/programs/mythwelcome/main.cpp
+++ b/mythtv/programs/mythwelcome/main.cpp
@@ -79,13 +79,7 @@ int main(int argc, char **argv)
         bShowSettings = true;
 
 #ifndef _WIN32
-    QList<int> signallist;
-    signallist << SIGINT << SIGTERM << SIGSEGV << SIGABRT << SIGBUS << SIGFPE
-               << SIGILL;
-#ifndef Q_OS_DARWIN
-    signallist << SIGRTMIN;
-#endif
-    SignalHandler::Init(signallist);
+    SignalHandler::Init();
     SignalHandler::SetHandler(SIGHUP, logSigHup);
 #endif
 


### PR DESCRIPTION
The only functional change is mythavtest and mythscreenwizard now use the logSigHup() signal handler, like the rest of the programs, instead of just ignoring it.

SIGHUP is hangup, which is raised when the terminal that launched it closes (or the session logs out, if I understand correctly), and by default terminates the application https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html .

By ignoring SIGHUP the application outlives the terminal that launched it, which makes more sense as a default when the program was launched as a background process with `&`.

logSigHup() calls FileLogger::reopen for each FileLogger, which presumably closes the logging to the terminal and fails to reopen it.
https://github.com/MythTV/mythtv/blob/1a9204f41e09c3a4652e1eec058d820c184a29f2/mythtv/libs/libmythbase/loggingserver.cpp#L150-L159

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

