### PR TITLE
Show transcoding profiles menu when job is _not_ running

### DIFF
--- a/mythtv/programs/mythfrontend/playbackbox.cpp
+++ b/mythtv/programs/mythfrontend/playbackbox.cpp
@@ -3208,7 +3208,7 @@ MythMenu* PlaybackBox::createJobMenu()
         bool running = JobQueue::IsJobQueuedOrRunning(
             kJobs[i], pginfo->GetChanID(), pginfo->GetRecordingStartTime());
 
-        MythMenu *submenu = ((kJobs[i] == JOB_TRANSCODE) && running)
+        MythMenu *submenu = ((kJobs[i] == JOB_TRANSCODE) && !running)
             ? createTranscodingProfilesMenu() : nullptr;
         menu->AddItem((running) ? stop_desc : start_desc,
                       kMySlots[i * 2 + (running ? 0 : 1)], submenu);


### PR DESCRIPTION
The transcoding profiles menu needs to be shown when the transcoding job
is not running.
With commit bf15fbee54 the logic was inverted accidently.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

