### PR TITLE
replace qBound() with C++17 std::clamp()

### DIFF
--- a/mythtv/libs/libmythbase/platforms/mythpowerdbus.cpp
+++ b/mythtv/libs/libmythbase/platforms/mythpowerdbus.cpp
@@ -4,6 +4,7 @@
 
 // Std
 #include <unistd.h>
+#include <algorithm>
 
 #define LOC QString("PowerDBus: ")
 
@@ -246,7 +247,7 @@ bool MythPowerDBus::UpdateStatus(void)
     // NB we don't care about user preference here. We are giving
     // MythTV interested components an opportunity to cleanup before
     // an externally initiated shutdown/suspend
-    auto delay = qBound(0s, m_maxRequestedDelay, m_maxSupportedDelay);
+    auto delay = std::clamp(m_maxRequestedDelay, 0s, m_maxSupportedDelay);
     LOG(VB_GENERAL, LOG_INFO, LOC + QString("Trying to delay system %1 for %2 seconds")
         .arg(FeatureToString(feature)).arg(delay.count()));
     m_delayTimer.start(delay);

--- a/mythtv/libs/libmythtv/Bluray/mythbdoverlay.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdoverlay.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 // Qt
 #include <QPainter>
 
@@ -31,9 +33,9 @@ void MythBDOverlay::SetPalette(const BD_PG_PALETTE_ENTRY *Palette)
         int cr = Palette[i].Cr;
         int cb = Palette[i].Cb;
         int a  = Palette[i].T;
-        int r  = qBound(0, int(y + 1.4022 * (cr - 128)), 0xff);
-        int b  = qBound(0, int(y + 1.7710 * (cb - 128)), 0xff);
-        int g  = qBound(0, int(1.7047 * y - (0.1952 * b) - (0.5647 * r)), 0xff);
+        int r  = std::clamp(int(y + 1.4022 * (cr - 128)), 0, 0xff);
+        int b  = std::clamp(int(y + 1.7710 * (cb - 128)), 0, 0xff);
+        int g  = std::clamp(int(1.7047 * y - (0.1952 * b) - (0.5647 * r)), 0, 0xff);
         rgbpalette.push_back(static_cast<uint>((a << 24) | (r << 16) | (g << 8) | b));
     }
     m_image.setColorTable(rgbpalette);

--- a/mythtv/libs/libmythtv/DVD/mythdvdbuffer.cpp
+++ b/mythtv/libs/libmythtv/DVD/mythdvdbuffer.cpp
@@ -1991,9 +1991,9 @@ void MythDVDBuffer::GuessPalette(uint32_t *RGBAPalette, const PaletteArray Palet
         uint y  = (yuv >> 16) & 0xff;
         uint cr = (yuv >> 8) & 0xff;
         uint cb = (yuv >> 0) & 0xff;
-        uint r  = qBound(0U, uint(y + 1.4022 * (cr - 128)), 0xFFU);
-        uint b  = qBound(0U, uint(y + 1.7710 * (cb - 128)), 0xFFU);
-        uint g  = qBound(0U, uint(1.7047 * y - (0.1952 * b) - (0.5647 * r)), 0xFFU);
+        uint r  = std::clamp(uint(y + 1.4022 * (cr - 128)), 0U, 0xFFU);
+        uint b  = std::clamp(uint(y + 1.7710 * (cb - 128)), 0U, 0xFFU);
+        uint g  = std::clamp(uint(1.7047 * y - (0.1952 * b) - (0.5647 * r)), 0U, 0xFFU);
         RGBAPalette[i] = ((Alpha[i] * 17U) << 24) | (r << 16 )| (g << 8) | b;
     }
 }

--- a/mythtv/libs/libmythtv/mythvideoprofile.cpp
+++ b/mythtv/libs/libmythtv/mythvideoprofile.cpp
@@ -368,7 +368,7 @@ QString MythVideoProfile::GetUpscaler() const
 
 uint MythVideoProfile::GetMaxCPUs() const
 {
-    return qBound(1U, GetPreference(PREF_CPUS).toUInt(), VIDEO_MAX_CPUS);
+    return std::clamp(GetPreference(PREF_CPUS).toUInt(), 1U, VIDEO_MAX_CPUS);
 }
 
 bool MythVideoProfile::IsSkipLoopEnabled() const
@@ -454,7 +454,7 @@ void MythVideoProfile::LoadBestPreferences(const QSize Size, float Framerate,
     }
     else
     {
-        int threads = qBound(1, QThread::idealThreadCount(), 4);
+        int threads = std::clamp(QThread::idealThreadCount(), 1, 4);
         LOG(VB_PLAYBACK, LOG_INFO, LOC + "No useable profile. Using defaults.");
         SetPreference(PREF_DEC,    "ffmpeg");
         SetPreference(PREF_CPUS,   QString::number(threads));

--- a/mythtv/libs/libmythui/mythdisplay.cpp
+++ b/mythtv/libs/libmythui/mythdisplay.cpp
@@ -1,3 +1,6 @@
+// Std
+#include <algorithm>
+
 //Qt
 #include <QTimer>
 #include <QThread>
@@ -1166,7 +1169,7 @@ void MythDisplay::ConfigureQtGUI(int SwapInterval, const MythCommandLineParser& 
     if (qEnvironmentVariableIsSet("MYTHTV_DEPTH"))
     {
         // Note: Don't set depth and stencil to give Qt as much flexibility as possible
-        int depth = qBound(6, qEnvironmentVariableIntValue("MYTHTV_DEPTH"), 16);
+        int depth = std::clamp(qEnvironmentVariableIntValue("MYTHTV_DEPTH"), 6, 16);
         LOG(VB_GENERAL, LOG_INFO, LOC + QString("Trying to force depth to '%1'").arg(depth));
         format.setRedBufferSize(depth);
     }


### PR DESCRIPTION
std::clamp() is used elsewhere in the codebase and, in my opinion, has a better parameter ordering than qBound.  (std::clamp(val, min, max) vs. qBound(min, val, max))
