### PR TITLE
MythMediaMonitor: Replace UDisks with UDisks2

### DIFF
--- a/mythtv/libs/libmyth/mediamonitor-unix.cpp
+++ b/mythtv/libs/libmyth/mediamonitor-unix.cpp
@@ -243,7 +243,7 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
                 device = UDisks2DVD;
                 return true;
             }
-            else if (isfsmountable)
+            if (isfsmountable)
             {
                 device = UDisks2HDD;
                 return true;
@@ -324,16 +324,12 @@ bool MediaMonitorUnix::CheckMountable(void)
             "CheckMountable: Start listening on UDisks2 DBus");
 
         // Listen on DBus for UDisk add/remove device messages
-        (void)QDBusConnection::systemBus().connect(
-            "org.freedesktop.UDisks2", "/org/freedesktop/UDisks2",
+        (void)QDBusConnection::systemBus().connect(UDISKS2_SVC, UDISKS2_PATH,
             "org.freedesktop.DBus.ObjectManager", "InterfacesAdded",
-            this, SLOT(deviceAdded(const QDBusObjectPath &,
-                                   const QMap<QString, QVariant> &)) );
-        (void)QDBusConnection::systemBus().connect(
-            "org.freedesktop.UDisks2", "/org/freedesktop/UDisks2",
+            this, SLOT(deviceAdded(QDBusObjectPath,QMap<QString,QVariant>)) );
+        (void)QDBusConnection::systemBus().connect(UDISKS2_SVC, UDISKS2_PATH,
             "org.freedesktop.DBus.ObjectManager", "InterfacesRemoved",
-            this, SLOT(deviceRemoved(const QDBusObjectPath &,
-                                     const QStringList &)) );
+            this, SLOT(deviceRemoved(QDBusObjectPath,QStringList)) );
 
         // Parse the returned device array
         const QDBusObjectPathList& list(reply.value());
@@ -341,7 +337,7 @@ bool MediaMonitorUnix::CheckMountable(void)
         {
             // Create the MythMediaDevice
             MythMediaDevice* pDevice = nullptr;
-            MythUdisksDevice mythdevice;
+            MythUdisksDevice mythdevice = UDisks2INVALID;
             QString description;
             QString path;
 
@@ -557,8 +553,9 @@ QStringList MediaMonitorUnix::GetCDROMBlockDevices(void)
 #endif
             if (!name.isEmpty())
             {
-                QDBusObjectPath entry {"/org/freedesktop/UDisks2/block_devices/" + name};
-                MythUdisksDevice mythdevice;
+                QString sbdevices = QString::fromUtf8(UDISKS2_PATH_BLOCK_DEVICES);
+                QDBusObjectPath entry {sbdevices + "/" + name};
+                MythUdisksDevice mythdevice = UDisks2INVALID;
                 QString description;
                 QString dev;
 
@@ -841,7 +838,7 @@ void MediaMonitorUnix::deviceAdded( const QDBusObjectPath& o,
 
     // Create the MythMediaDevice
     MythMediaDevice* pDevice = nullptr;
-    MythUdisksDevice mythdevice;
+    MythUdisksDevice mythdevice = UDisks2INVALID;
     QString description;
     QString path;
 

--- a/mythtv/libs/libmyth/mediamonitor-unix.h
+++ b/mythtv/libs/libmyth/mediamonitor-unix.h
@@ -61,8 +61,9 @@ class MediaMonitorUnix : public MediaMonitor
 #if CONFIG_QTDBUS
     enum MythUdisksDevice
     {
-        UDisks2DVD = 0,
-        UDisks2HDD = 1,
+        UDisks2INVALID = 0, 
+        UDisks2DVD     = 1,
+        UDisks2HDD     = 2,
     };
 #endif
 #endif // MYTH_MEDIA_MONITOR_H

--- a/mythtv/libs/libmyth/mediamonitor-unix.h
+++ b/mythtv/libs/libmyth/mediamonitor-unix.h
@@ -18,8 +18,10 @@ class MediaMonitorUnix : public MediaMonitor
 #if CONFIG_QTDBUS
     Q_OBJECT
   public slots:
-    Q_NOREPLY void deviceAdded(const QDBusObjectPath& o);
-    Q_NOREPLY void deviceRemoved(const QDBusObjectPath& o);
+    Q_NOREPLY void deviceAdded(const QDBusObjectPath& o,
+                               const QMap<QString, QVariant> &interfaces);
+    Q_NOREPLY void deviceRemoved(const QDBusObjectPath& o,
+                                 const QStringList &interfaces);
 #endif
 
   public:
@@ -56,4 +58,11 @@ class MediaMonitorUnix : public MediaMonitor
 ;
 };
 
+#if CONFIG_QTDBUS
+    enum MythUdisksDevice
+    {
+        UDisks2DVD = 0,
+        UDisks2HDD = 1,
+    };
+#endif
 #endif // MYTH_MEDIA_MONITOR_H


### PR DESCRIPTION
UDisks is long time deprecated and not available in modern Linux
distributions anymore.
It was replaced by UDisks2 which is now provided by the storaged.org
project and linked from freedesktop.org.
See https://udisks.freedesktop.org/ and
http://storaged.org/doc/udisks2-api/latest/ for details.

When monitoring is enabled in the frontend:
Setup -> General ->  Monitor Devices
a 'MythMediaDevice' is added for every removeable device.

Refs https://github.com/MythTV/mythtv/issues/605

Thank you for contributing to MythTV!


##### Checklist


- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

