### PR TITLE
mythdate: match type with Qt, preventing potential Y2106 bug

### DIFF
--- a/mythtv/libs/libmythbase/mythdate.cpp
+++ b/mythtv/libs/libmythbase/mythdate.cpp
@@ -70,7 +70,7 @@ MBASE_PUBLIC QDateTime fromString(const QString &str, const QString &format)
  *                  at Jan 1 1970 at 00:00:00.
  *  \return A QDateTime.
  */
-MBASE_PUBLIC QDateTime fromSecsSinceEpoch(uint seconds)
+MBASE_PUBLIC QDateTime fromSecsSinceEpoch(int64_t seconds)
 {
     QDateTime dt = QDateTime::fromSecsSinceEpoch(seconds);
     return dt.toUTC();

--- a/mythtv/libs/libmythbase/mythdate.h
+++ b/mythtv/libs/libmythbase/mythdate.h
@@ -1,6 +1,8 @@
 #ifndef MYTH_DATE_H
 #define MYTH_DATE_H
 
+#include <cstdint>
+
 #include <QDateTime>
 #include <QString>
 
@@ -43,7 +45,7 @@ MBASE_PUBLIC QDateTime as_utc(const QDateTime &dt);
 MBASE_PUBLIC QDateTime fromString(const QString &dtstr);
 /// Converts dy in format to QDateTime
 MBASE_PUBLIC QDateTime fromString(const QString &dt, const QString &format);
-MBASE_PUBLIC QDateTime fromSecsSinceEpoch(uint seconds);
+MBASE_PUBLIC QDateTime fromSecsSinceEpoch(int64_t seconds);
 /// Returns formatted string representing the time.
 MBASE_PUBLIC QString toString(
     const QDateTime &datetime, uint format = MythDate::kDateTimeFull);


### PR DESCRIPTION
This is redone without the inlining from https://github.com/MythTV/mythtv/pull/466

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

