### PR TITLE
Corrects escaping of variable reference in configure script

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -6296,7 +6296,7 @@ fi
 
 # add some linker flags
 check_ldflags -Wl,--warn-common
-check_ldflags '-Wl,-rpath-link,\${SRC_PATH_BARE}/external/FFmpeg/libpostproc:\${SRC_PATH_BARE}/external/FFmpeg/libswresample:\${SRC_PATH_BARE}/external/FFmpeg/libswscale:\${SRC_PATH_BARE}/external/FFmpeg/libavfilter:\${SRC_PATH_BARE}/external/FFmpeg/libavdevice:\${SRC_PATH_BARE}/external/FFmpeg/libavformat:\${SRC_PATH_BARE}/external/FFmpeg/libavcodec:\${SRC_PATH_BARE}/external/FFmpeg/libavutil:\${SRC_PATH_BARE}/external/FFmpeg/libavresample'
+check_ldflags '-Wl,-rpath-link,\$\${SRC_PATH_BARE}/external/FFmpeg/libpostproc:\$\${SRC_PATH_BARE}/external/FFmpeg/libswresample:\$\${SRC_PATH_BARE}/external/FFmpeg/libswscale:\$\${SRC_PATH_BARE}/external/FFmpeg/libavfilter:\$\${SRC_PATH_BARE}/external/FFmpeg/libavdevice:\$\${SRC_PATH_BARE}/external/FFmpeg/libavformat:\$\${SRC_PATH_BARE}/external/FFmpeg/libavcodec:\$\${SRC_PATH_BARE}/external/FFmpeg/libavutil:\$\${SRC_PATH_BARE}/external/FFmpeg/libavresample'
 enabled rpath && add_ldexeflags -Wl,-rpath,$libdir
 enabled rpath && add_ldlibflags -Wl,-rpath,$libdir
 test_ldflags -Wl,-Bsymbolic && append SHFLAGS -Wl,-Bsymbolic


### PR DESCRIPTION
Closes issue 549 "Link error building libexiv2 in mythtv 32.0".

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ ] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

