### PR TITLE
GitHub Actions: MythTV no longer supports Ubunutu 18.04

### DIFF
--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -11,7 +11,7 @@ jobs:
     name: build
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'ubuntu-20.04', 'macos-10.15', 'macos-11']
+        os: ['ubuntu-20.04', 'macos-10.15', 'macos-11']
         cc: ['gcc', 'clang']
         include:
           - cc: 'gcc'


### PR DESCRIPTION
due to the required Qt version increase to 5.12.  (Ubuntu 18.04
has Qt 5.9.)

---
@linuxdude42 you should have done this as part of https://github.com/MythTV/mythtv/commit/88c85fb31b7e3286c49f575605a0dbbff343b1d2
