### PR TITLE
revert changes to FFmpeg's libpostproc

### DIFF
--- a/mythtv/external/FFmpeg/libpostproc/Makefile
+++ b/mythtv/external/FFmpeg/libpostproc/Makefile
@@ -2,14 +2,6 @@ NAME = postproc
 DESC = FFmpeg postprocessing library
 FFLIBS = avutil
 
-# x86_32 needs -O1 -fomit-frame-pointer to compile inline asm
-ifeq ($(ARCH_X86_32), yes)
-    CFLAGS += -fomit-frame-pointer
-    ifneq (, $(findstring debug, $(CCONFIG)))
-        CFLAGS += -O1
-    endif
-endif
-
 HEADERS = postprocess.h        \
           version.h            \
 

--- a/mythtv/external/FFmpeg/libpostproc/postprocess.c
+++ b/mythtv/external/FFmpeg/libpostproc/postprocess.c
@@ -91,8 +91,6 @@ try to unroll inner for(x=0 ... loop to avoid these damn if(x ... checks
 #include "libavutil/avstring.h"
 #include "libavutil/ppc/util_altivec.h"
 
-#include "libavutil/cpu.h"
-
 #include "libavutil/ffversion.h"
 const char postproc_ffversion[] = "FFmpeg version " FFMPEG_VERSION;
 

--- a/mythtv/external/FFmpeg/libpostproc/postprocess.c
+++ b/mythtv/external/FFmpeg/libpostproc/postprocess.c
@@ -880,25 +880,9 @@ av_cold pp_context *pp_get_context(int width, int height, int cpuCaps){
     PPContext *c= av_mallocz(sizeof(PPContext));
     int stride= FFALIGN(width, 16);  //assumed / will realloc if needed
     int qpStride= (width+15)/16 + 2; //assumed / will realloc if needed
-    int cpuflags;
 
     if (!c)
         return NULL;
-
-    if (CONFIG_RUNTIME_CPUDETECT &&
-        !(cpuCaps & (PP_CPU_CAPS_MMX   | PP_CPU_CAPS_MMX2    |
-                     PP_CPU_CAPS_3DNOW | PP_CPU_CAPS_ALTIVEC ))) {
-        cpuflags = av_get_cpu_flags();
-
-        if (HAVE_MMX && cpuflags & AV_CPU_FLAG_MMX)
-            cpuCaps |= PP_CPU_CAPS_MMX;
-        if (HAVE_MMX2 && cpuflags & AV_CPU_FLAG_MMX2)
-            cpuCaps |= PP_CPU_CAPS_MMX2;
-        if (HAVE_AMD3DNOW && cpuflags & AV_CPU_FLAG_3DNOW)
-            cpuCaps |= PP_CPU_CAPS_3DNOW;
-        if (HAVE_ALTIVEC && cpuflags & AV_CPU_FLAG_ALTIVEC)
-            cpuCaps |= PP_CPU_CAPS_ALTIVEC;
-    }
 
     c->av_class = &av_codec_context_class;
     if(cpuCaps&PP_FORMAT){


### PR DESCRIPTION
Originally part of https://github.com/MythTV/mythtv/pull/416

libpostproc is now unmodified.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

