### PR TITLE
create ByteReader to eliminate use of FFmpeg modification

### DIFF
--- a/mythtv/external/FFmpeg/libavcodec/avcodec.h
+++ b/mythtv/external/FFmpeg/libavcodec/avcodec.h
@@ -4184,7 +4184,6 @@ int avcodec_is_open(AVCodecContext *s);
 /* MythTV */
 const char *ff_codec_id_string(enum AVCodecID codec_id);
 const char *ff_codec_type_string(enum AVMediaType codec_type);
-const uint8_t *avpriv_find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state);
 
 
 /**

--- a/mythtv/libs/libmythtv/bytereader.cpp
+++ b/mythtv/libs/libmythtv/bytereader.cpp
@@ -1,0 +1,114 @@
+/*
+ * find_start_code from libavcodec/FFmpeg
+ * Copyright (c) 2022 Scott Theisen
+ *
+ * This file is part of MythTV.  The functions have been adapted to use C++.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "bytereader.h"
+
+extern "C" {
+#include "libavutil/intreadwrite.h"
+#ifndef AV_RB32
+#   define AV_RB32(x)                                \
+    (((uint32_t)((const uint8_t*)(x))[0] << 24) |    \
+               (((const uint8_t*)(x))[1] << 16) |    \
+               (((const uint8_t*)(x))[2] <<  8) |    \
+                ((const uint8_t*)(x))[3])
+#endif
+}
+
+const uint8_t* ByteReader::find_start_code(const uint8_t * p,
+                                           const uint8_t * const end,
+                                           uint32_t * const start_code)
+{
+    // minimum length for a start code
+    if (p + 4 > end)
+    {
+        *start_code = ~0; // set to an invalid start code
+        return end;
+    }
+
+    p += 3; // offset for negative indices in while loop
+
+    /* with memory address increasing left to right, we are looking for (in hexadecimal):
+     * 00 00 01 XX
+     * p points at the address which should have the value of XX
+     */
+    while (p < end)
+    {
+        // UU UU UU
+        if      (p[-1]  > 1)
+        {
+            p += 3;
+            // start check over with 3 new bytes
+        }
+        else if (p[-1] == 0)
+        {
+            p++;
+            // could be in a start code, so check next byte
+        }
+        else if (/* UU UU 01 */ p[-2] != 0 ||
+                 /* UU 00 01 */ p[-3] != 0)
+        {
+            p += 3;
+        }
+        else /* 00 00 01 */
+        {
+            p++;
+            // p now points at the address following the start code value XX
+            break;
+        }
+    }
+
+    if (p > end)
+        p = end;
+    // read the previous 4 bytes, i.e. bytes {p - 4, p - 3, p - 2, p - 1}
+    *start_code = AV_RB32(p - 4);
+    return p;
+}
+
+const uint8_t* ByteReader::find_start_code_truncated(const uint8_t * p,
+                                         const uint8_t * const end,
+                                         uint32_t * const start_code)
+{
+    if (p >= end)
+    {
+        return end;
+    }
+
+    if (*start_code == 0x100)
+    {
+        *start_code = ~0;
+    // invalidate byte 0 so overlapping start codes are not erroneously detected
+    }
+
+    // read up to the first three bytes in p to enable reading a start code across
+    // two (to four) buffers
+    for (int i = 0; i < 3; i++)
+    {
+        *start_code <<= 8;
+        *start_code += *p;
+        p++;
+        if (start_code_is_valid(*start_code) || p == end)
+        {
+            return p;
+        }
+    }
+    // buffer length is at least 4
+    return find_start_code(p - 3, end, start_code);
+}

--- a/mythtv/libs/libmythtv/bytereader.h
+++ b/mythtv/libs/libmythtv/bytereader.h
@@ -1,0 +1,103 @@
+/*
+ * find_start_code from libavcodec/FFmpeg
+ * Copyright (c) 2022 Scott Theisen
+ *
+ * This file is part of MythTV.  The functions have been adapted to use C++.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef BYTEREADER_H
+#define BYTEREADER_H
+
+#include <cstdint>
+
+#include "mythtvexp.h"
+
+/**
+@file
+@ingroup libmythtv
+
+This is in libmythtv because that is where the parsers, which are its main users,
+are.
+*/
+
+/**
+These functions are rewritten copies from FFmpeg's libavcodec, where
+find_start_code() is prefixed with <b>@c avpriv_ </b>.
+*/
+namespace ByteReader
+{
+/**
+ * @brief Test whether a start code found by find_start_code() is valid.
+ *
+ * Use this to test the validity of a start code especially if a start code can
+ * be at the end of the buffer, where testing the return value of find_start_code()
+ * would incorrectly imply that the start code is invalid (since the returned value
+ * equals <b>@c end </b>).
+ *
+ * @param[in] start_code The start code to test.
+ * @return A boolean that is true if and only if <b>@p start_code</b> is valid
+ */
+inline bool start_code_is_valid(uint32_t start_code)
+{
+    return (start_code & 0xFFFFFF00) == 0x100;
+}
+
+/**
+ * @brief Find the first start code in the buffer @p p.
+ *
+ * A start code is a sequence of 4 bytes with the hexadecimal value <b><tt> 00 00 01 XX </tt></b>,
+ * where <b><tt> XX </tt></b> represents any value and memory address increases left to right.
+ *
+ * @param[in] p     A pointer to the start of the memory buffer to scan.
+ * @param[in] end   A pointer to the past-the-end memory address for the buffer
+ *                  given by @p p.  <b>@p p</b> must be ≤ <b>@p end</b>.
+ *
+ * @param[out] start_code A pointer to a mutable @c uint32_t.<br>
+ *             Set to the found start code if it exists or an invalid start code
+ *             (the 4 bytes prior to the returned value or <b>@c ~0 </b> if
+ *             @f$ end - p < 4 @f$).
+ *
+ * @return A pointer to the memory address following the found start code, or <b>@p end</b>
+ *         if no start code was found.
+ */
+MTV_PUBLIC
+const uint8_t* find_start_code(const uint8_t *p,
+                               const uint8_t *end,
+                               uint32_t *start_code);
+
+/**
+ * By preserving the <b>@p start_code</b> value between subsequent calls, the caller can
+ * detect start codes across buffer boundaries.
+ *
+ * @param[in,out] start_code A pointer to a mutable @c uint32_t.<br>
+ *          As input: For no history preset to <b>@c ~0 </b>, otherwise preset to the last
+ *                    returned start code to enable detecting start codes across
+ *                    buffer boundaries.<br>
+ *          On output: Set to the found start code if it exists or an invalid
+ *                     start code (the 4 bytes prior to the returned value,
+ *                     using the input history if @f$ end - p < 4 @f$).
+ *
+ * @sa find_start_code()
+ */
+MTV_PUBLIC
+const uint8_t *find_start_code_truncated(const uint8_t * p,
+                                         const uint8_t * end,
+                                         uint32_t * start_code);
+
+} // namespace ByteReader
+
+#endif // BYTEREADER_H

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -88,6 +88,7 @@ extern "C" {
 #include "mpeg/atscdescriptors.h"
 #include "mpeg/dvbdescriptors.h"
 #include "mpeg/mpegtables.h"
+#include "bytereader.h"
 #include "mythavutil.h"
 #include "mythframe.h"
 #include "mythhdrvideometadata.h"
@@ -3144,7 +3145,7 @@ void AvFormatDecoder::MpegPreProcessPkt(AVStream *stream, AVPacket *pkt)
 
     while (bufptr < bufend)
     {
-        bufptr = avpriv_find_start_code(bufptr, bufend, &m_startCodeState);
+        bufptr = ByteReader::find_start_code_truncated(bufptr, bufend, &m_startCodeState);
 
         float aspect_override = -1.0F;
         if (m_ringBuffer->IsDVD())

--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -108,6 +108,7 @@ HEADERS += mythframe.h
 
 # Misc. needed by backend/frontend
 HEADERS += mythtvexp.h
+HEADERS += bytereader.h
 HEADERS += recordinginfo.h
 HEADERS += dbcheck.h
 HEADERS += videodbcheck.h
@@ -147,6 +148,7 @@ HEADERS += driveroption.h
 HEADERS += mythhdrvideometadata.h
 HEADERS += mythhdrtracker.h
 
+SOURCES += bytereader.cpp
 SOURCES += recordinginfo.cpp
 SOURCES += dbcheck.cpp
 SOURCES += videodbcheck.cpp

--- a/mythtv/libs/libmythtv/mpeg/AVCParser.cpp
+++ b/mythtv/libs/libmythtv/mpeg/AVCParser.cpp
@@ -15,6 +15,8 @@ extern "C" {
 #include <cmath>
 #include <strings.h>
 
+#include "bytereader.h"
+
 /*
   Most of the comments below were cut&paste from ITU-T Rec. H.264
   as found here:  http://www.itu.int/rec/T-REC-H.264/e
@@ -298,11 +300,10 @@ uint32_t AVCParser::addBytes(const uint8_t  *bytes,
 
     while (startP < bytes + byte_count && !m_onFrame)
     {
-        const uint8_t *endP = avpriv_find_start_code(startP,
-                                                     bytes + byte_count,
-                                                     &m_syncAccumulator);
+        const uint8_t *endP =
+            ByteReader::find_start_code_truncated(startP, bytes + byte_count, &m_syncAccumulator);
 
-        bool found_start_code = ((m_syncAccumulator & 0xffffff00) == 0x00000100);
+        bool found_start_code = ByteReader::start_code_is_valid(m_syncAccumulator);
 
         /* Between startP and endP we potentially have some more
          * bytes of a NAL that we've been parsing (plus some bytes of

--- a/mythtv/libs/libmythtv/mpeg/HEVCParser.cpp
+++ b/mythtv/libs/libmythtv/mpeg/HEVCParser.cpp
@@ -15,6 +15,8 @@ extern "C" {
 #include <cmath>
 #include <strings.h>
 
+#include "bytereader.h"
+
 #define LOC "HEVCParser "
 
 /*
@@ -158,12 +160,10 @@ uint32_t HEVCParser::addBytes(const uint8_t  *bytes,
 
     while (!m_onFrame && (startP < bytes + byte_count))
     {
-        const uint8_t *endP = avpriv_find_start_code(startP,
-                                                     bytes + byte_count,
-                                                     &m_syncAccumulator);
+        const uint8_t *endP =
+            ByteReader::find_start_code_truncated(startP, bytes + byte_count, &m_syncAccumulator);
 
-        // start_code_prefix_one_3bytes
-        bool found_start_code = ((m_syncAccumulator & 0xffffff00) == 0x00000100);
+        bool found_start_code = ByteReader::start_code_is_valid(m_syncAccumulator);
 
         /* Between startP and endP we potentially have some more
          * bytes of a NAL that we've been parsing (plus some bytes of

--- a/mythtv/libs/libmythtv/recorders/dtvrecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/dtvrecorder.cpp
@@ -21,6 +21,7 @@
 #include "libmyth/programinfo.h"
 #include "libmythbase/mythlogging.h"
 
+#include "bytereader.h"
 #include "dtvrecorder.h"
 #include "io/mythmediabuffer.h"
 #include "mpeg/AVCParser.h"
@@ -437,9 +438,9 @@ bool DTVRecorder::FindMPEG2Keyframes(const TSPacket* tspacket)
 
     while (bufptr < bufend)
     {
-        bufptr = avpriv_find_start_code(bufptr, bufend, &m_startCode);
+        bufptr = ByteReader::find_start_code_truncated(bufptr, bufend, &m_startCode);
         int bytes_left = bufend - bufptr;
-        if ((m_startCode & 0xffffff00) == 0x00000100)
+        if (ByteReader::start_code_is_valid(m_startCode))
         {
             // At this point we have seen the start code 0 0 1
             // the next byte will be the PES packet stream id.
@@ -1090,14 +1091,13 @@ void DTVRecorder::FindPSKeyFrames(const uint8_t *buffer, uint len)
         bool hasKeyFrame  = false;
 
         const uint8_t *tmp = bufptr;
-        bufptr =
-            avpriv_find_start_code(bufptr + skip, bufend, &m_startCode);
+        bufptr = ByteReader::find_start_code_truncated(bufptr + skip, bufend, &m_startCode);
         m_audioBytesRemaining = 0;
         m_otherBytesRemaining = 0;
         m_videoBytesRemaining -= std::min(
             (uint)(bufptr - tmp), m_videoBytesRemaining);
 
-        if ((m_startCode & 0xffffff00) != 0x00000100)
+        if (!ByteReader::start_code_is_valid(m_startCode))
             continue;
 
         // NOTE: Length may be zero for packets that only contain bytes from

--- a/mythtv/programs/mythutil/mpegutils.cpp
+++ b/mythtv/programs/mythutil/mpegutils.cpp
@@ -30,6 +30,8 @@
 #include "libmythtv/mpeg/scanstreamdata.h"
 #include "libmythtv/mpeg/sctetables.h"
 #include "libmythtv/mpeg/streamlisteners.h"
+#include "libmythtv/bytereader.h"
+
 
 // Application local headers
 #include "mpegutils.h"
@@ -359,9 +361,9 @@ bool PTSListener::ProcessTSPacket(const TSPacket &tspacket)
 
     while (bufptr < bufend)
     {
-        bufptr = avpriv_find_start_code(bufptr, bufend, &m_startCode);
+        bufptr = ByteReader::find_start_code_truncated(bufptr, bufend, &m_startCode);
         int bytes_left = bufend - bufptr;
-        if ((m_startCode & 0xffffff00) == 0x00000100)
+        if (ByteReader::start_code_is_valid(m_startCode))
         {
             // At this point we have seen the start code 0 0 1
             // the next byte will be the PES packet stream id.


### PR DESCRIPTION
by copying avpriv_find_start_code() into MythTV as ByteReader::find_start_code().

Refs: https://github.com/MythTV/mythtv/issues/428

Note: I have rewritten this function.  The only functional change is
00 00 01 00 01 XX no longer incorrectly returns a start code at
offset 7 that overlaps the start code at offset 4 if the start_code
input is not modified between the two calls.

FFmpeg only has one use that keeps the history,
(ff_)mpeg1_find_frame_end().

So, I have split the truncated start code logic into its own function
as I have now done for FFmpeg, which only used this functionality once.

Determining if it is necessary would require further analysis or
adding logging to see if truncated start codes are detected.

This was originally part of https://github.com/MythTV/mythtv/pull/416

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

