### PR TITLE
Revert "GitHub Actions: overwrite prior cache instead of rotating"

### DIFF
--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -30,6 +30,9 @@ jobs:
         echo "MYTHTV_CONFIG=--prefix=${{ github.workspace }}/build/install --cc=${{ matrix.cc }} --cxx=${{ matrix.cxx }}" >> $GITHUB_ENV
         echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
 
+    # GitHub caches are immutable, so to update a cache, use a unique key with a
+    # prefixed restore-key.  GitHub will rotate the caches within their 10 GB
+    # storage limit.  See https://github.com/actions/cache/blob/471fb0c87e5d7210f339d8ea2e01505ddafd793d/workarounds.md#update-a-cache
     - name: Check ccache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.ccache
-        key: ${{ matrix.os }}-${{ matrix.cc }}-ccache-master
+        key: ${{ matrix.os }}-${{ matrix.cc }}-ccache-${{ github.sha }}
         restore-keys: ${{ matrix.os }}-${{ matrix.cc }}-ccache
 
     # N.B. These dependencies are for the master branch. Unlike the ansible playlists they do not include old dependencies that may


### PR DESCRIPTION
This reverts commit 1d4074607fe90b3183bdc287151cf11ea5a8d94a.

My understanding of the caches was incorrect.  The caches are immutable, see https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache

To keep the ccache up to date, restore the previous behavior of using a unique key for each run.  This is the accepted method to update a cache.

---

@stuarta This needs to be reverted to keep the cache up to date.  My reasoning was sound, but incorrect, since caches are immutable.