### PR TITLE
mpegts-mythtv.c: export disposition from ISO_639_LANGUAGE_DESCRIPTOR 

### DIFF
--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -1595,25 +1595,43 @@ int ff_parse_mpeg2_descriptor(AVFormatContext *fc, pmt_entry_t *item, int stream
         *pp += 4;
         break;
     case 0x0a: /* ISO 639 language descriptor */
+#ifdef UPSTREAM_TO_MYTHTV
         for (i = 0; i + 4 <= desc_len; i += 4) {
             language[i + 0] = get8(pp, desc_end);
             language[i + 1] = get8(pp, desc_end);
             language[i + 2] = get8(pp, desc_end);
             language[i + 3] = ',';
-#if 0
-        switch (get8(pp, desc_end)) {
-            case 0x01: st->disposition |= AV_DISPOSITION_CLEAN_EFFECTS; break;
-            case 0x02: st->disposition |= AV_DISPOSITION_HEARING_IMPAIRED; break;
-            case 0x03: st->disposition |= AV_DISPOSITION_VISUAL_IMPAIRED; break;
+            switch (get8(pp, desc_end)) {
+            case 0x01:
+                st->disposition |= AV_DISPOSITION_CLEAN_EFFECTS;
+                break;
+            case 0x02:
+                st->disposition |= AV_DISPOSITION_HEARING_IMPAIRED;
+                break;
+            case 0x03:
+                st->disposition |= AV_DISPOSITION_VISUAL_IMPAIRED;
+                st->disposition |= AV_DISPOSITION_DESCRIPTIONS;
+                break;
+            }
         }
-	}
-#else
-        }
-        get8(pp, desc_end);
-#endif
-        if (i) {
+        if (i && language[0]) {
             language[i - 1] = 0;
+            /* don't overwrite language, as it may already have been set by
+             * another, more specific descriptor (e.g. supplementary audio) */
+            av_dict_set(&st->metadata, "language", language, AV_DICT_DONT_OVERWRITE);
         }
+#else
+        language[0] = get8(pp, desc_end);
+        language[1] = get8(pp, desc_end);
+        language[2] = get8(pp, desc_end);
+        language[3] = 0;
+
+        switch (get8(pp, desc_end)) {
+            case 0x01: dvbci->disposition |= AV_DISPOSITION_CLEAN_EFFECTS; break;
+            case 0x02: dvbci->disposition |= AV_DISPOSITION_HEARING_IMPAIRED; break;
+            case 0x03: dvbci->disposition |= AV_DISPOSITION_VISUAL_IMPAIRED; break;
+        }
+#endif
         break;
     case 0x05: /* registration descriptor */
         dvbci->codec_tag = bytestream_get_le32(pp);

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -2623,19 +2623,6 @@ AudioTrackType AvFormatDecoder::GetAudioTrackType(uint StreamIndex)
     AudioTrackType type = kAudioTypeNormal;
     AVStream *stream = m_ic->streams[StreamIndex];
 
-    if (m_ic->cur_pmt_sect) // mpeg-ts
-    {
-        const ProgramMapTable pmt(PSIPTable(m_ic->cur_pmt_sect));
-        switch (pmt.GetAudioType(StreamIndex))
-        {
-            case 0x01 : type = kAudioTypeCleanEffects;     break;
-            case 0x02 : type = kAudioTypeHearingImpaired;  break;
-            case 0x03 : type = kAudioTypeAudioDescription; break;
-            case 0x00 :
-            default:    type = kAudioTypeNormal;
-        }
-    }
-    else // all other containers
     {
         // We only support labelling/filtering of these two types for now
         if (stream->disposition & AV_DISPOSITION_VISUAL_IMPAIRED)


### PR DESCRIPTION
Originally part of https://github.com/MythTV/mythtv/pull/416

The change to MythTV depends on the change to FFmpeg to work properly (if made without it, the audio track type will always be detected as normal).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

