### PR TITLE
DTVRecorder::FindMPEG2Keyframes: fix frame counting with field pictures

### DIFF
--- a/mythtv/libs/libmythtv/recorders/dtvrecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/dtvrecorder.cpp
@@ -447,7 +447,13 @@ bool DTVRecorder::FindMPEG2Keyframes(const TSPacket* tspacket)
             // the next byte will be the PES packet stream id.
             const int stream_id = m_startCode & 0x000000ff;
             if (PESStreamID::PictureStartCode == stream_id)
-                hasFrame = true;
+            {
+                if (m_progressiveSequence)
+                {
+                    hasFrame = true;
+                }
+                // else deterimine hasFrame from the following picture_coding_extension()
+            }
             else if (PESStreamID::GOPStartCode == stream_id)
             {
                 m_lastGopSeen   = m_framesSeenCount;
@@ -483,10 +489,47 @@ bool DTVRecorder::FindMPEG2Keyframes(const TSPacket* tspacket)
                     case 0x8: /* picture coding extension */
                         if (bytes_left >= 5)
                         {
-                            //int picture_structure = bufptr[2]&3;
+                            int picture_structure  = bufptr[2] & 3;
                             int top_field_first = bufptr[3] & (1 << 7);
                             int repeat_first_field = bufptr[3] & (1 << 1);
                             int progressive_frame = bufptr[4] & (1 << 7);
+#if 0
+                            LOG(VB_RECORD, LOG_DEBUG, LOC +
+                                QString("picture_coding_extension(): (m_progressiveSequence: %1) picture_structure: %2 top_field_first: %3 repeat_first_field: %4 progressive_frame: %5")
+                                    .arg(QString::number(m_progressiveSequence , 2),
+                                         QString::number(picture_structure , 2),
+                                         QString::number(top_field_first , 2),
+                                         QString::number(repeat_first_field , 2),
+                                         QString::number(progressive_frame , 2)
+                                        )
+                               );
+#endif
+                            if (!m_progressiveSequence)
+                            {
+                                if (picture_structure == 0b00)
+                                {
+                                    ; // reserved
+                                }
+                                else if (picture_structure == 0b11)
+                                {
+                                    // frame picture (either interleaved interlaced or progressive)
+                                    hasFrame = true;
+                                }
+                                else if (picture_structure < 0b11)
+                                {
+                                    // field picture
+                                    // Only add a frame for the first presented field.
+                                    // Do not add a frame for each field picture.
+                                    if (top_field_first != 0)
+                                    {
+                                        hasFrame = (picture_structure == 0b01); // Top Field
+                                    }
+                                    else // top_field_first == 0
+                                    {
+                                        hasFrame = (picture_structure == 0b10); // Bottom Field
+                                    }
+                                }
+                            }
 
                             /* check if we must repeat the frame */
                             m_repeatPict = 1;


### PR DESCRIPTION
refs: https://github.com/MythTV/mythtv/issues/548 (This fixes @Jpilk's issue with MPEG-2 video, not the original issue with H.265.)

See:
ITU-T Rec. H.262 (2000 E)
§6.1.1 Video sequence,
§6.2.2 Video Sequence, and
§6.3.10 Picture Coding Extension
and Table 6-14 Meaning of picture_structure.

When an interlaced stream is encoded with each coded frame
consisting of two field pictures, the picture_header() (and its
start code) appear twice per frame.  This causes the duration
estimate to be twice what is should be by double counting frames.

To fix this use the immediately following picture_coding_extension()
for non-progressive sequences and only count a new frame at the
first field to be presented instead of incorrectly counting each
field picture as its own frame.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

