### PR TITLE
MythDate: replace formatTime() with formatDuration()

### DIFF
--- a/mythplugins/mytharchive/mytharchive/thumbfinder.cpp
+++ b/mythplugins/mytharchive/mytharchive/thumbfinder.cpp
@@ -404,7 +404,7 @@ QString ThumbFinder::frameToTime(int64_t frame, bool addFrame) const
     int sec = (int) (frame / m_fps);
     frame = frame - (int) (sec * m_fps);
 
-    QString str = MythDate::formatTime(std::chrono::seconds(sec), "HH:mm:ss");
+    QString str = MythDate::formatDuration(std::chrono::seconds(sec));
     if (addFrame)
         str += QString(".%1").arg(frame,10,2,QChar('0'));
     return str;

--- a/mythplugins/mythmusic/mythmusic/cdrip.cpp
+++ b/mythplugins/mythmusic/mythmusic/cdrip.cpp
@@ -1224,7 +1224,7 @@ void Ripper::updateTrackList(void)
 
             if (track->length >= 1s)
             {
-                item->SetText(MythDate::formatTime(track->length, "mm:ss"), "length");
+                item->SetText(MythDate::formatDuration(track->length), "length");
             }
             else
                 item->SetText("", "length");

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -2141,11 +2141,9 @@ void MusicCommon::updatePlaylistStats(void)
 QString MusicCommon::getTimeString(std::chrono::seconds exTime, std::chrono::seconds maxTime)
 {
     if (maxTime <= 0ms)
-        return MythDate::formatTime(exTime,
-                              (exTime >= 1h) ? "H:mm:ss" : "mm:ss");
+        return MythDate::formatDuration(exTime);
 
-    QString fmt = (maxTime >= 1h) ? "H:mm:ss" : "mm:ss";
-    return MythDate::formatTime(exTime, fmt) + " / " + MythDate::formatTime(maxTime, fmt);
+    return MythDate::formatDuration(exTime) + " / " + MythDate::formatDuration(maxTime);
 }
 
 void MusicCommon::searchButtonList(void)

--- a/mythtv/libs/libmythbase/mythdate.cpp
+++ b/mythtv/libs/libmythbase/mythdate.cpp
@@ -206,36 +206,6 @@ std::chrono::seconds secsInFuture (const QDateTime& future)
     return std::chrono::seconds(MythDate::current().secsTo(future));
 }
 
-/**
- * \brief Format a milliseconds time value
- *
- * Convert a millisecond time value into a textual representation of the value.
- *
- * \param msecs The time value in milliseconds. Since the type of this
- *     field is std::chrono::duration, any duration of a larger
- *     interval can be passed to this function and the compiler will
- *     convert it to milliseconds.
- *
- * \param fmt A formatting string specifying how to output the time.
- *     See QTime::toString for the definition of valid formatting
- *     characters.
- */
-QString formatTime(std::chrono::milliseconds msecs, QString fmt)
-{
-    int count = 0;
-
-    // QTime can't handle times of more than 24 hours.  Do that part
-    // of the formatting manually, and then let QTime::toString handle
-    // the rest of the formatting.
-    while (fmt[count] == QLatin1Char('H'))
-        count++;
-    fmt.remove(0, count);
-
-    QString result = QString("%1").arg(msecs / 1h, count,10,QLatin1Char('0'));
-    msecs = msecs % 1h;
-    return result + QTime::fromMSecsSinceStartOfDay(msecs.count()).toString(fmt);
-}
-
 QString formatDuration(std::chrono::milliseconds dur,
                        FormatDurationUnit min_unit,
                        FormatDurationUnit max_unit,

--- a/mythtv/libs/libmythbase/mythdate.h
+++ b/mythtv/libs/libmythbase/mythdate.h
@@ -63,6 +63,43 @@ MBASE_PUBLIC std::chrono::seconds secsInFuture (const QDateTime& future);
 MBASE_PUBLIC QString formatTime(std::chrono::milliseconds msecs,
                                 QString fmt = "HH:mm:ss");
 
+enum class FormatDurationUnit : int
+{
+    automatic = -1,
+    ms,
+    s,
+    min,
+    h,
+    d,
+};
+
+/**
+ * @brief Format a milliseconds duration.
+ *
+ * Convert a millisecond time value into a textual representation of the value
+ * in the format "n day(s) HH:mm:ss.zzz" where any subset of consecutive elements
+ * can be selected, omitting the rest.  All elements after the first are always
+ * 0 padded.
+ *
+ * @param dur The time value in milliseconds. Since the type of this
+ *     field is std::chrono::duration, any duration of a larger
+ *     interval can be passed to this function and the compiler will
+ *     convert it to milliseconds.
+ *
+ * @param min_unit The minimum sized unit that will be output.
+ *                 Automatic is invalid at this time.
+ * @param max_unit The maximum sized unit that will be output.  Automatic selects
+ *                 the minimum required unit for a fully reduced representation.
+ * @param padded   Whether or not the first entry should be padded with a 0.  The
+ *                 days value is never padded.
+ *
+ * @todo Implement trimming trailing zeroes, i.e. enable automatic for min_unit?
+ */
+MBASE_PUBLIC QString formatDuration(std::chrono::milliseconds dur,
+                                    FormatDurationUnit min_unit = FormatDurationUnit::s,
+                                    FormatDurationUnit max_unit = FormatDurationUnit::automatic,
+                                    bool padded = true);
+
 } // namespace MythDate
 
 #endif // MYTH_DATE_H

--- a/mythtv/libs/libmythbase/mythdate.h
+++ b/mythtv/libs/libmythbase/mythdate.h
@@ -60,9 +60,6 @@ MBASE_PUBLIC std::chrono::milliseconds currentMSecsSinceEpochAsDuration(void);
 MBASE_PUBLIC std::chrono::seconds secsInPast (const QDateTime& past);
 MBASE_PUBLIC std::chrono::seconds secsInFuture (const QDateTime& future);
 
-MBASE_PUBLIC QString formatTime(std::chrono::milliseconds msecs,
-                                QString fmt = "HH:mm:ss");
-
 enum class FormatDurationUnit : int
 {
     automatic = -1,

--- a/mythtv/libs/libmythmetadata/lyricsdata.h
+++ b/mythtv/libs/libmythmetadata/lyricsdata.h
@@ -38,7 +38,7 @@ class META_PUBLIC LyricsLine
   private:
     QString formatTime(void) const
     {
-        QString timestr = MythDate::formatTime(m_time,"mm:ss.zzz");
+        QString timestr = MythDate::formatDuration(m_time, MythDate::FormatDurationUnit::ms);
         timestr.chop(1); // Chop 1 to return hundredths
         return QString("[%1]").arg(timestr);
     }

--- a/mythtv/libs/libmythmetadata/musicmetadata.cpp
+++ b/mythtv/libs/libmythmetadata/musicmetadata.cpp
@@ -1114,8 +1114,9 @@ void MusicMetadata::toMap(InfoMap &metadataMap, const QString &prefix)
     metadataMap[prefix + "genre"] = m_genre;
     metadataMap[prefix + "year"] = (m_year > 0 ? QString("%1").arg(m_year) : "");
 
-    QString fmt = (m_length >= 1h) ? "H:mm:ss" : "mm:ss";
-    metadataMap[prefix + "length"] = MythDate::formatTime(m_length, fmt);
+    metadataMap[prefix + "length"] =
+        MythDate::formatDuration(m_length, MythDate::FormatDurationUnit::s,
+                                 MythDate::FormatDurationUnit::automatic, m_length > 1h);
 
     if (m_lastPlay.isValid())
     {

--- a/mythtv/libs/libmythtv/Bluray/mythbdbuffer.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdbuffer.cpp
@@ -718,7 +718,7 @@ bool MythBDBuffer::UpdateTitleInfo(void)
     m_titlesize = bd_get_title_size(m_bdnav);
     uint32_t chapter_count = GetNumChapters();
     auto total_msecs = duration_cast<std::chrono::milliseconds>(m_currentTitleLength);
-    auto duration = MythDate::formatTime(total_msecs, "HH:mm:ss.zzz");
+    auto duration = MythDate::formatDuration(total_msecs, MythDate::FormatDurationUnit::ms);
     duration.chop(2); // Chop 2 to show tenths
     LOG(VB_GENERAL, LOG_INFO, LOC + QString("New title info: Index %1 Playlist: %2 Duration: %3 ""Chapters: %5")
             .arg(m_currentTitle).arg(m_currentTitleInfo->playlist).arg(duration).arg(chapter_count));
@@ -731,7 +731,7 @@ bool MythBDBuffer::UpdateTitleInfo(void)
         uint64_t framenum   = GetChapterStartFrame(i);
         LOG(VB_PLAYBACK, LOG_INFO, LOC + QString("Chapter %1 found @ [%2]->%3")
             .arg(i + 1,   2, 10, QChar('0'))
-            .arg(MythDate::formatTime(GetChapterStartTimeMs(i), "HH:mm:ss.zzz"))
+            .arg(MythDate::formatDuration(GetChapterStartTimeMs(i), MythDate::FormatDurationUnit::ms))
             .arg(framenum));
     }
 

--- a/mythtv/libs/libmythtv/Bluray/mythbdplayer.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdplayer.cpp
@@ -242,7 +242,7 @@ QString MythBDPlayer::GetTitleName(int Title) const
     if (Title >= 0 && Title < GetNumTitles())
     {
         // BD doesn't provide title names, so show title number and duration
-        QString timestr = MythDate::formatTime(GetTitleDuration(Title), "HH:mm:ss");
+        QString timestr = MythDate::formatDuration(GetTitleDuration(Title));
         QString name = QString("%1 (%2)").arg(Title+1).arg(timestr);
         return name;
     }

--- a/mythtv/libs/libmythtv/commbreakmap.cpp
+++ b/mythtv/libs/libmythtv/commbreakmap.cpp
@@ -215,7 +215,9 @@ bool CommBreakMap::AutoCommercialSkip(uint64_t &jumpToFrame,
 
     auto skipped_seconds = std::chrono::seconds((int)((m_commBreakIter.key() -
                                  framesPlayed) / video_frame_rate));
-    QString skipTime = MythDate::formatTime(skipped_seconds, "m:ss");
+    QString skipTime =
+        MythDate::formatDuration(skipped_seconds, MythDate::FormatDurationUnit::s,
+                                 MythDate::FormatDurationUnit::automatic, false);
     if (kCommSkipOn == m_autocommercialskip)
     {
         //: %1 is the skip time
@@ -335,7 +337,9 @@ bool CommBreakMap::DoSkipCommercials(uint64_t &jumpToFrame,
         MergeShortCommercials(video_frame_rate);
     int64_t framediff = m_commBreakIter.key() - framesPlayed;
     auto skipped_seconds = std::chrono::seconds((int)(framediff / video_frame_rate));
-    QString skipTime = MythDate::formatTime(skipped_seconds, "m:ss");
+    QString skipTime =
+        MythDate::formatDuration(skipped_seconds, MythDate::FormatDurationUnit::s,
+                                 MythDate::FormatDurationUnit::automatic, false);
 
     if ((MythDate::secsInPast(m_lastIgnoredManualSkip) > 3s) &&
         (abs(skipped_seconds) >= m_maxskip))

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -1265,7 +1265,7 @@ int AvFormatDecoder::OpenFile(MythMediaBuffer *Buffer, bool novideo,
         LOG(VB_PLAYBACK, LOG_INFO, LOC +
             QString("Chapter %1 found @ [%2]->%3")
                 .arg(i + 1,   2,10,QChar('0'))
-                .arg(MythDate::formatTime(msec, "HH:mm:ss.zzz"))
+                .arg(MythDate::formatDuration(msec, MythDate::FormatDurationUnit::ms))
                 .arg(framenum));
     }
 

--- a/mythtv/libs/libmythtv/deletemap.cpp
+++ b/mythtv/libs/libmythtv/deletemap.cpp
@@ -164,10 +164,9 @@ QString DeleteMap::CreateTimeString(uint64_t frame, bool use_cutlist,
     const
 {
     std::chrono::milliseconds ms = TranslatePositionFrameToMs(frame, frame_rate, use_cutlist);
-    QString fmt = (ms >= 1h) ? "H:mm:ss" : "mm:ss";
     if (full_resolution)
-        fmt += ".zzz";
-    return MythDate::formatTime(ms, fmt);
+        return MythDate::formatDuration(ms, MythDate::FormatDurationUnit::ms);
+    return MythDate::formatDuration(ms);
 }
 
  /**

--- a/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
+++ b/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
@@ -210,22 +210,44 @@ void MythPlayerOverlayUI::UpdateSliderInfo(osdInfo &Info, bool PaddedFields)
         QString text3;
         if (PaddedFields)
         {
-            text1 = MythDate::formatTime(secsplayed, "HH:mm:ss");
-            text2 = MythDate::formatTime(playbackLen, "HH:mm:ss");
-            text3 = MythDate::formatTime(secsbehind, "HH:mm:ss");
+            text1 =
+                MythDate::formatDuration(secsplayed,
+                                         MythDate::FormatDurationUnit::s,
+                                         MythDate::FormatDurationUnit::h);
+            text2 =
+                MythDate::formatDuration(playbackLen,
+                                         MythDate::FormatDurationUnit::s,
+                                         MythDate::FormatDurationUnit::h);
+            text3 =
+                MythDate::formatDuration(secsbehind,
+                                         MythDate::FormatDurationUnit::s,
+                                         MythDate::FormatDurationUnit::h);
         }
         else
         {
-            QString fmt = (playbackLen >= 1h) ? "H:mm:ss" : "m:ss";
-            text1 = MythDate::formatTime(secsplayed, fmt);
-            text2 = MythDate::formatTime(playbackLen, fmt);
+            text1 =
+                MythDate::formatDuration(secsplayed,
+                                         MythDate::FormatDurationUnit::s,
+                                         MythDate::FormatDurationUnit::automatic,
+                                         false);
+            text2 =
+                MythDate::formatDuration(playbackLen,
+                                         MythDate::FormatDurationUnit::s,
+                                         MythDate::FormatDurationUnit::automatic,
+                                         false);
 
-            if (secsbehind >= 1h)
-                text3 = MythDate::formatTime(secsbehind, "H:mm:ss");
-            else if (secsbehind >= 1min)
-                text3 = MythDate::formatTime(secsbehind, "m:ss");
+            if (secsbehind >= 1min)
+            {
+                text3 =
+                    MythDate::formatDuration(secsbehind,
+                                             MythDate::FormatDurationUnit::s,
+                                             MythDate::FormatDurationUnit::automatic,
+                                             false);
+            }
             else
+            {
                 text3 = tr("%n second(s)", "", static_cast<int>(secsbehind.count()));
+            }
         }
 
         QString desc = stillFrame ? tr("Still Frame") : tr("%1 of %2").arg(text1, text2);

--- a/mythtv/libs/libmythtv/tv_play.cpp
+++ b/mythtv/libs/libmythtv/tv_play.cpp
@@ -6607,7 +6607,7 @@ void TV::ShowLCDDVDInfo()
         int totalParts = dvd->NumPartsInTitle();
 
         mainStatus = tr("Title: %1 (%2)").arg(playingTitle)
-            .arg(MythDate::formatTime(dvd->GetTotalTimeOfTitle(), "HH:mm"));
+            .arg(MythDate::formatDuration(dvd->GetTotalTimeOfTitle(), MythDate::FormatDurationUnit::min));
         subStatus = tr("Chapter: %1/%2").arg(playingPart).arg(totalParts);
     }
     if ((dvdName != m_lcdCallsign) || (mainStatus != m_lcdTitle) || (subStatus != m_lcdSubtitle))
@@ -8667,7 +8667,7 @@ bool TV::MenuItemDisplayPlayback(const MythTVMenuItemContext& Context, MythOSDDi
             {
                 QString chapter1 = QString("%1").arg(i+1, size, 10, QChar(48));
                 QString chapter2 = QString("%1").arg(i+1, 3   , 10, QChar(48));
-                QString timestr = MythDate::formatTime(m_tvmChapterTimes[i], "HH:mm:ss");
+                QString timestr = MythDate::formatDuration(m_tvmChapterTimes[i]);
                 QString desc = chapter1 + QString(" (%1)").arg(timestr);
                 QString action = prefix + chapter2;
                 active = (m_tvmCurrentChapter == (i + 1));

--- a/mythtv/programs/mythcommflag/CommDetector2.cpp
+++ b/mythtv/programs/mythcommflag/CommDetector2.cpp
@@ -252,13 +252,13 @@ QString frameToTimestamp(long long frameno, float fps)
 {
     auto ms = millisecondsFromFloat(frameno / fps * 1000);
     auto secs = std::chrono::ceil<std::chrono::seconds>(ms);
-    return MythDate::formatTime(secs, "hh:mm:ss");
+    return MythDate::formatDuration(secs);
 }
 
 QString frameToTimestampms(long long frameno, float fps)
 {
     auto ms = millisecondsFromFloat(frameno / fps * 1000);
-    QString timestr = MythDate::formatTime(ms, "mm:ss.zzz");
+    QString timestr = MythDate::formatDuration(ms, MythDate::FormatDurationUnit::ms);
     timestr.chop(1); // Chop 1 to return hundredths
     return timestr;
 }

--- a/mythtv/programs/mythfrontend/statusbox.cpp
+++ b/mythtv/programs/mythfrontend/statusbox.cpp
@@ -1113,19 +1113,7 @@ static QString uptimeStr(std::chrono::seconds uptime)
     if (uptime == 0s)
         return str + StatusBox::tr("unknown", "unknown uptime");
 
-    auto days = duration_cast<std::chrono::days>(uptime);
-    auto secs = uptime % 24h;
-
-    QString astext;
-    if (days.count() > 0)
-    {
-        astext = QString("%1, %2")
-            .arg(StatusBox::tr("%n day(s)", "", days.count()),
-                 MythDate::formatTime(secs, "H:mm"));
-    } else {
-        astext = MythDate::formatTime(secs, "H:mm:ss");
-    }
-    return str + astext;
+    return str + MythDate::formatDuration(uptime);
 }
 
 /** \fn StatusBox::getActualRecordedBPS(QString hostnames)


### PR DESCRIPTION
QTime will only print up to 23 hours, 59 minutes, 59 seconds, and 999
milliseconds.  This implementation has none of those restrictions.

Fixes https://github.com/MythTV/mythtv/issues/520

However, some of the output is changed: in particular, zero padding is
now the default, but can be disabled if desired.

As far as I can tell, this is only used for human readable output.


I am open to changing any of the calls to better match the prior formats, if desired.

I would like to use StringUtil::intToPaddedString() but that is not yet merged.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

