### PR TITLE
unziputils: move zlib include to proper file

### DIFF
--- a/mythtv/libs/libmythbase/unzip2.h
+++ b/mythtv/libs/libmythbase/unzip2.h
@@ -18,9 +18,7 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-#include "zlib.h"
-#undef Z_NULL
-#define Z_NULL nullptr
+// libzip
 #include "zip.h"
 
 // Qt headers

--- a/mythtv/libs/libmythbase/unziputil.cpp
+++ b/mythtv/libs/libmythbase/unziputil.cpp
@@ -2,6 +2,10 @@
 
 #include <array>
 
+#include "zlib.h"
+#undef Z_NULL
+#define Z_NULL nullptr
+
 // Qt headers
 #include <QByteArray>
 #include <QFile>


### PR DESCRIPTION
unzip2.(h|cpp) does not use any zlib symbols, only unziputil.cpp does.