### PR TITLE
Harmonize mpegts-mythtv with FFmpeg 4.4

### DIFF
--- a/mythtv/external/FFmpeg/libavcodec/codec_desc.c
+++ b/mythtv/external/FFmpeg/libavcodec/codec_desc.c
@@ -3400,6 +3400,24 @@ static const AVCodecDescriptor codec_descriptors[] = {
         .props     = AV_CODEC_PROP_TEXT_SUB,
         .profiles  = NULL_IF_CONFIG_SMALL(ff_arib_caption_profiles),
     },
+    {
+        .id        = AV_CODEC_ID_MPEG2VBI,
+        .type      = AVMEDIA_TYPE_DATA,
+        .name      = "mpeg2vbi",
+        .long_name = NULL_IF_CONFIG_SMALL("ivtv proprietary embedded VBI captions"),
+    },
+    {
+        .id        = AV_CODEC_ID_DVB_VBI,
+        .type      = AVMEDIA_TYPE_DATA,
+        .name      = "dvb_vbi",
+        .long_name = NULL_IF_CONFIG_SMALL("dvb teletext"),
+    },
+    {
+        .id        = AV_CODEC_ID_DSMCC_B,
+        .type      = AVMEDIA_TYPE_DATA,
+        .name      = "dsmcc_b",
+        .long_name = NULL_IF_CONFIG_SMALL("DSMCC B"),
+    },
 
     /* other kind of codecs and pseudo-codecs */
     {
@@ -3460,24 +3478,6 @@ static const AVCodecDescriptor codec_descriptors[] = {
         .type      = AVMEDIA_TYPE_DATA,
         .name      = "dvd_nav_packet",
         .long_name = NULL_IF_CONFIG_SMALL("DVD Nav packet"),
-    },
-    {
-        .id        = AV_CODEC_ID_MPEG2VBI,
-        .type      = AVMEDIA_TYPE_DATA,
-        .name      = "mpeg2vbi",
-        .long_name = NULL_IF_CONFIG_SMALL("ivtv proprietary embedded VBI captions"),
-    },
-    {
-        .id        = AV_CODEC_ID_DVB_VBI,
-        .type      = AVMEDIA_TYPE_DATA,
-        .name      = "dvb_vbi",
-        .long_name = NULL_IF_CONFIG_SMALL("dvb teletext"),
-    },
-    {
-        .id        = AV_CODEC_ID_DSMCC_B,
-        .type      = AVMEDIA_TYPE_DATA,
-        .name      = "dsmcc_b",
-        .long_name = NULL_IF_CONFIG_SMALL("DSMCC B"),
     },
     {
         .id        = AV_CODEC_ID_TIMED_ID3,

--- a/mythtv/external/FFmpeg/libavformat/avformat.h
+++ b/mythtv/external/FFmpeg/libavformat/avformat.h
@@ -1370,6 +1370,12 @@ typedef struct AVFormatContext {
     void *stream_change_data;
     const uint8_t *cur_pmt_sect;
     int cur_pmt_sect_len;
+
+    /**
+     * A reference-counted buffer holding the last seen PMT in an MPEG-TS.
+     * Only set by mpegts-mythtv.
+     */
+    AVBufferRef *pmt_section;
     /* End Myth addons */
 
     /**

--- a/mythtv/external/FFmpeg/libavformat/avformat.h
+++ b/mythtv/external/FFmpeg/libavformat/avformat.h
@@ -1368,8 +1368,6 @@ typedef struct AVFormatContext {
     /* mpeg-ts support */
     void (*streams_changed)(void*);
     void *stream_change_data;
-    const uint8_t *cur_pmt_sect;
-    int cur_pmt_sect_len;
 
     /**
      * A reference-counted buffer holding the last seen PMT in an MPEG-TS.

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -125,7 +125,6 @@ static void av_mpegts_remove_stream(AVFormatContext *s, int id) {
             av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st = NULL\n");
             s->cur_st = NULL;
         }
-#endif
      /*   else if (s->cur_st > &s->streams[i]) {
             av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st -= 1\n");
             s->cur_st -= sizeof(AVFormatContext *);
@@ -134,6 +133,7 @@ static void av_mpegts_remove_stream(AVFormatContext *s, int id) {
             av_log(NULL, AV_LOG_DEBUG,
                    "av_mpegts_remove_stream: no change to cur_st\n");
         }
+#endif
 
         av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: removing... "
                "s->nb_streams=%d i=%d\n", s->nb_streams, i);

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -113,12 +113,16 @@ static void av_mpegts_remove_stream(AVFormatContext *s, int id) {
 
         av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream 0x%x\n", id);
 
+#if FF_API_LAVF_AVCTX
+FF_DISABLE_DEPRECATION_WARNINGS
         /* close codec context */
         codec_ctx = s->streams[i]->codec;
         if (codec_ctx->codec) {
             avcodec_close(codec_ctx);
             av_free(codec_ctx);
         }
+FF_ENABLE_DEPRECATION_WARNINGS
+#endif
 #if 0
         /* make sure format context is not using the codec context */
         if (&s->streams[i] == s->cur_st) {

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -280,7 +280,6 @@ struct MpegTSContext {
     int raw_packet_size;
 
     int64_t pos47_full;
-    int pos47; // not in upstream (will be replaced by pos47_full)
 
     /** if true, all pids are analyzed to find streams */
     int auto_guess;

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -249,7 +249,7 @@ struct Stream {
 #define MAX_PIDS_PER_PROGRAM (MAX_STREAMS_PER_PROGRAM + 2)
 struct Program {
     unsigned int id; // program id/service id
-    unsigned int pid; // PMT PID (not in upstream)
+    unsigned int pid; // PMT PID (not in upstream), only used in add_pat_entry() and is_pat_same()
     unsigned int nb_pids;
     unsigned int pids[MAX_PIDS_PER_PROGRAM];
     unsigned int nb_streams;
@@ -2859,6 +2859,7 @@ void mpegts_remove_stream(MpegTSContext *ts, int pid)
     }
 }
 
+// from FFmpeg sync
 static void add_pat_entry(MpegTSContext *ts, unsigned int programid, unsigned int pid)
 {
     struct Program *p;
@@ -2868,7 +2869,7 @@ static void add_pat_entry(MpegTSContext *ts, unsigned int programid, unsigned in
     ts->prg = tmp;
     p = &ts->prg[ts->nb_prg];
     p->id = programid;
-    p->pid = pid;
+    p->pid = pid; // MythTV added
     p->nb_pids = 0;
     ts->nb_prg++;
 }

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -3093,6 +3093,8 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         }
 
         pmt_count++;
+        if (sid == ts->req_sid)
+            found = 1;
 
     }
 
@@ -3110,7 +3112,6 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         }
     }
 
-    found = 0;
     for (i = 0; i < pmt_count; ++i)
     {
         /* if an MPEG program number is requested, and this is that program,
@@ -3131,8 +3132,6 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
 
             if (!ts->pids[pmt_pid])
                 mpegts_open_section_filter(ts, pmt_pid, pmt_cb, ts, 1);
-
-            found = 1;
         }
     }
 

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -1542,32 +1542,30 @@ skip:
 
 static PESContext *add_pes_stream(MpegTSContext *ts, int pid, int pcr_pid)
 {
-    MpegTSFilter *tss = ts->pids[pid];
-    PESContext *pes = 0;
-    if (tss) { /* filter already exists */
-        if (tss->type == MPEGTS_PES)
-            pes = (PESContext*) tss->u.pes_filter.opaque;
-        /* otherwise, kill it, and start a new stream */
+    MpegTSFilter *tss;
+    PESContext *pes;
+
+    // MythTV
+    if (tss = ts->pids[pid]) { /* filter already exists */
+        /* kill it, and start a new stream */
         mpegts_close_filter(ts, tss);
     }
+    // end MythTV
 
-    /* create a PES context */
-    if (!(pes=av_mallocz(sizeof(PESContext)))) {
-        av_log(NULL, AV_LOG_ERROR, "Error: av_mallocz() failed in add_pes_stream");
+    /* if no pid found, then add a pid context */
+    pes = av_mallocz(sizeof(PESContext));
+    if (!pes)
         return 0;
-    }
-    pes->ts = ts;
-    pes->stream = ts->stream;
-    pes->pid = pid;
+    pes->ts      = ts;
+    pes->stream  = ts->stream;
+    pes->pid     = pid;
     pes->pcr_pid = pcr_pid;
-    pes->state = MPEGTS_SKIP;
-    pes->pts = AV_NOPTS_VALUE;
-    pes->dts = AV_NOPTS_VALUE;
-    tss = mpegts_open_pes_filter(ts, pid, mpegts_push_data, pes);
+    pes->state   = MPEGTS_SKIP;
+    pes->pts     = AV_NOPTS_VALUE;
+    pes->dts     = AV_NOPTS_VALUE;
+    tss          = mpegts_open_pes_filter(ts, pid, mpegts_push_data, pes);
     if (!tss) {
         av_free(pes);
-        av_log(NULL, AV_LOG_ERROR, "Error: unable to open "
-               "mpegts PES filter in add_pes_stream");
         return 0;
     }
     return pes;

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2492,7 +2492,7 @@ static void mpegts_push_section(MpegTSFilter *filter, const uint8_t *section, in
         return;
     }
 
-    if (sect->new_packet && pkt && sect->st && pkt->size == 0) {
+    if (sect->new_packet && pkt && sect->st && pkt->size == -1) {
         int pktLen = section_len + 184; /* Add enough for a complete TS payload. */
         sect->new_packet = 0;
         av_free_packet(pkt);
@@ -3567,7 +3567,7 @@ static int mpegts_read_packet(AVFormatContext *s, AVPacket *pkt)
     MpegTSContext *ts = s->priv_data;
     int ret, i;
 
-    //pkt->size = -1; // this breaks MHEG
+    pkt->size = -1;
     ts->pkt = pkt;
     ret = handle_packets(ts, 0);
     if (ret < 0) {

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2600,14 +2600,13 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
         } else {
             PESContext *pes = NULL;
 
+            /* now create stream */
             if (ts->pids[pid] && ts->pids[pid]->type == MPEGTS_PES) {
                 pes = ts->pids[pid]->u.pes_filter.opaque;
                 st = pes->st;
             } else {
-                if (ts->pids[pid]) {
-                    //wrongly added sdt filter probably
-                    mpegts_close_filter(ts, ts->pids[pid]);
-                }
+                if (ts->pids[pid])
+                    mpegts_close_filter(ts, ts->pids[pid]); // wrongly added sdt filter probably
                 pes = add_pes_stream(ts, pid, pcr_pid);
                 if (pes)
                 {
@@ -2637,8 +2636,10 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
 
             st->codecpar->codec_tag = item->dvbci.codec_tag;
 
-            if (prog_reg_desc == AV_RL32("HDMV") && stream_type == 0x83 && pes->sub_st) {
-                av_program_add_stream_index(ts->stream, id, pes->sub_st->index);
+            if (pes && prog_reg_desc == AV_RL32("HDMV") &&
+                stream_type == 0x83 && pes->sub_st) {
+                av_program_add_stream_index(ts->stream, id,
+                                            pes->sub_st->index);
                 pes->sub_st->codecpar->codec_tag = st->codecpar->codec_tag;
             }
 

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -57,12 +57,6 @@ static AVStream *av_new_stream(AVFormatContext *s, int id)
     return st;
 }
 
-static void av_set_pts_info(AVStream *s, int pts_wrap_bits,
-                     unsigned int pts_num, unsigned int pts_den)
-{
-    avpriv_set_pts_info(s, pts_wrap_bits, pts_num, pts_den);
-}
-
 /**
  * av_dlog macros
  * copied from libavutil/log.h since they are deprecated and removed from there
@@ -2642,7 +2636,7 @@ static AVStream *new_section_av_stream(SectionContext *sect, enum AVMediaType ty
 
     sect->st = av_new_stream(sect->stream, sect->pid);
 
-    av_set_pts_info(sect->st, 33, 1, 90000);
+    avpriv_set_pts_info(sect->st, 33, 1, 90000);
 
     sect->st->codecpar->codec_type = type;
     sect->st->codecpar->codec_id   = id;

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2607,7 +2607,6 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     // MythTV
     int equal_streams = 0;
     int last_item = 0;
-    int desc_count = 0;
 
     pmt_entry_t items[PMT_PIDS_MAX];
     memset(&items, 0, sizeof(pmt_entry_t) * PMT_PIDS_MAX);
@@ -2760,8 +2759,6 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
                    sizeof(dvb_caption_info_t));
             last_item++;
         }
-
-        desc_count++;
     }
 
     // begin MythTV

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -232,8 +232,6 @@ struct MpegTSContext {
     AVBufferPool* pools[32];
 
     // MythTV only
-    /** filter for the PAT                                   */
-    MpegTSFilter *pat_filter;
     /** MPEG program number of stream we want to decode      */
     int req_sid;
 
@@ -590,7 +588,7 @@ static MpegTSFilter *mpegts_open_section_filter(MpegTSContext *ts,
     MpegTSSectionFilter *sec;
     uint8_t *section_buf = av_mallocz(MAX_SECTION_SIZE);
 
-    // MythTV from PMT tracking in ffmpeg patch from danielk.
+    // MythTV from PMT tracking in ffmpeg patch from danielk. https://github.com/MythTV/mythtv/commit/236872aa4dc73c45f01d71f749eb50eaf7eb12e4
     if (filter = ts->pids[pid]) {
         mpegts_close_filter(ts, filter);
     }
@@ -3197,14 +3195,6 @@ static int handle_packet(MpegTSContext *ts, const uint8_t *packet, int64_t pos)
         has_adaptation, has_payload;
     const uint8_t *p, *p_end;
 
-    // MythTV PMT tracking in ffmpeg patch from danielk. https://github.com/MythTV/mythtv/commit/236872aa4dc73c45f01d71f749eb50eaf7eb12e4
-    if (!ts->pids[0]) {
-        /* make sure we're always scanning for new PAT's */
-        av_log(ts->stream, AV_LOG_INFO, "opening pat filter\n");
-        ts->pat_filter = mpegts_open_section_filter(ts, PAT_PID, pat_cb, ts, 1);
-    }
-    // end MythTV
-
     pid = AV_RB16(packet + 1) & 0x1fff;
     is_start = packet[1] & 0x40;
     tss = ts->pids[pid];
@@ -3595,7 +3585,6 @@ static int mpegts_read_header(AVFormatContext *s)
         ts->req_sid = -1;
 
         ts->scanning = 1;
-        ts->pat_filter =
         mpegts_open_section_filter(ts, PAT_PID, pat_cb, ts, 1);
         mpegts_open_section_filter(ts, EIT_PID, eit_cb, ts, 1);
 

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -3067,6 +3067,11 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     }
 
     // begin MythTV
+
+    /* cache pmt */
+    av_log(ts->stream, AV_LOG_TRACE, "exporting PMT\n");
+    export_pmt(ts->stream, section, section_len);
+
     /* if the pmt has changed delete old streams,
      * create new ones, and notify any listener.
      */
@@ -3086,10 +3091,6 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         /* create new streams */
         for (idx = equal_streams; idx < last_item; idx++)
             mpegts_add_stream(ts, h->id, &items[idx], prog_reg_desc, pcr_pid);
-
-        /* cache pmt */
-        av_log(ts->stream, AV_LOG_TRACE, "exporting PMT\n");
-        export_pmt(avctx, section, section_len);
 
         /* notify stream_changed listeners */
         if (avctx->streams_changed)

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -71,88 +71,6 @@ typedef struct SectionContext {
     AVStream *st;
 } SectionContext;
 
-static void mpegts_remove_stream(MpegTSContext *ts, int pid);
-
-/**
- * @brief Remove a stream from a media stream.
- *
- * This is used by mpegts, so we can track streams as indicated by the PMT.
- *
- * @param s MPEG media stream handle
- * @param id stream id of stream to remove
- * @param remove_ts if true, remove any matching MPEG-TS filter as well
- */
-static void av_mpegts_remove_stream(AVFormatContext *s, int id) {
-    int i;
-    int changes = 0;
-
-    for (i=0; i<s->nb_streams; i++) {
-        AVCodecContext *codec_ctx;
-        if (s->streams[i]->id != id)
-            continue;
-
-        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream 0x%x\n", id);
-
-#if FF_API_LAVF_AVCTX
-FF_DISABLE_DEPRECATION_WARNINGS
-        /* close codec context */
-        codec_ctx = s->streams[i]->codec;
-        if (codec_ctx->codec) {
-            avcodec_close(codec_ctx);
-            av_free(codec_ctx);
-        }
-FF_ENABLE_DEPRECATION_WARNINGS
-#endif
-#if 0
-        /* make sure format context is not using the codec context */
-        if (&s->streams[i] == s->cur_st) {
-            av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st = NULL\n");
-            s->cur_st = NULL;
-        }
-     /*   else if (s->cur_st > &s->streams[i]) {
-            av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st -= 1\n");
-            s->cur_st -= sizeof(AVFormatContext *);
-        } */
-        else {
-            av_log(NULL, AV_LOG_DEBUG,
-                   "av_mpegts_remove_stream: no change to cur_st\n");
-        }
-#endif
-
-        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: removing... "
-               "s->nb_streams=%d i=%d\n", s->nb_streams, i);
-        /* actually remove av stream */
-        s->nb_streams--;
-        if ((s->nb_streams - i) > 0) {
-            memmove(&s->streams[i], &s->streams[i+1],
-                    (s->nb_streams-i)*sizeof(AVFormatContext *));
-        }
-        else
-            s->streams[i] = NULL;
-
-        /* remove ts filter if remove ts is true and
-         * the format decoder is the "mpegts" decoder
-         */
-        if (s->iformat && s->priv_data &&
-            (0 == strncmp(s->iformat->name, "mpegts", 6))) {
-            av_log(NULL, AV_LOG_DEBUG,
-                   "av_mpegts_remove_stream: mpegts_remove_stream\n");
-            mpegts_remove_stream((MpegTSContext*) s->priv_data, id);
-        }
-        changes = 1;
-    }
-    if (changes)
-    {
-        // flush queued packets after a stream change (might need to make smarter)
-        mythtv_flush_packet_queue(s);
-
-        /* renumber the streams */
-        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: renumbering streams\n");
-        for (i=0; i<s->nb_streams; i++)
-            s->streams[i]->index=i;
-    }
-}
-
 /** maximum number of PMT's we expect to be described in a PAT */
 #define PAT_MAX_PMT 128
 
@@ -2271,26 +2189,6 @@ static void set_pcr_pid(AVFormatContext *s, unsigned int programid, unsigned int
     }
 }
 
-static void mpegts_cleanup_streams(MpegTSContext *ts)
-{
-    int i;
-    int orig_pid_cnt = ts->pid_cnt;
-    for (i=0; i<ts->pid_cnt; i++)
-    {
-        if (!ts->pids[ts->pmt_pids[i]])
-        {
-            mpegts_remove_stream(ts, ts->pmt_pids[i]);
-            i--;
-        }
-    }
-    if (orig_pid_cnt != ts->pid_cnt)
-    {
-        av_log(NULL, AV_LOG_DEBUG,
-               "mpegts_cleanup_streams: pid_cnt bfr %d aft %d\n",
-               orig_pid_cnt, ts->pid_cnt);
-    }
-}
-
 static AVStream *new_section_av_stream(SectionContext *sect, enum AVMediaType type,
                                        enum AVCodecID id)
 {
@@ -2487,6 +2385,106 @@ static void mpegts_remove_stream(MpegTSContext *ts, int pid)
     else
     {
         av_log(NULL, AV_LOG_DEBUG, "ERROR: closing filter for pid 0x%x, indx = %i\n", pid, indx);
+    }
+}
+
+/**
+ * @brief Remove a stream from a media stream.
+ *
+ * This is used by mpegts, so we can track streams as indicated by the PMT.
+ *
+ * @param s MPEG media stream handle
+ * @param id stream id of stream to remove
+ * @param remove_ts if true, remove any matching MPEG-TS filter as well
+ */
+static void av_mpegts_remove_stream(AVFormatContext *s, int id) {
+    int i;
+    int changes = 0;
+
+    for (i=0; i<s->nb_streams; i++) {
+        AVCodecContext *codec_ctx;
+        if (s->streams[i]->id != id)
+            continue;
+
+        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream 0x%x\n", id);
+
+#if FF_API_LAVF_AVCTX
+FF_DISABLE_DEPRECATION_WARNINGS
+        /* close codec context */
+        codec_ctx = s->streams[i]->codec;
+        if (codec_ctx->codec) {
+            avcodec_close(codec_ctx);
+            av_free(codec_ctx);
+        }
+FF_ENABLE_DEPRECATION_WARNINGS
+#endif
+#if 0
+        /* make sure format context is not using the codec context */
+        if (&s->streams[i] == s->cur_st) {
+            av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st = NULL\n");
+            s->cur_st = NULL;
+        }
+     /*   else if (s->cur_st > &s->streams[i]) {
+            av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st -= 1\n");
+            s->cur_st -= sizeof(AVFormatContext *);
+        } */
+        else {
+            av_log(NULL, AV_LOG_DEBUG,
+                   "av_mpegts_remove_stream: no change to cur_st\n");
+        }
+#endif
+
+        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: removing... "
+               "s->nb_streams=%d i=%d\n", s->nb_streams, i);
+        /* actually remove av stream */
+        s->nb_streams--;
+        if ((s->nb_streams - i) > 0) {
+            memmove(&s->streams[i], &s->streams[i+1],
+                    (s->nb_streams-i)*sizeof(AVFormatContext *));
+        }
+        else
+            s->streams[i] = NULL;
+
+        /* remove ts filter if remove ts is true and
+         * the format decoder is the "mpegts" decoder
+         */
+        if (s->iformat && s->priv_data &&
+            (0 == strncmp(s->iformat->name, "mpegts", 6))) {
+            av_log(NULL, AV_LOG_DEBUG,
+                   "av_mpegts_remove_stream: mpegts_remove_stream\n");
+            mpegts_remove_stream((MpegTSContext*) s->priv_data, id);
+        }
+        changes = 1;
+    }
+    if (changes)
+    {
+        // flush queued packets after a stream change (might need to make smarter)
+        mythtv_flush_packet_queue(s);
+
+        /* renumber the streams */
+        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: renumbering streams\n");
+        for (i=0; i<s->nb_streams; i++)
+            s->streams[i]->index=i;
+    }
+}
+
+static void mpegts_cleanup_streams(MpegTSContext *ts)
+{
+    int i;
+    int orig_pid_cnt = ts->pid_cnt;
+    for (i=0; i<ts->pid_cnt; i++)
+    {
+        if (!ts->pids[ts->pmt_pids[i]])
+        {
+            mpegts_remove_stream(ts, ts->pmt_pids[i]);
+            i--;
+        }
+    }
+    if (orig_pid_cnt != ts->pid_cnt)
+    {
+        av_log(NULL, AV_LOG_DEBUG,
+               "mpegts_cleanup_streams: pid_cnt bfr %d aft %d\n",
+               orig_pid_cnt, ts->pid_cnt);
     }
 }
 

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -46,18 +46,6 @@
 
 // MythTV only -----------------------------------------------------------------
 
-/**
- * av_dlog macros
- * copied from libavutil/log.h since they are deprecated and removed from there
- * Useful to print debug messages that shouldn't get compiled in normally.
- */
-
-#ifdef DEBUG
-#    define av_dlog(pctx, ...) av_log(pctx, AV_LOG_DEBUG, __VA_ARGS__)
-#else
-#    define av_dlog(pctx, ...) do { if (0) av_log(pctx, AV_LOG_DEBUG, __VA_ARGS__); } while (0)
-#endif
-
 #define PMT_NOT_YET_FOUND 0
 #define PMT_NOT_IN_PAT    1
 #define PMT_FOUND         2
@@ -2151,7 +2139,7 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, pmt_entry_t *item, int stream
         break;
 #else
         dvbci->codec_tag = bytestream_get_le32(pp);
-        av_dlog(fc, "reg_desc=%.4s\n", (char*)&dvbci->codec_tag);
+        av_log(fc, AV_LOG_TRACE, "reg_desc=%.4s\n", (char*)&dvbci->codec_tag);
         if (item->codec_id == AV_CODEC_ID_NONE &&
             stream_type == STREAM_TYPE_PRIVATE_DATA)
             mpegts_find_stream_type_pmt(item, dvbci->codec_tag, REGD_types);

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -3888,6 +3888,8 @@ static void mpegts_free(MpegTSContext *ts)
     for (i = 0; i < NB_PID_MAX; i++)
         if (ts->pids[i])
             mpegts_close_filter(ts, ts->pids[i]);
+
+    av_buffer_unref(&ts->stream->pmt_section); // MythTV
 }
 
 static int mpegts_read_close(AVFormatContext *s)

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2418,21 +2418,6 @@ FF_DISABLE_DEPRECATION_WARNINGS
         }
 FF_ENABLE_DEPRECATION_WARNINGS
 #endif
-#if 0
-        /* make sure format context is not using the codec context */
-        if (&s->streams[i] == s->cur_st) {
-            av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st = NULL\n");
-            s->cur_st = NULL;
-        }
-     /*   else if (s->cur_st > &s->streams[i]) {
-            av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream cur_st -= 1\n");
-            s->cur_st -= sizeof(AVFormatContext *);
-        } */
-        else {
-            av_log(NULL, AV_LOG_DEBUG,
-                   "av_mpegts_remove_stream: no change to cur_st\n");
-        }
-#endif
 
         av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: removing... "
                "s->nb_streams=%d i=%d\n", s->nb_streams, i);

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2658,7 +2658,7 @@ static void mpegts_push_section(MpegTSFilter *filter, const uint8_t *section, in
     if (sect->new_packet && pkt && sect->st && pkt->size == -1) {
         int pktLen = section_len + 184; /* Add enough for a complete TS payload. */
         sect->new_packet = 0;
-        av_free_packet(pkt);
+        av_packet_unref(pkt);
         if (av_new_packet(pkt, pktLen) == 0) {
             memcpy(pkt->data, section, section_len);
             memset(pkt->data+section_len, 0xff, pktLen-section_len);

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -3109,6 +3109,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
             mpegts_add_stream(ts, h->id, &items[idx], prog_reg_desc, pcr_pid);
 
         /* cache pmt */
+        av_log(ts->stream, AV_LOG_TRACE, "exporting PMT\n");
         export_pmt(avctx, section, section_len);
 
         /* notify stream_changed listeners */

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -576,8 +576,6 @@ static MpegTSFilter *mpegts_open_filter(MpegTSContext *ts, unsigned int pid,
     return filter;
 }
 
-static void mpegts_close_filter(MpegTSContext *ts, MpegTSFilter *filter);
-
 static MpegTSFilter *mpegts_open_section_filter(MpegTSContext *ts,
                                                 unsigned int pid,
                                                 SectionCallback *section_cb,
@@ -587,12 +585,6 @@ static MpegTSFilter *mpegts_open_section_filter(MpegTSContext *ts,
     MpegTSFilter *filter;
     MpegTSSectionFilter *sec;
     uint8_t *section_buf = av_mallocz(MAX_SECTION_SIZE);
-
-    // MythTV from PMT tracking in ffmpeg patch from danielk. https://github.com/MythTV/mythtv/commit/236872aa4dc73c45f01d71f749eb50eaf7eb12e4
-    if (filter = ts->pids[pid]) {
-        mpegts_close_filter(ts, filter);
-    }
-    // end MythTV
 
     if (!section_buf)
         return NULL;

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2634,6 +2634,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     av_log(ts->stream, AV_LOG_TRACE, "sid=0x%x sec_num=%d/%d version=%d tid=%d\n",
             h->id, h->sec_num, h->last_sec_num, h->version, h->tid);
 
+    // begin MythTV
     /* if we require a specific PMT, and this isn't it return silently */
     if (ts->req_sid >= 0 && h->id != ts->req_sid)
     {
@@ -2641,6 +2642,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
                ts->req_sid, h->id);
          return;
     }
+    // end MythTV
 
     if (!ts->scan_all_pmts && ts->skip_changes)
         return;
@@ -2762,6 +2764,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         desc_count++;
     }
 
+    // begin MythTV
     /* if the pmt has changed delete old streams,
      * create new ones, and notify any listener.
      */
@@ -2806,6 +2809,10 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         ts->pmt_scan_state = PMT_FOUND;
         ts->stop_parse = 1;
     }
+    // end MythTV
+
+    if (!ts->pids[pcr_pid])
+        mpegts_open_pcr_filter(ts, pcr_pid);
 
 out:
     for (i = 0; i < mp4_descr_count; i++)

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2557,22 +2557,23 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
                               uint32_t prog_reg_desc, int pcr_pid)
 {
     AVStream *st = NULL;
-    int pid = item->pid;
+    const int pid         = item->pid;
+    const int stream_type = item->type;
 
     av_log(ts, AV_LOG_DEBUG,
-           "mpegts_add_stream: at pid 0x%x with type %i\n", item->pid, item->type);
+           "mpegts_add_stream: at pid 0x%x with type %i\n", pid, stream_type);
 
     if (ts->pid_cnt < PMT_PIDS_MAX)
     {
-        if (item->type == STREAM_TYPE_DSMCC_B)
+        if (stream_type == STREAM_TYPE_DSMCC_B)
         {
             SectionContext *sect = NULL;
-            sect = add_section_stream(ts, item->pid, item->type);
+            sect = add_section_stream(ts, pid, stream_type);
             if (!sect)
             {
                 av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                        "error creating Section context for pid 0x%x with type %i\n",
-                       item->pid, item->type);
+                       pid, stream_type);
                 return;
             }
 
@@ -2581,7 +2582,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
             {
                 av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                        "error creating A/V stream for pid 0x%x with type %i\n",
-                       item->pid, item->type);
+                       pid, stream_type);
                 return;
             }
 
@@ -2589,7 +2590,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
             st->data_id  = item->dvbci.data_id;
             st->carousel_id = item->dvbci.carousel_id;
 
-            ts->pmt_pids[ts->pid_cnt] = item->pid;
+            ts->pmt_pids[ts->pid_cnt] = pid;
             ts->pid_cnt++;
 
             av_log(ts, AV_LOG_DEBUG, "mpegts_add_stream: "
@@ -2618,7 +2619,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
                 {
                     av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                            "error creating PES context for pid 0x%x with type %i\n",
-                           item->pid, item->type);
+                           pid, stream_type);
                     return;
                 }
             }
@@ -2627,16 +2628,16 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
             {
                 av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                        "error creating A/V stream for pid 0x%x with type %i\n",
-                       item->pid, item->type);
+                       pid, stream_type);
                 return;
             }
 
             if (!pes->stream_type)
-                mpegts_set_stream_info(st, pes, item->type, prog_reg_desc);
+                mpegts_set_stream_info(st, pes, stream_type, prog_reg_desc);
 
             st->codecpar->codec_tag = item->dvbci.codec_tag;
 
-            if (prog_reg_desc == AV_RL32("HDMV") && item->type == 0x83 && pes->sub_st) {
+            if (prog_reg_desc == AV_RL32("HDMV") && stream_type == 0x83 && pes->sub_st) {
                 av_program_add_stream_index(ts->stream, id, pes->sub_st->index);
                 pes->sub_st->codecpar->codec_tag = st->codecpar->codec_tag;
             }
@@ -2647,7 +2648,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
                 st->codecpar->codec_id   = item->codec_id;
             }
 
-            ts->pmt_pids[ts->pid_cnt] = item->pid;
+            ts->pmt_pids[ts->pid_cnt] = pid;
             ts->pid_cnt++;
 
             if (item->dvbci.language[0])
@@ -2674,7 +2675,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
     {
         av_log(ts, AV_LOG_ERROR,
                "ERROR: adding pes stream at pid 0x%x, pid_cnt = %i\n",
-               item->pid, ts->pid_cnt);
+               pid, ts->pid_cnt);
     }
 }
 

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2503,7 +2503,7 @@ static AVStream *new_section_av_stream(SectionContext *sect, enum AVMediaType ty
 {
     sect->st = avformat_new_stream(sect->stream, NULL);
     if (!(sect->st)) {
-        av_log(NULL, AV_LOG_ERROR, "Cannot allocate memory.\n");
+        av_log(sect->ts, AV_LOG_ERROR, "Cannot allocate memory.\n");
         return NULL;
     }
 
@@ -2536,7 +2536,7 @@ static SectionContext *add_section_stream(MpegTSContext *ts, int pid, int stream
 
     /* create a SECTION context */
     if (!(sect=av_mallocz(sizeof(SectionContext)))) {
-        av_log(NULL, AV_LOG_ERROR, "Error: av_mallocz() failed in add_section_stream");
+        av_log(ts, AV_LOG_ERROR, "Error: av_mallocz() failed in add_section_stream");
         return 0;
     }
     sect->ts = ts;
@@ -2546,7 +2546,7 @@ static SectionContext *add_section_stream(MpegTSContext *ts, int pid, int stream
     tss = mpegts_open_section_filter(ts, pid, mpegts_push_section, sect, 1);
     if (!tss) {
         av_free(sect);
-        av_log(NULL, AV_LOG_ERROR, "Error: unable to open mpegts Section filter in add_section_stream");
+        av_log(ts, AV_LOG_ERROR, "Error: unable to open mpegts Section filter in add_section_stream");
         return 0;
     }
 
@@ -2559,7 +2559,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
     AVStream *st = NULL;
     int pid = item->pid;
 
-    av_log(NULL, AV_LOG_DEBUG,
+    av_log(ts, AV_LOG_DEBUG,
            "mpegts_add_stream: at pid 0x%x with type %i\n", item->pid, item->type);
 
     if (ts->pid_cnt < PMT_PIDS_MAX)
@@ -2570,7 +2570,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
             sect = add_section_stream(ts, item->pid, item->type);
             if (!sect)
             {
-                av_log(NULL, AV_LOG_ERROR, "mpegts_add_stream: "
+                av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                        "error creating Section context for pid 0x%x with type %i\n",
                        item->pid, item->type);
                 return;
@@ -2579,7 +2579,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
             st = new_section_av_stream(sect, item->codec_type, item->codec_id);
             if (!st)
             {
-                av_log(NULL, AV_LOG_ERROR, "mpegts_add_stream: "
+                av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                        "error creating A/V stream for pid 0x%x with type %i\n",
                        item->pid, item->type);
                 return;
@@ -2592,7 +2592,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
             ts->pmt_pids[ts->pid_cnt] = item->pid;
             ts->pid_cnt++;
 
-            av_log(NULL, AV_LOG_DEBUG, "mpegts_add_stream: "
+            av_log(ts, AV_LOG_DEBUG, "mpegts_add_stream: "
                    "stream #%d, has id 0x%x and codec %s, type %s at 0x%p\n",
                    st->index, st->id, avcodec_get_name(st->codecpar->codec_id),
                    av_get_media_type_string(st->codecpar->codec_type), st);
@@ -2616,7 +2616,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
                 }
                 else
                 {
-                    av_log(NULL, AV_LOG_ERROR, "mpegts_add_stream: "
+                    av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                            "error creating PES context for pid 0x%x with type %i\n",
                            item->pid, item->type);
                     return;
@@ -2625,7 +2625,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
 
             if (!st)
             {
-                av_log(NULL, AV_LOG_ERROR, "mpegts_add_stream: "
+                av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "
                        "error creating A/V stream for pid 0x%x with type %i\n",
                        item->pid, item->type);
                 return;
@@ -2659,7 +2659,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
             st->component_tag = item->dvbci.component_tag;
             st->disposition   = item->dvbci.disposition;
 
-            av_log(NULL, AV_LOG_DEBUG, "mpegts_add_stream: "
+            av_log(ts, AV_LOG_DEBUG, "mpegts_add_stream: "
                    "stream #%d, has id 0x%x and codec %s, type %s at 0x%p\n",
                    st->index, st->id, avcodec_get_name(st->codecpar->codec_id),
                    av_get_media_type_string(st->codecpar->codec_type), st);
@@ -2672,7 +2672,7 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
     }
     else
     {
-        av_log(NULL, AV_LOG_ERROR,
+        av_log(ts, AV_LOG_ERROR,
                "ERROR: adding pes stream at pid 0x%x, pid_cnt = %i\n",
                item->pid, ts->pid_cnt);
     }
@@ -2681,10 +2681,10 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
 static void mpegts_remove_stream(MpegTSContext *ts, int pid)
 {
     int indx = -1;
-    av_log(NULL, AV_LOG_DEBUG, "mpegts_remove_stream 0x%x\n", pid);
+    av_log(ts, AV_LOG_DEBUG, "mpegts_remove_stream 0x%x\n", pid);
     if (ts->pids[pid])
     {
-        av_log(NULL, AV_LOG_DEBUG, "closing filter for pid 0x%x\n", pid);
+        av_log(ts, AV_LOG_DEBUG, "closing filter for pid 0x%x\n", pid);
         mpegts_close_filter(ts, ts->pids[pid]);
     }
     indx = find_in_list(ts->pmt_pids, pid);
@@ -2696,7 +2696,7 @@ static void mpegts_remove_stream(MpegTSContext *ts, int pid)
     }
     else
     {
-        av_log(NULL, AV_LOG_DEBUG, "ERROR: closing filter for pid 0x%x, indx = %i\n", pid, indx);
+        av_log(ts, AV_LOG_DEBUG, "ERROR: closing filter for pid 0x%x, indx = %i\n", pid, indx);
     }
 }
 
@@ -2718,7 +2718,7 @@ static void av_mpegts_remove_stream(AVFormatContext *s, int id) {
         if (s->streams[i]->id != id)
             continue;
 
-        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream 0x%x\n", id);
+        av_log(s, AV_LOG_DEBUG, "av_mpegts_remove_stream 0x%x\n", id);
 
 #if FF_API_LAVF_AVCTX
 FF_DISABLE_DEPRECATION_WARNINGS
@@ -2731,7 +2731,7 @@ FF_DISABLE_DEPRECATION_WARNINGS
 FF_ENABLE_DEPRECATION_WARNINGS
 #endif
 
-        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: removing... "
+        av_log(s, AV_LOG_DEBUG, "av_mpegts_remove_stream: removing... "
                "s->nb_streams=%d i=%d\n", s->nb_streams, i);
         /* actually remove av stream */
         s->nb_streams--;
@@ -2747,7 +2747,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
          */
         if (s->iformat && s->priv_data &&
             (0 == strncmp(s->iformat->name, "mpegts", 6))) {
-            av_log(NULL, AV_LOG_DEBUG,
+            av_log(s, AV_LOG_DEBUG,
                    "av_mpegts_remove_stream: mpegts_remove_stream\n");
             mpegts_remove_stream((MpegTSContext*) s->priv_data, id);
         }
@@ -2759,7 +2759,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
         mythtv_flush_packet_queue(s);
 
         /* renumber the streams */
-        av_log(NULL, AV_LOG_DEBUG, "av_mpegts_remove_stream: renumbering streams\n");
+        av_log(s, AV_LOG_DEBUG, "av_mpegts_remove_stream: renumbering streams\n");
         for (i=0; i<s->nb_streams; i++)
             s->streams[i]->index=i;
     }
@@ -2779,7 +2779,7 @@ static void mpegts_cleanup_streams(MpegTSContext *ts)
     }
     if (orig_pid_cnt != ts->pid_cnt)
     {
-        av_log(NULL, AV_LOG_DEBUG,
+        av_log(ts, AV_LOG_DEBUG,
                "mpegts_cleanup_streams: pid_cnt bfr %d aft %d\n",
                orig_pid_cnt, ts->pid_cnt);
     }
@@ -2801,7 +2801,7 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
         if (loc < 0)
         {
 #ifdef DEBUG
-            av_log(NULL, AV_LOG_DEBUG,
+            av_log(mpegts_ctx, AV_LOG_DEBUG,
                    "find_in_list(..,[%d].pid=%d) => -1\n",
                    idx, items[idx].pid);
 #endif
@@ -2813,7 +2813,7 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
         if (!tss)
         {
 #ifdef DEBUG
-            av_log(NULL, AV_LOG_DEBUG,
+            av_log(mpegts_ctx, AV_LOG_DEBUG,
                    "mpegts_ctx->pids[items[%d].pid=%d] => null\n",
                    idx, items[idx].pid);
 #endif
@@ -2825,14 +2825,14 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
             if (!pes)
             {
 #ifdef DEBUG
-                av_log(NULL, AV_LOG_DEBUG, "pes == null, where idx %d\n", idx);
+                av_log(mpegts_ctx, AV_LOG_DEBUG, "pes == null, where idx %d\n", idx);
 #endif
                 break;
             }
             if (pes->stream_type != items[idx].type)
             {
 #ifdef DEBUG
-                av_log(NULL, AV_LOG_DEBUG,
+                av_log(mpegts_ctx, AV_LOG_DEBUG,
                        "pes->stream_type != items[%d].type\n", idx);
 #endif
                 break;
@@ -2844,14 +2844,14 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
             if (!sect)
             {
 #ifdef DEBUG
-                av_log(NULL, AV_LOG_DEBUG, "sect == null, where idx %d\n", idx);
+                av_log(mpegts_ctx, AV_LOG_DEBUG, "sect == null, where idx %d\n", idx);
 #endif
                 break;
             }
             if (sect->stream_type != items[idx].type)
             {
 #ifdef DEBUG
-                av_log(NULL, AV_LOG_DEBUG,
+                av_log(mpegts_ctx, AV_LOG_DEBUG,
                        "sect->stream_type != items[%d].type\n", idx);
 #endif
                 break;
@@ -2860,14 +2860,14 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
         else
         {
 #ifdef DEBUG
-            av_log(NULL, AV_LOG_DEBUG,
+            av_log(mpegts_ctx, AV_LOG_DEBUG,
                    "tss->type != MPEGTS_PES, where idx %d\n", idx);
 #endif
             break;
         }
     }
 #ifdef DEBUG
-    av_log(NULL, AV_LOG_DEBUG, "pmt_equal_streams:%d old:%d new:%d limit:%d\n",
+    av_log(mpegts_ctx, AV_LOG_DEBUG, "pmt_equal_streams:%d old:%d new:%d limit:%d\n",
         idx, mpegts_ctx->pid_cnt, item_cnt, limit);
 #endif
     return idx;
@@ -3034,7 +3034,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
 
         /* break if we are out of space. */
         if (last_item >= PMT_PIDS_MAX) {
-            av_log(NULL, AV_LOG_DEBUG,
+            av_log(ts->stream, AV_LOG_DEBUG,
                    "Could not add new pid 0x%x, i = %i, "
                    "would cause overrun\n", pid, last_item);
             assert(0);
@@ -3103,7 +3103,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         /* notify stream_changed listeners */
         if (avctx->streams_changed)
         {
-            av_log(NULL, AV_LOG_DEBUG, "streams_changed()\n");
+            av_log(ts->stream, AV_LOG_DEBUG, "streams_changed()\n");
             avctx->streams_changed(avctx->stream_change_data);
         }
     }
@@ -3156,7 +3156,7 @@ static void mpegts_push_section(MpegTSFilter *filter, const uint8_t *section, in
 
     if (parse_section_header(&header, &p, p_end) < 0)
     {
-        av_log(NULL, AV_LOG_DEBUG, "Unable to parse header\n");
+        av_log(ts, AV_LOG_DEBUG, "Unable to parse header\n");
         return;
     }
 
@@ -3182,7 +3182,7 @@ static void mpegts_push_section(MpegTSFilter *filter, const uint8_t *section, in
             } /* Otherwise we've got filler. */
         }
         if (space < section_len) {
-            av_log(NULL, AV_LOG_DEBUG, "Insufficient space for additional packet\n");
+            av_log(ts, AV_LOG_DEBUG, "Insufficient space for additional packet\n");
             return;
         }
         memcpy(data, section, section_len);
@@ -3259,7 +3259,7 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
 
         if (pmt_pids[i] == 0x0)
         {
-            av_log(NULL, AV_LOG_ERROR, "Invalid PAT ignored "
+            av_log(ts->stream, AV_LOG_ERROR, "Invalid PAT ignored "
                    "MPEG Program Number=0x%x pid=0x%x req_sid=0x%x\n",
                    pmt_pnums[i], pmt_pids[i], ts->req_sid);
             return;
@@ -3271,9 +3271,8 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
 
     if (!is_pat_same(ts, pmt_pnums, pmt_pids, pmt_count))
     {
-#ifdef DEBUG
-        av_log(NULL, AV_LOG_DEBUG, "New PAT!\n");
-#endif
+        av_log(ts->stream, AV_LOG_TRACE, "New PAT!\n");
+
         /* if there were services, get rid of them */
         ts->nb_prg = 0;
 
@@ -3905,7 +3904,7 @@ static int mpegts_read_header(AVFormatContext *s)
             if (ts->pids[ts->req_sid] &&
                 (ts->pmt_scan_state == PMT_NOT_YET_FOUND))
             {
-                av_log(NULL, AV_LOG_ERROR,
+                av_log(ts->stream, AV_LOG_ERROR,
                        "Tuning to pnum: 0x%x without CRC check on PMT\n",
                        ts->prg[i].id);
                 /* turn off crc checking */
@@ -3921,7 +3920,7 @@ static int mpegts_read_header(AVFormatContext *s)
             if (ts->pids[ts->req_sid] &&
                 (ts->pmt_scan_state == PMT_NOT_YET_FOUND))
             {
-                av_log(NULL, AV_LOG_ERROR,
+                av_log(ts->stream, AV_LOG_ERROR,
                        "Overriding PMT data length, using "
                        "contents of first TS packet only!\n");
                 ts->pids[ts->req_sid]->pmt_chop_at_ts = 1;
@@ -3936,7 +3935,7 @@ static int mpegts_read_header(AVFormatContext *s)
         /* if we could not find any PMTs, fail */
         if (ts->pmt_scan_state == PMT_NOT_YET_FOUND)
         {
-            av_log(NULL, AV_LOG_ERROR,
+            av_log(ts->stream, AV_LOG_ERROR,
                    "mpegts_read_header: could not find any PMT's\n");
             return -1;
         }

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -45,17 +45,6 @@
 #endif
 
 // MythTV only -----------------------------------------------------------------
-/* from APIchanges:
-2011-10-19 - d049257 / 569129a - lavf 53.17.0 / 53.10.0
-  Add avformat_new_stream(). Deprecate av_new_stream().
-*/
-static AVStream *av_new_stream(AVFormatContext *s, int id)
-{
-    AVStream *st = avformat_new_stream(s, NULL);
-    if (st)
-        st->id = id;
-    return st;
-}
 
 /**
  * av_dlog macros
@@ -2638,7 +2627,8 @@ static AVStream *new_section_av_stream(SectionContext *sect, enum AVMediaType ty
 {
     FF_ALLOCZ_OR_GOTO(NULL, sect->st, sizeof(AVStream), fail);
 
-    sect->st = av_new_stream(sect->stream, sect->pid);
+    sect->st = avformat_new_stream(sect->stream, NULL);
+    sect->st->id = sect->pid;
 
     avpriv_set_pts_info(sect->st, 33, 1, 90000);
 
@@ -2791,7 +2781,11 @@ static void mpegts_add_stream(MpegTSContext *ts, int id, pmt_entry_t* item,
                 }
                 pes = add_pes_stream(ts, pid, pcr_pid);
                 if (pes)
-                    st = av_new_stream(pes->stream, pes->pid);
+                {
+                    st = avformat_new_stream(pes->stream, NULL);
+                    if (st)
+                        st->id = pes->pid;
+                }
                 else
                 {
                     av_log(NULL, AV_LOG_ERROR, "mpegts_add_stream: "

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2930,8 +2930,6 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     AVProgram *program;
 
     // MythTV added
-    char buf[256];
-
     int pmt_pnums[PAT_MAX_PMT];
     int pmt_pids[PAT_MAX_PMT];
     unsigned int pmt_count = 0;
@@ -2997,7 +2995,6 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         /* if there are new services, add them */
         for (i = 0; i < pmt_count; ++i)
         {
-            snprintf(buf, sizeof(buf), "MPEG Program %x", pmt_pnums[i]);
             add_pat_entry(ts, pmt_pnums[i], pmt_pids[i]);
         }
     }

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2614,13 +2614,12 @@ static void mpegts_cleanup_streams(MpegTSContext *ts)
 static AVStream *new_section_av_stream(SectionContext *sect, enum AVMediaType type,
                                        enum AVCodecID id)
 {
-    sect->st = av_mallocz(sizeof(AVStream));
-    if (!(sect->st) && (sizeof(AVStream)) != 0) {
+    sect->st = avformat_new_stream(sect->stream, NULL);
+    if (!(sect->st)) {
         av_log(NULL, AV_LOG_ERROR, "Cannot allocate memory.\n");
         return NULL;
     }
 
-    sect->st = avformat_new_stream(sect->stream, NULL);
     sect->st->id = sect->pid;
 
     avpriv_set_pts_info(sect->st, 33, 1, 90000);

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -440,7 +440,7 @@ typedef struct PESContext {
 
 extern AVInputFormat ff_mythtv_mpegts_demuxer;
 
-static void clear_program(MpegTSContext *ts, unsigned int programid)
+static void clear_program_pid(MpegTSContext *ts, unsigned int programid)
 {
     int i;
 
@@ -2248,7 +2248,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
          return;
     }
 
-    clear_program(ts, h->id);
+    clear_program_pid(ts, h->id);
     pcr_pid = get16(&p, p_end);
     if (pcr_pid < 0)
         return;

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -3071,9 +3071,8 @@ static int mpegts_probe(const AVProbeData *p)
 }
 
 /* return the 90kHz PCR and the extension for the 27MHz PCR. return
-   (-1) if not available */
-static int parse_pcr(int64_t *ppcr_high, int *ppcr_low,
-                     const uint8_t *packet)
+ * (-1) if not available */
+static int parse_pcr(int64_t *ppcr_high, int *ppcr_low, const uint8_t *packet)
 {
     int afc, len, flags;
     const uint8_t *p;
@@ -3081,21 +3080,21 @@ static int parse_pcr(int64_t *ppcr_high, int *ppcr_low,
 
     afc = (packet[3] >> 4) & 3;
     if (afc <= 1)
-        return -1;
-    p = packet + 4;
+        return AVERROR_INVALIDDATA;
+    p   = packet + 4;
     len = p[0];
     p++;
     if (len == 0)
-        return -1;
+        return AVERROR_INVALIDDATA;
     flags = *p++;
     len--;
     if (!(flags & 0x10))
-        return -1;
+        return AVERROR_INVALIDDATA;
     if (len < 6)
-        return -1;
-    v = AV_RB32(p);
-    *ppcr_high = ((int64_t)v << 1) | (p[4] >> 7);
-    *ppcr_low = ((p[4] & 1) << 8) | p[5];
+        return AVERROR_INVALIDDATA;
+    v          = AV_RB32(p);
+    *ppcr_high = ((int64_t) v << 1) | (p[4] >> 7);
+    *ppcr_low  = ((p[4] & 1) << 8) | p[5];
     return 0;
 }
 

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2800,11 +2800,9 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
         int loc = find_in_list(mpegts_ctx->pmt_pids, items[idx].pid);
         if (loc < 0)
         {
-#ifdef DEBUG
-            av_log(mpegts_ctx, AV_LOG_DEBUG,
+            av_log(mpegts_ctx, AV_LOG_TRACE,
                    "find_in_list(..,[%d].pid=%d) => -1\n",
                    idx, items[idx].pid);
-#endif
             break;
         }
 
@@ -2812,11 +2810,9 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
         tss = mpegts_ctx->pids[items[idx].pid];
         if (!tss)
         {
-#ifdef DEBUG
-            av_log(mpegts_ctx, AV_LOG_DEBUG,
+            av_log(mpegts_ctx, AV_LOG_TRACE,
                    "mpegts_ctx->pids[items[%d].pid=%d] => null\n",
                    idx, items[idx].pid);
-#endif
             break;
         }
         if (tss->type == MPEGTS_PES)
@@ -2824,17 +2820,13 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
             PESContext *pes = (PESContext*) tss->u.pes_filter.opaque;
             if (!pes)
             {
-#ifdef DEBUG
-                av_log(mpegts_ctx, AV_LOG_DEBUG, "pes == null, where idx %d\n", idx);
-#endif
+                av_log(mpegts_ctx, AV_LOG_TRACE, "pes == null, where idx %d\n", idx);
                 break;
             }
             if (pes->stream_type != items[idx].type)
             {
-#ifdef DEBUG
-                av_log(mpegts_ctx, AV_LOG_DEBUG,
+                av_log(mpegts_ctx, AV_LOG_TRACE,
                        "pes->stream_type != items[%d].type\n", idx);
-#endif
                 break;
             }
         }
@@ -2843,33 +2835,25 @@ static int pmt_equal_streams(MpegTSContext *mpegts_ctx,
             SectionContext *sect = (SectionContext*) tss->u.section_filter.opaque;
             if (!sect)
             {
-#ifdef DEBUG
-                av_log(mpegts_ctx, AV_LOG_DEBUG, "sect == null, where idx %d\n", idx);
-#endif
+                av_log(mpegts_ctx, AV_LOG_TRACE, "sect == null, where idx %d\n", idx);
                 break;
             }
             if (sect->stream_type != items[idx].type)
             {
-#ifdef DEBUG
-                av_log(mpegts_ctx, AV_LOG_DEBUG,
+                av_log(mpegts_ctx, AV_LOG_TRACE,
                        "sect->stream_type != items[%d].type\n", idx);
-#endif
                 break;
             }
         }
         else
         {
-#ifdef DEBUG
-            av_log(mpegts_ctx, AV_LOG_DEBUG,
+            av_log(mpegts_ctx, AV_LOG_TRACE,
                    "tss->type != MPEGTS_PES, where idx %d\n", idx);
-#endif
             break;
         }
     }
-#ifdef DEBUG
-    av_log(mpegts_ctx, AV_LOG_DEBUG, "pmt_equal_streams:%d old:%d new:%d limit:%d\n",
+    av_log(mpegts_ctx, AV_LOG_TRACE, "pmt_equal_streams:%d old:%d new:%d limit:%d\n",
         idx, mpegts_ctx->pid_cnt, item_cnt, limit);
-#endif
     return idx;
 }
 
@@ -3887,10 +3871,8 @@ static int mpegts_read_header(AVFormatContext *s)
         for (int i = 0; ((i < ts->nb_prg) &&
                      (ts->pmt_scan_state == PMT_NOT_YET_FOUND)); i++)
         {
-#ifdef DEBUG
-            av_log(ts->stream, AV_LOG_DEBUG, "Tuning to pnum: 0x%x\n",
+            av_log(ts->stream, AV_LOG_TRACE, "Tuning to pnum: 0x%x\n",
                    ts->prg[i].id);
-#endif
 
             /* now find the info for the first service if we found any,
                otherwise try to filter all PATs */

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2781,7 +2781,14 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
             SectionContext *sect = NULL;
             int idx = -1;
 
-            sect = add_section_stream(ts, pid, stream_type);
+            if (ts->pids[pid] && ts->pids[pid]->type == MPEGTS_SECTION &&
+                ts->pids[pid]->u.section_filter.section_cb == mpegts_push_section) {
+                // u.section_filter.opaque may be the MpegTSContext, so test the section_cb
+                sect = (SectionContext*) ts->pids[pid]->u.section_filter.opaque;
+            }
+            if (!sect) {
+                sect = add_section_stream(ts, pid, stream_type);
+            }
             if (!sect)
             {
                 av_log(ts, AV_LOG_ERROR, "mpegts_add_stream: "

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2478,13 +2478,7 @@ static SectionContext *add_section_stream(MpegTSContext *ts, int pid, int stream
     MpegTSFilter *tss = ts->pids[pid];
     SectionContext *sect = 0;
     if (tss) { /* filter already exists */
-        if (tss->type == MPEGTS_SECTION)
-            sect = (SectionContext*) tss->u.section_filter.opaque;
-
-        if (sect && (sect->stream_type == stream_type))
-            return sect; /* if it's the same stream type, just return ok */
-
-        /* otherwise, kill it, and start a new stream */
+        /* kill it, and start a new stream */
         mpegts_close_filter(ts, tss);
     }
 

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2611,21 +2611,14 @@ static void mpegts_cleanup_streams(MpegTSContext *ts)
     }
 }
 
-// This was previously in libavutil/internal.h
-// Copied here because it is no longer used in the rest of ffmpeg
-#define FF_ALLOCZ_OR_GOTO(ctx, p, size, label)\
-{\
-    p = av_mallocz(size);\
-    if (!(p) && (size) != 0) {\
-        av_log(ctx, AV_LOG_ERROR, "Cannot allocate memory.\n");\
-        goto label;\
-    }\
-}
-
 static AVStream *new_section_av_stream(SectionContext *sect, enum AVMediaType type,
                                        enum AVCodecID id)
 {
-    FF_ALLOCZ_OR_GOTO(NULL, sect->st, sizeof(AVStream), fail);
+    sect->st = av_mallocz(sizeof(AVStream));
+    if (!(sect->st) && (sizeof(AVStream)) != 0) {
+        av_log(NULL, AV_LOG_ERROR, "Cannot allocate memory.\n");
+        return NULL;
+    }
 
     sect->st = avformat_new_stream(sect->stream, NULL);
     sect->st->id = sect->pid;
@@ -2638,8 +2631,6 @@ static AVStream *new_section_av_stream(SectionContext *sect, enum AVMediaType ty
     sect->st->need_parsing = AVSTREAM_PARSE_NONE;
 
     return sect->st;
-fail: /*for the CHECKED_ALLOCZ macro*/
-    return NULL;
 }
 
 /* mpegts_push_section: return one or more tables.  The tables may not completely fill

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2994,9 +2994,8 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
          * add a filter for the PMT. */
         if (ts->req_sid == pmt_pnums[i])
         {
-#ifdef DEBUG
-            av_log(NULL, AV_LOG_DEBUG, "Found program number!\n");
-#endif
+            av_log(ts->stream, AV_LOG_TRACE, "Found program number!\n");
+
             pmt_pid = pmt_pids[i];
             MpegTSFilter *fil = ts->pids[pmt_pid];
             /* close old filter if it doesn't match */
@@ -3018,9 +3017,7 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
      * tell parser it is safe to quit. */
     if (ts->req_sid < 0 && ts->scanning)
     {
-#ifdef DEBUG
-        av_log(NULL, AV_LOG_DEBUG, "Found PAT, ending scan\n");
-#endif
+        av_log(ts->stream, AV_LOG_TRACE, "Found PAT, ending scan\n");
         ts->stop_parse = 1;
     }
 
@@ -3029,10 +3026,8 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
      * and tell parser it is safe to quit. */
     if (ts->req_sid >= 0 && !found)
     {
-#ifdef DEBUG
-        av_log(NULL, AV_LOG_DEBUG, "Program 0x%x is not in PAT, ending scan\n",
+        av_log(ts->stream, AV_LOG_TRACE, "Program 0x%x is not in PAT, ending scan\n",
                ts->req_sid);
-#endif
         ts->pmt_scan_state = PMT_NOT_IN_PAT;
         ts->stop_parse = 1;
     }

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -2672,10 +2672,8 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     /* if we require a specific PMT, and this isn't it return silently */
     if (ts->req_sid >= 0 && h->id != ts->req_sid)
     {
-#ifdef DEBUG
-        av_dlog(ts->stream, "We are looking for program 0x%x, not 0x%x",
+        av_log(ts->stream, AV_LOG_TRACE, "We are looking for program 0x%x, not 0x%x",
                ts->req_sid, h->id);
-#endif
          return;
     }
 
@@ -2687,7 +2685,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     add_pid_to_pmt(ts, h->id, pcr_pid);
     set_pcr_pid(ts->stream, h->id, pcr_pid);
 
-    av_dlog(ts->stream, "pcr_pid=0x%x\n", pcr_pid);
+    av_log(ts->stream, AV_LOG_TRACE, "pcr_pid=0x%x\n", pcr_pid);
 
     program_info_length = get16(&p, p_end);
     if (program_info_length < 0)
@@ -2698,7 +2696,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         tag = get8(&p, p_end);
         len = get8(&p, p_end);
 
-        av_dlog(ts->stream, "program tag: 0x%02x len=%d\n", tag, len);
+        av_log(ts->stream, AV_LOG_TRACE, "program tag: 0x%02x len=%d\n", tag, len);
 
         if(len > program_info_length - 2)
             //something else is broken, exit the program_descriptors_loop

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.h
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.h
@@ -217,32 +217,6 @@ typedef struct DVBAC3Descriptor {
     uint8_t  asvc;
 } DVBAC3Descriptor;
 
-typedef struct
-{
-    char language[4];
-    int comp_page;
-    int anc_page;
-    int sub_id;
-    int txt_type;
-    int vbi_data;
-    int disposition;
-    /* DSMCC data */
-    int data_id;
-    int carousel_id;
-    int component_tag;
-    unsigned int codec_tag;
-} dvb_caption_info_t;
-
-typedef struct
-{
-    int pid;
-    int type;
-    enum AVCodecID       codec_id;
-    enum AVMediaType   codec_type;
-    dvb_caption_info_t dvbci;
-} pmt_entry_t;
-
-
 /**
  * Parse an MPEG-2 descriptor
  * @param[in] fc                    Format context (used for logging only)
@@ -252,10 +226,10 @@ typedef struct
  * @param desc_list_end             End of buffer
  * @return <0 to stop processing
  */
-int ff_parse_mpeg2_descriptor(AVFormatContext *fc, pmt_entry_t *item, int stream_type,
+int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
                               const uint8_t **pp, const uint8_t *desc_list_end,
                               Mp4Descr *mp4_descr, int mp4_descr_count, int pid,
-                              MpegTSContext *ts, dvb_caption_info_t *dvbci);
+                              MpegTSContext *ts);
 
 /**
  * Check presence of H264 startcode


### PR DESCRIPTION
This needs testing with DSMCC/MHEG streams.

The streams_changed callback can be removed if there are no issues.

MythTV only removes audio streams on a DVD title change, so mpegts_remove_stream() and mpegts_cleanup_streams() might be able to be removed also.

See:
https://github.com/MythTV/mythtv/blob/c516faf2e8bc94a7fa95fafcfa88d0a1aa0ab60b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp#L2748-L2768
https://github.com/MythTV/mythtv/blob/c516faf2e8bc94a7fa95fafcfa88d0a1aa0ab60b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp#L2002-L2007


`git diff --no-index --color-moved libavformat/mpegts.c libavformat/mpegts-mythtv.c`
now shows a useful diff.  Now that we can see what the customizations are, I should be possible to eliminate or upstream them, which would likely need samples, however.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

