### PR TITLE
mythdb: New function GetDatabaseName

### DIFF
--- a/mythplugins/mytharchive/mytharchive/archivedbcheck.cpp
+++ b/mythplugins/mytharchive/mytharchive/archivedbcheck.cpp
@@ -69,7 +69,7 @@ bool UpgradeArchiveDatabaseSchema(void)
         DBUpdates updates
         {
             qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET latin1;")
-                       .arg(gContext->GetDatabaseParams().m_dbName)),
+                       .arg(GetMythDB()->GetDatabaseName())),
             "ALTER TABLE archiveitems"
             "  MODIFY title varbinary(128) default NULL,"
             "  MODIFY subtitle varbinary(128) default NULL,"
@@ -91,7 +91,7 @@ bool UpgradeArchiveDatabaseSchema(void)
         DBUpdates updates
         {
             qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;")
-                       .arg(gContext->GetDatabaseParams().m_dbName)),
+                       .arg(GetMythDB()->GetDatabaseName())),
             "ALTER TABLE archiveitems"
             "  DEFAULT CHARACTER SET utf8,"
             "  MODIFY title varchar(128) CHARACTER SET utf8 NULL,"

--- a/mythplugins/mytharchive/mytharchivehelper/mytharchivehelper.cpp
+++ b/mythplugins/mytharchive/mytharchivehelper/mytharchivehelper.cpp
@@ -2205,7 +2205,7 @@ static int getFileInfo(const QString& inFile, const QString& outFile, int lenMet
 
 static int getDBParamters(const QString& outFile)
 {
-    DatabaseParams params = gContext->GetDatabaseParams();
+    DatabaseParams params = GetMythDB()->GetDatabaseParams();
 
     // save the db paramters to the file
     QFile f(outFile);

--- a/mythplugins/mythgame/mythgame/gamedbcheck.cpp
+++ b/mythplugins/mythgame/mythgame/gamedbcheck.cpp
@@ -249,7 +249,7 @@ bool UpgradeGameDatabaseSchema(void)
     {
         DBUpdates updates {
 qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET latin1;")
-        .arg(gContext->GetDatabaseParams().m_dbName)),
+        .arg(GetMythDB()->GetDatabaseName())),
 "ALTER TABLE gamemetadata"
 "  MODIFY `system` varbinary(128) NOT NULL default '',"
 "  MODIFY romname varbinary(128) NOT NULL default '',"
@@ -295,7 +295,7 @@ qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET latin1;")
     {
         DBUpdates updates {
 qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;")
-        .arg(gContext->GetDatabaseParams().m_dbName)),
+        .arg(GetMythDB()->GetDatabaseName())),
 "ALTER TABLE gamemetadata"
 "  DEFAULT CHARACTER SET utf8,"
 "  MODIFY `system` varchar(128) CHARACTER SET utf8 NOT NULL default '',"

--- a/mythplugins/mythmusic/mythmusic/musicdbcheck.cpp
+++ b/mythplugins/mythmusic/mythmusic/musicdbcheck.cpp
@@ -682,7 +682,7 @@ static bool doUpgradeMusicDatabaseSchema(QString &dbver)
         DBUpdates updates
         {
             qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET latin1;")
-                       .arg(gContext->GetDatabaseParams().m_dbName)),
+                       .arg(GetMythDB()->GetDatabaseName())),
             // NOLINTNEXTLINE(bugprone-suspicious-missing-comma)
             "ALTER TABLE music_albumart"
             "  MODIFY filename varbinary(255) NOT NULL default '';",
@@ -732,7 +732,7 @@ static bool doUpgradeMusicDatabaseSchema(QString &dbver)
         DBUpdates updates
         {
             qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;")
-                    .arg(gContext->GetDatabaseParams().m_dbName)),
+                    .arg(GetMythDB()->GetDatabaseName())),
             // NOLINTNEXTLINE(bugprone-suspicious-missing-comma)
             "ALTER TABLE music_albumart"
             "  DEFAULT CHARACTER SET utf8,"

--- a/mythplugins/mythweather/mythweather/weatherdbcheck.cpp
+++ b/mythplugins/mythweather/mythweather/weatherdbcheck.cpp
@@ -99,7 +99,7 @@ bool InitializeDatabase()
     {
         DBUpdates updates {
             qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET latin1;")
-            .arg(gContext->GetDatabaseParams().m_dbName)),
+            .arg(GetMythDB()->GetDatabaseName())),
             "ALTER TABLE weatherdatalayout"
             "  MODIFY location varbinary(64) NOT NULL,"
             "  MODIFY dataitem varbinary(64) NOT NULL;",
@@ -126,7 +126,7 @@ bool InitializeDatabase()
     {
         DBUpdates updates {
             qPrintable(QString("ALTER DATABASE %1 DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;")
-            .arg(gContext->GetDatabaseParams().m_dbName)),
+            .arg(GetMythDB()->GetDatabaseName())),
             "ALTER TABLE weatherdatalayout"
             "  DEFAULT CHARACTER SET utf8,"
             "  MODIFY location varchar(64) CHARACTER SET utf8 NOT NULL,"

--- a/mythtv/libs/libmyth/dbsettings.cpp
+++ b/mythtv/libs/libmyth/dbsettings.cpp
@@ -138,7 +138,7 @@ DatabaseSettings::DatabaseSettings(QString DBhostOverride) :
 
 void DatabaseSettings::Load(void)
 {
-    DatabaseParams params = gContext->GetDatabaseParams();
+    DatabaseParams params = GetMythDB()->GetDatabaseParams();
 
     if (params.m_dbHostName.isEmpty() ||
         params.m_dbUserName.isEmpty() ||
@@ -185,7 +185,7 @@ void DatabaseSettings::Load(void)
 }
 void DatabaseSettings::Save(void)
 {
-    DatabaseParams params = gContext->GetDatabaseParams();
+    DatabaseParams params = GetMythDB()->GetDatabaseParams();
 
     params.m_dbHostName = m_dbHostName->getValue();
     params.m_dbHostPing = m_dbHostPing->boolValue();

--- a/mythtv/libs/libmyth/mythcontext.cpp
+++ b/mythtv/libs/libmyth/mythcontext.cpp
@@ -735,7 +735,7 @@ bool MythContextPrivate::PromptForDatabaseParams(const QString &error)
     }
     else
     {
-        DatabaseParams params = m_parent->GetDatabaseParams();
+        DatabaseParams params = m_dbParams;
         QString        response;
         std::this_thread::sleep_for(1s);
         // give user chance to skip config
@@ -1694,11 +1694,6 @@ MythContext::~MythContext()
 void MythContext::SetDisableEventPopup(bool check)
 {
     d->m_disableeventpopup = check;
-}
-
-DatabaseParams MythContext::GetDatabaseParams(void)
-{
-    return d->m_dbParams;
 }
 
 bool MythContext::SaveDatabaseParams(const DatabaseParams &params)

--- a/mythtv/libs/libmyth/mythcontext.h
+++ b/mythtv/libs/libmyth/mythcontext.h
@@ -51,7 +51,6 @@ class MPUBLIC MythContext
               bool disableAutoDiscovery = false,
               bool ignoreDB = false);
 
-    DatabaseParams GetDatabaseParams(void);
     bool SaveDatabaseParams(const DatabaseParams &params);
     bool saveSettingsCache(void);
 

--- a/mythtv/libs/libmythbase/dbutil.cpp
+++ b/mythtv/libs/libmythbase/dbutil.cpp
@@ -567,7 +567,7 @@ bool DBUtil::CreateTemporaryDBConf(
 bool DBUtil::DoBackup(const QString &backupScript, QString &filename,
                       bool disableRotation)
 {
-    DatabaseParams dbParams = gCoreContext->GetDatabaseParams();
+    DatabaseParams dbParams = GetMythDB()->GetDatabaseParams();
     QString     dbSchemaVer = gCoreContext->GetSetting("DBSchemaVer");
     QString backupDirectory = GetBackupDirectory();
     QString  backupFilename = CreateBackupFilename(dbParams.m_dbName + "-" +
@@ -663,7 +663,7 @@ bool DBUtil::DoBackup(const QString &backupScript, QString &filename,
  */
 bool DBUtil::DoBackup(QString &filename)
 {
-    DatabaseParams dbParams = gCoreContext->GetDatabaseParams();
+    DatabaseParams dbParams = GetMythDB()->GetDatabaseParams();
     QString     dbSchemaVer = gCoreContext->GetSetting("DBSchemaVer");
     QString backupDirectory = GetBackupDirectory();
 
@@ -822,7 +822,7 @@ int DBUtil::CountClients(void)
 
     QSqlRecord record = query.record();
     int db_index = record.indexOf("db");
-    QString dbName = gCoreContext->GetDatabaseParams().m_dbName;
+    QString dbName = GetMythDB()->GetDatabaseName();
     QString inUseDB;
 
     while (query.next())

--- a/mythtv/libs/libmythbase/mythcorecontext.h
+++ b/mythtv/libs/libmythbase/mythcorecontext.h
@@ -146,8 +146,6 @@ class MBASE_PUBLIC MythCoreContext : public QObject, public MythObservable, publ
     MythScheduler *GetScheduler(void);
 
     bool IsDatabaseIgnored(void) const;
-    DatabaseParams GetDatabaseParams(void)
-        { return GetDB()->GetDatabaseParams(); }
 
     void SaveSetting(const QString &key, int newValue);
     void SaveSetting(const QString &key, const QString &newValue);

--- a/mythtv/libs/libmythbase/mythdb.cpp
+++ b/mythtv/libs/libmythbase/mythdb.cpp
@@ -244,6 +244,11 @@ QString MythDB::DBErrorMessage(const QSqlError& err)
              err.databaseText());
 }
 
+QString MythDB::GetDatabaseName() const
+{
+    return d->m_dbParams.m_dbName;
+}
+
 DatabaseParams MythDB::GetDatabaseParams(void) const
 {
     return d->m_dbParams;

--- a/mythtv/libs/libmythbase/mythdb.h
+++ b/mythtv/libs/libmythbase/mythdb.h
@@ -22,6 +22,7 @@ class MBASE_PUBLIC MythDB
     static void DBError(const QString &where, const MSqlQuery &query);
     static QString DBErrorMessage(const QSqlError &err);
 
+    QString GetDatabaseName() const;
     DatabaseParams GetDatabaseParams(void) const;
     void SetDatabaseParams(const DatabaseParams &params);
 

--- a/mythtv/libs/libmythbase/mythversion.h
+++ b/mythtv/libs/libmythbase/mythversion.h
@@ -12,7 +12,7 @@
 /// Update this whenever the plug-in ABI changes.
 /// Including changes in the libmythbase, libmyth, libmythtv, libmythav* and
 /// libmythui class methods in exported headers.
-static constexpr const char* MYTH_BINARY_VERSION { "33.20220201-1" };
+static constexpr const char* MYTH_BINARY_VERSION { "33.20220913-1" };
 
 /** \brief Increment this whenever the MythTV network protocol changes.
  *   Note that the token currently cannot contain spaces.

--- a/mythtv/libs/libmythtv/dbcheck.cpp
+++ b/mythtv/libs/libmythtv/dbcheck.cpp
@@ -497,7 +497,7 @@ static bool doUpgradeTVDatabaseSchema(void)
         MSqlQuery query(MSqlQuery::InitCon());
         if (!query.exec(QString("ALTER DATABASE %1 DEFAULT "
                                 "CHARACTER SET utf8 COLLATE utf8_general_ci;")
-                        .arg(gCoreContext->GetDatabaseParams().m_dbName)))
+                        .arg(GetMythDB()->GetDatabaseName())))
         {
             MythDB::DBError("UpgradeTVDatabaseSchema -- alter charset", query);
         }
@@ -3690,7 +3690,7 @@ static bool doUpgradeTVDatabaseSchema(void)
             "and table_name = 'recordedartwork' "
             "and seq_in_index = 1 "
             "and column_name = 'inetref'")
-            .arg(gCoreContext->GetDatabaseParams().m_dbName));
+            .arg(GetMythDB()->GetDatabaseName()));
 
         if (!select.exec())
         {

--- a/mythtv/programs/mythbackend/services/myth.cpp
+++ b/mythtv/programs/mythbackend/services/myth.cpp
@@ -65,7 +65,7 @@ DTC::ConnectionInfo* Myth::GetConnectionInfo( const QString  &sPin )
         throw( QString( "Not Authorized" ));
         //SB: UPnPResult_ActionNotAuthorized );
 
-    DatabaseParams params = gCoreContext->GetDatabaseParams();
+    DatabaseParams params = GetMythDB()->GetDatabaseParams();
 
     // ----------------------------------------------------------------------
     // Check for DBHostName of "localhost" and change to public name or IP

--- a/mythtv/programs/mythbackend/servicesv2/v2config.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2config.cpp
@@ -82,7 +82,7 @@ bool V2Config::SetDatabaseCredentials(const QString &Host, const QString &UserNa
 /////////////////////////////////////////////////////////////////////////////
 V2DatabaseStatus* V2Config::GetDatabaseStatus()
 {
-    const DatabaseParams params = gCoreContext->GetDatabaseParams();
+    const DatabaseParams params = GetMythDB()->GetDatabaseParams();
 
     auto *pInfo = new V2DatabaseStatus();
 

--- a/mythtv/programs/mythbackend/servicesv2/v2myth.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2myth.cpp
@@ -9,9 +9,9 @@
 #include "libmythbase/dbutil.h"
 #include "libmythbase/hardwareprofile.h"
 #include "libmythbase/http/mythhttpmetaservice.h"
-#include "libmythbase/mythcorecontext.h"
 #include "libmythbase/mythcoreutil.h"
 #include "libmythbase/mythdate.h"
+#include "libmythbase/mythdb.h"
 #include "libmythbase/mythdbcon.h"
 #include "libmythbase/mythlogging.h"
 #include "libmythbase/mythtimezone.h"
@@ -75,7 +75,7 @@ V2ConnectionInfo* V2Myth::GetConnectionInfo( const QString  &sPin )
         throw( QString( "Not Authorized" ));
         //SB: UPnPResult_ActionNotAuthorized );
 
-    DatabaseParams params = gCoreContext->GetDatabaseParams();
+    DatabaseParams params = GetMythDB()->GetDatabaseParams();
 
     // ----------------------------------------------------------------------
     // Check for DBHostName of "localhost" and change to public name or IP


### PR DESCRIPTION
also remove (MythContext|MythCoreContext)->GetDatabaseParams(), use GetMythDB() instead

This was originally part of https://github.com/MythTV/mythtv/pull/435 but is unrelated to the rest of those changes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

