### PR TITLE
mythfrontend/exitprompt.cpp: fix use after free

### DIFF
--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -27,7 +27,7 @@ ExitPrompter::ExitPrompter()
 ExitPrompter::~ExitPrompter()
 {
     // Ensure additional actions are not processed after we are deleted
-    if (m_dialog)
+    if (m_dialog && GetMythMainWindow()->GetStack("popup stack")->GetTopScreen() == m_dialog)
         m_dialog->SetReturnEvent(nullptr, QString());
 
     if (m_power)


### PR DESCRIPTION
discvered by valgrind:
```
2022-06-28 01:34:29.544115 I [25872/25872] CoreContext exitprompt.cpp:24:ExitPrompter  Created ExitPrompter
==25872== Invalid write of size 8
==25872==    at 0x5C38AC1: MythDialogBox::SetReturnEvent(QObject*, QString const&) (mythdialogbox.cpp:304)
==25872==    by 0x2A852C: ExitPrompter::~ExitPrompter() (exitprompt.cpp:31)
==25872==    by 0x2A888C: ExitPrompter::~ExitPrompter() (exitprompt.cpp:36)
==25872==    by 0xA4B61B2: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB712: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48FCFB: QCoreApplication::exec() (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x195D64: main (mythfrontend.cpp:2201)
==25872==  Address 0x1d49abf0 is 496 bytes inside a block of size 600 free'd
==25872==    at 0x484BB6F: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25872==    by 0xA4B61B2: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB712: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA4E2A56: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xF47AD1A: g_main_context_dispatch (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xF4CF6F7: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xF4783C2: g_main_context_iteration (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xA4E20A7: QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48774A: QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48FCE3: QCoreApplication::exec() (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==  Block was alloc'd at
==25872==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25872==    by 0x2A908D: ExitPrompter::HandleExit() (exitprompt.cpp:248)
==25872==    by 0x18CB59: handleExit(bool) (mythfrontend.cpp:1223)
==25872==    by 0x18C45A: TVMenuCallback(void*, QString&) (mythfrontend.cpp:1195)
==25872==    by 0x5C2EC5A: MythThemedMenu::keyPressEvent(QKeyEvent*) (myththemedmenu.cpp:257)
==25872==    by 0x5BA27F2: MythMainWindow::eventFilter(QObject*, QEvent*) (mythmainwindow.cpp:1690)
==25872==    by 0xA488B89: QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB701: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0x63C349D: QApplication::notify(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA4E2A56: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==
==25872== Invalid read of size 8
==25872==    at 0xA31F2BE: QString::operator=(QString const&) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x2A852C: ExitPrompter::~ExitPrompter() (exitprompt.cpp:31)
==25872==    by 0x2A888C: ExitPrompter::~ExitPrompter() (exitprompt.cpp:36)
==25872==    by 0xA4B61B2: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB712: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48FCFB: QCoreApplication::exec() (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x195D64: main (mythfrontend.cpp:2201)
==25872==  Address 0x1d49abf8 is 504 bytes inside a block of size 600 free'd
==25872==    at 0x484BB6F: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25872==    by 0xA4B61B2: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB712: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA4E2A56: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xF47AD1A: g_main_context_dispatch (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xF4CF6F7: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xF4783C2: g_main_context_iteration (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xA4E20A7: QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48774A: QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48FCE3: QCoreApplication::exec() (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==  Block was alloc'd at
==25872==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25872==    by 0x2A908D: ExitPrompter::HandleExit() (exitprompt.cpp:248)
==25872==    by 0x18CB59: handleExit(bool) (mythfrontend.cpp:1223)
==25872==    by 0x18C45A: TVMenuCallback(void*, QString&) (mythfrontend.cpp:1195)
==25872==    by 0x5C2EC5A: MythThemedMenu::keyPressEvent(QKeyEvent*) (myththemedmenu.cpp:257)
==25872==    by 0x5BA27F2: MythMainWindow::eventFilter(QObject*, QEvent*) (mythmainwindow.cpp:1690)
==25872==    by 0xA488B89: QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB701: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0x63C349D: QApplication::notify(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA4E2A56: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==
==25872== Invalid write of size 8
==25872==    at 0xA31F2D6: QString::operator=(QString const&) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x2A852C: ExitPrompter::~ExitPrompter() (exitprompt.cpp:31)
==25872==    by 0x2A888C: ExitPrompter::~ExitPrompter() (exitprompt.cpp:36)
==25872==    by 0xA4B61B2: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB712: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48FCFB: QCoreApplication::exec() (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x195D64: main (mythfrontend.cpp:2201)
==25872==  Address 0x1d49abf8 is 504 bytes inside a block of size 600 free'd
==25872==    at 0x484BB6F: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25872==    by 0xA4B61B2: QObject::event(QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB712: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA4E2A56: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xF47AD1A: g_main_context_dispatch (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xF4CF6F7: ??? (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xF4783C2: g_main_context_iteration (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==25872==    by 0xA4E20A7: QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48774A: QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48FCE3: QCoreApplication::exec() (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==  Block was alloc'd at
==25872==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==25872==    by 0x2A908D: ExitPrompter::HandleExit() (exitprompt.cpp:248)
==25872==    by 0x18CB59: handleExit(bool) (mythfrontend.cpp:1223)
==25872==    by 0x18C45A: TVMenuCallback(void*, QString&) (mythfrontend.cpp:1195)
==25872==    by 0x5C2EC5A: MythThemedMenu::keyPressEvent(QKeyEvent*) (myththemedmenu.cpp:257)
==25872==    by 0x5BA27F2: MythMainWindow::eventFilter(QObject*, QEvent*) (mythmainwindow.cpp:1690)
==25872==    by 0xA488B89: QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0x63BB701: QApplicationPrivate::notify_helper(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0x63C349D: QApplication::notify(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Widgets.so.5.15.3)
==25872==    by 0xA488E29: QCoreApplication::notifyInternal2(QObject*, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA48BF16: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==    by 0xA4E2A56: ??? (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.3)
==25872==
2022-06-28 01:34:31.215319 I [25872/25872] CoreContext exitprompt.cpp:35:~ExitPrompter  Deleted ExitPrompter
```

This occurred on ExitPrompter::DoQuit() but not if "No" or no
selection were made.

This was appearently introduced by 79f1005638a34e2a2b20632e09fe093adfddbe1b
, attempted to be fixed in 18922a7a1dc45e3621672b9cfcee54d54aabb9aa
but the fix reverted in 2026896393da7024b0367c97b56f64c550a36154 .

Alternatively, this should also work:
```
    QVector<MythScreenType *> screenList;
    GetMythMainWindow()->GetStack("popup stack")->GetScreenList(screenList);

    // Ensure additional actions are not processed after we are deleted
    if (m_dialog && screenList.contains(m_dialog))
        m_dialog->SetReturnEvent(nullptr, QString());
```

However, the only way that m_dialog is not the top screen is in
ExitPrompter::Confirm(), which creates another confirmation dialog
but also sets m_dialog = nullptr.

---
@linuxdude42 @kmdewaal You had previously looked at this bug.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

