### PR TITLE
bitreader.h: get_upper_bits() make undefined behavior protection consistent

### DIFF
--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -195,9 +195,14 @@ class BitReader
 
     static constexpr uint64_t get_upper_bits(uint64_t val, unsigned bits)
     {
-        if ((bits == 0) || (bits > 64))
+        // protect against undefined behavior
+        if (bits == 0)
         {
-            return val; // protect against undefined behavior
+            return UINT64_C(0);
+        }
+        else if (bits > 64)
+        {
+            return val;
         }
         return (val & mask_upper(bits)) >> (64 - bits);
     }


### PR DESCRIPTION
If bits == 0, which should never occur, we want the top 0 bits.
Return 0, as would be expected from shifting in 64 `0` bits.
Also, mask_upper(0) returns 0, which would clear all the bits anyways.

@linuxdude42 This is the correct return value for an input of 0.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

