### PR TITLE
Use MythDate::kDatabase format for all QDateTime SQL bindings

### DIFF
--- a/mythtv/libs/libmythbase/mythdbcon.cpp
+++ b/mythtv/libs/libmythbase/mythdbcon.cpp
@@ -882,6 +882,18 @@ bool MSqlQuery::testDBConnection()
 
 void MSqlQuery::bindValue(const QString &placeholder, const QVariant &val)
 {
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    auto type = static_cast<QMetaType::Type>(val.type());
+#else
+    auto type = val.typeId();
+#endif
+    if (type == QMetaType::QDateTime)
+    {
+        QSqlQuery::bindValue(placeholder,
+                             MythDate::toString(val.toDateTime(), MythDate::kDatabase),
+                             QSql::In);
+        return;
+    }
     QSqlQuery::bindValue(placeholder, val, QSql::In);
 }
 
@@ -895,6 +907,13 @@ void MSqlQuery::bindValueNoNull(const QString &placeholder, const QVariant &val)
     if (type == QMetaType::QString && val.toString().isNull())
     {
         QSqlQuery::bindValue(placeholder, QString(""), QSql::In);
+        return;
+    }
+    if (type == QMetaType::QDateTime)
+    {
+        QSqlQuery::bindValue(placeholder,
+                             MythDate::toString(val.toDateTime(), MythDate::kDatabase),
+                             QSql::In);
         return;
     }
     QSqlQuery::bindValue(placeholder, val, QSql::In);


### PR DESCRIPTION
Mariadb 10.2+ does not like the trailing Z that is generated when QDateTime is rendered in bindvalue for DELETE FROM requests. INSERT, UPDATE and replace seem to work but they shouldn't, so all instances are fixed to use MythDate's kDatabase format.

This prevents last played position and bookmarks from working correctly as well as deleting recordings when using mariadb 10.2.1 onwards due to changes in strictness from that version on and that mariadb does not have a timezoned datetime type.

Unknown as to mysql effects so some testing would be required with mysql before merging.

------------------------------
Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

