### PR TITLE
GitHub Actions: update OS versions (fixes/32)

### DIFF
--- a/.github/workflows/buildfixes32.yml
+++ b/.github/workflows/buildfixes32.yml
@@ -11,7 +11,7 @@ jobs:
     name: build
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'ubuntu-20.04', 'macos-10.15', 'macos-11']
+        os: ['ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04', 'macos-11', 'macos-12']
         cc: ['gcc', 'clang']
         include:
           - cc: 'gcc'


### PR DESCRIPTION
The macOS-10.15 environment is deprecated and will be removed on August 30th, 2022.

Add Ubuntu 22.04.