### PR TITLE
Fix #579 LCD time by replacing colon with space.

### DIFF
--- a/mythtv/programs/mythlcdserver/lcdprocclient.cpp
+++ b/mythtv/programs/mythlcdserver/lcdprocclient.cpp
@@ -1891,7 +1891,7 @@ void LCDProcClient::dostdclock()
         aString += time + "\"";
         if ( m_timeFlash )
         {
-            aString = aString.remove(":");
+            aString = aString.replace(':', ' ');
             m_timeFlash = false;
         }
         else


### PR DESCRIPTION
(cherry picked from commit 0b7f3d5a5c7f65a848bb8ead5411cb87856d6385)

Recent LCD time fix is done in master, this would fix it in production fixes/32

Ref #579 
