### PR TITLE
MythEDID: fix out of bounds memory access

### DIFF
--- a/mythtv/libs/libmythui/mythedid.cpp
+++ b/mythtv/libs/libmythui/mythedid.cpp
@@ -274,7 +274,7 @@ bool MythEDID::ParseBaseBlock(const quint8* Data)
                  qFuzzyCompare(m_gamma + 1.0F, 2.20F + 1.0F);
 
     // Parse blocks
-    for (uint i = 0; i < 5; ++i)
+    for (uint i = 0; i < 4; ++i)
     {
         uint offset = DATA_BLOCK_OFFSET + i * 18;
         if (Data[offset] == 0 || Data[offset + 1] == 0 || Data[offset + 2] == 0)


### PR DESCRIPTION
found by valgrind while investigating segmentation faults that
occured randomly on startup of mythfrontend.

There are only 4 descriptors in the EDID data structure.
By incorrectly looping 5 times in MythEDID::ParseBaseBlock(),
an offset of 126 is passed to ParseDisplayDescriptor() or
ParseDetailedTimingDescriptor() which will then read past
the end of the 128 byte EDID data structure.

This appears to have always been wrong since it was added in
53d170221983764ae108939cbdb0bcbfc48b6114 .

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

