### PR TITLE
make FlagIsSet() a protected function instead of a MACRO

### DIFF
--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -254,6 +254,8 @@ class AvFormatDecoder : public DecoderBase
 
     virtual int ReadPacket(AVFormatContext *ctx, AVPacket *pkt, bool &storePacket);
 
+    bool FlagIsSet(PlayerFlags arg) { return m_playerFlags & arg; }
+
     bool               m_isDbIgnored;
 
     AVCParser         *m_avcParser                    {nullptr};

--- a/mythtv/libs/libmythtv/mythplayer.h
+++ b/mythtv/libs/libmythtv/mythplayer.h
@@ -77,8 +77,6 @@ enum PlayerFlags
     kMusicChoice          = 0x040000,
 };
 
-#define FlagIsSet(arg) (m_playerFlags & (arg))
-
 // Padding between class members reduced from 113 to 73 bytes, but its
 // still higher than the default warning threshhold of 24 bytes.
 //
@@ -318,6 +316,8 @@ class MTV_PUBLIC MythPlayer : public QObject
     // Edit mode stuff
     bool GetEditMode(void) const { return m_deleteMap.IsEditing(); }
     bool IsInDelete(uint64_t frame);
+
+    bool FlagIsSet(PlayerFlags arg) { return m_playerFlags & arg; }
 
   protected:
     // Private Sets


### PR DESCRIPTION
Doxygen doesn't list uses of MACROs.

