### PR TITLE
fixup MythDate::formatTime() calls and doxygen

### DIFF
--- a/mythtv/libs/libmythbase/mythdate.cpp
+++ b/mythtv/libs/libmythbase/mythdate.cpp
@@ -222,8 +222,10 @@ std::chrono::seconds secsInFuture (const QDateTime& future)
  *     convert it to milliseconds.
  *
  * \param fmt A formatting string specifying how to output the time.
- *     See QTime::toString for the definition of valid formatting
- *     characters.
+ *     Valid formatting characters are <tt>"Hmsz"</tt> for hours, minutes, seconds,
+ *     and milliseconds, respectively.  Consecutive runs of these characters will
+ *     be replaced by at least as many characters as the run length, zero padding
+ *     if necessary.
  */
 QString formatTime(std::chrono::milliseconds msecs, QString fmt)
 {

--- a/mythtv/programs/mythcommflag/CommDetector2.cpp
+++ b/mythtv/programs/mythcommflag/CommDetector2.cpp
@@ -252,23 +252,20 @@ QString frameToTimestamp(long long frameno, float fps)
 {
     auto ms = millisecondsFromFloat(frameno / fps * 1000);
     auto secs = std::chrono::ceil<std::chrono::seconds>(ms);
-    return MythDate::formatTime(secs, "hh:mm:ss");
+    return MythDate::formatTime(secs, "HH:mm:ss");
 }
 
 QString frameToTimestampms(long long frameno, float fps)
 {
     auto ms = millisecondsFromFloat(frameno / fps * 1000);
-    QString timestr = MythDate::formatTime(ms, "mm:ss.zzz");
-    timestr.chop(1); // Chop 1 to return hundredths
+    QString timestr = MythDate::formatTime(ms, "mm:ss.zz");
     return timestr;
 }
 
 QString strftimeval(std::chrono::microseconds usecs)
 {
     auto msecs = duration_cast<std::chrono::milliseconds>(usecs);
-    return QString("%1.%2")
-        .arg(duration_cast<std::chrono::seconds>(usecs).count())
-        .arg((msecs % 1s).count(), 3, 10, QChar(QChar('0')));
+    return MythDate::formatTime(msecs, "s.zzz");
 }
 
 };  /* namespace */


### PR DESCRIPTION
@linuxdude42 You missed some in https://github.com/MythTV/mythtv/commit/65b9c73adacabe38877c3e18af5d4a0545799c16

See commit messages for details.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

