### PR TITLE
Add #include <limits> before #include <QtEndian> to address QTBUG-90395

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include <QtGlobal>
+#include <limits>
 #include <QtEndian>
 
 #include "libmythbase/mythlogging.h"

--- a/mythtv/libs/libmyth/audio/eldutils.cpp
+++ b/mythtv/libs/libmyth/audio/eldutils.cpp
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 
 #include <QString>
+#include <limits>
 #include <QtEndian>
 
 #include "audiooutputbase.h"

--- a/mythtv/libs/libmythbase/bonjourregister.cpp
+++ b/mythtv/libs/libmythbase/bonjourregister.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 
 #include <QSocketNotifier>
+#include <limits>
 #include <QtEndian>
 
 #include "mythrandom.h"

--- a/mythtv/libs/libmythbase/http/mythwebsocket.cpp
+++ b/mythtv/libs/libmythbase/http/mythwebsocket.cpp
@@ -1,5 +1,6 @@
 // Qt
 #include <QThread>
+#include <limits>
 #include <QtEndian>
 #include <QTcpSocket>
 

--- a/mythtv/libs/libmythbase/mythbinaryplist.cpp
+++ b/mythtv/libs/libmythbase/mythbinaryplist.cpp
@@ -31,6 +31,7 @@
 
 // Qt
 #include <QtGlobal>
+#include <limits>
 #include <QtEndian>
 #include <QDateTime>
 #include <QSequentialIterable>

--- a/mythtv/libs/libmythtv/AirPlay/mythraopconnection.cpp
+++ b/mythtv/libs/libmythtv/AirPlay/mythraopconnection.cpp
@@ -5,6 +5,7 @@
 #include <QTcpSocket>
 #include <QTextStream>
 #include <QTimer>
+#include <limits>
 #include <QtEndian>
 #if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
 #include <QStringConverter>

--- a/mythtv/libs/libmythtv/AirPlay/mythraopdevice.cpp
+++ b/mythtv/libs/libmythtv/AirPlay/mythraopdevice.cpp
@@ -1,4 +1,5 @@
 #include <QTimer>
+#include <limits>
 #include <QtEndian>
 #include <QNetworkInterface>
 #include <QCoreApplication>

--- a/mythtv/libs/libmythtv/DVD/mythdvdbuffer.cpp
+++ b/mythtv/libs/libmythtv/DVD/mythdvdbuffer.cpp
@@ -4,6 +4,7 @@
 
 // Qt
 #include <QCoreApplication>
+#include <limits>
 #include <QtEndian>
 
 // MythTV

--- a/mythtv/libs/libmythtv/io/mythavformatwriter.cpp
+++ b/mythtv/libs/libmythtv/io/mythavformatwriter.cpp
@@ -20,6 +20,7 @@
 #include "io/mythavformatwriter.h"
 
 #include <QtGlobal>
+#include <limits>
 #include <QtEndian>
 
 // MythTV

--- a/mythtv/libs/libmythtv/mpeg/atsctables.h
+++ b/mythtv/libs/libmythtv/mpeg/atsctables.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>  // uint32_t
 #include <QString>
+#include <limits>
 #include <QtEndian>
 
 #include "libmythbase/mythdate.h"

--- a/mythtv/libs/libmythtv/recorders/NuppelVideoRecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/NuppelVideoRecorder.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include <QStringList>
+#include <limits>
 #include <QtEndian>
 
 #include "libmyth/mythcontext.h"

--- a/mythtv/libs/libmythtv/recorders/RTjpegN.cpp
+++ b/mythtv/libs/libmythtv/recorders/RTjpegN.cpp
@@ -30,6 +30,7 @@
 #include "RTjpegN.h"
 
 #include <QtGlobal>
+#include <limits>
 #include <QtEndian>
 
 #ifdef MMX

--- a/mythtv/libs/libmythtv/recorders/rtp/rtcpdatapacket.h
+++ b/mythtv/libs/libmythtv/recorders/rtp/rtcpdatapacket.h
@@ -11,6 +11,7 @@
 
 #include <QHostAddress>
 #include <QByteArray>
+#include <limits>
 #include <QtEndian>
 
 #include "libmythbase/mythlogging.h"

--- a/mythtv/libs/libmythtv/recorders/rtp/rtpdatapacket.h
+++ b/mythtv/libs/libmythtv/recorders/rtp/rtpdatapacket.h
@@ -6,6 +6,7 @@
 #ifndef RTP_DATA_PACKET_H
 #define RTP_DATA_PACKET_H
 
+#include <limits>
 #include <QtEndian>
 
 #include "libmythbase/mythlogging.h"


### PR DESCRIPTION
Add #include <limits> before #include <QtEndian> to address QTBUG-90395

As reported in QTBUG-90395 recent compiler library headers no longer
automatically include limits, which can result in QtEndian producing
errors about numeric_limits not being declared.  The Qt fix is available
in some (but not necessarily all) distros thanks to the KDE team making
available patches that are not yet in publicly available Qt releases
(due to The Qt Company's revised availability strategy).

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

Fixes #631 

