### PR TITLE
avformatdecoder: stylistic change to switch-case to default return

### DIFF
--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -1475,9 +1475,8 @@ int AvFormatDecoder::GetMaxReferenceFrames(AVCodecContext *Context)
         case AV_CODEC_ID_H265: return 16;
         case AV_CODEC_ID_VP9:  return 8;
         case AV_CODEC_ID_VP8:  return 3;
-        default: break;
+        default:               return 2;
     }
-    return 2;
 }
 
 void AvFormatDecoder::InitVideoCodec(AVStream *stream, AVCodecContext *enc,


### PR DESCRIPTION
Split from a commit originally in https://github.com/MythTV/mythtv/pull/416

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

