### PR TITLE
Fixes/32: Add missing include <array> to mythdate

### DIFF
--- a/mythtv/libs/libmythbase/mythdate.cpp
+++ b/mythtv/libs/libmythbase/mythdate.cpp
@@ -1,6 +1,7 @@
 #include <QtGlobal>
 #include <QCoreApplication>
 #include <QRegularExpression>
+#include <array>
 
 #include "mythcorecontext.h"
 #include "mythdate.h"


### PR DESCRIPTION
Fixes [PR535](https://github.com/MythTV/mythtv/issues/535) on fixes/32

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [fixes/32](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

