### PR TITLE
remove customization to FFmpeg regarding forced subtitles

### DIFF
--- a/mythtv/external/FFmpeg/libavcodec/avcodec.h
+++ b/mythtv/external/FFmpeg/libavcodec/avcodec.h
@@ -2322,7 +2322,6 @@ typedef struct AVSubtitle {
     unsigned num_rects;
     AVSubtitleRect **rects;
     int64_t pts;    ///< Same as packet pts, in AV_TIME_BASE
-    int forced;
 } AVSubtitle;
 
 /**

--- a/mythtv/external/FFmpeg/libavcodec/dvdsubdec.c
+++ b/mythtv/external/FFmpeg/libavcodec/dvdsubdec.c
@@ -418,10 +418,7 @@ static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
         cmd_pos = next_cmd_pos;
     }
     if (sub_header->num_rects > 0)
-    {
-        sub_header->forced = is_menu;
         return is_menu;
-    }
  fail:
     reset_rects(sub_header);
     return -1;

--- a/mythtv/external/FFmpeg/libavcodec/pgssubdec.c
+++ b/mythtv/external/FFmpeg/libavcodec/pgssubdec.c
@@ -63,7 +63,6 @@ typedef struct PGSSubPresentation {
     int id_number;
     int palette_id;
     int object_count;
-    int object_forced;
     PGSSubObjectRef objects[MAX_OBJECT_REFS];
     int64_t pts;
 } PGSSubPresentation;
@@ -468,8 +467,6 @@ static int parse_presentation_segment(AVCodecContext *avctx,
             object->crop_h = bytestream_get_be16(&buf);
         }
 
-        ctx->presentation.object_forced = (ctx->presentation.objects[i].composition_flag & 0x40) >> 6;
-
         ff_dlog(avctx, "Subtitle Placement x=%d, y=%d\n",
                 object->x, object->y);
 
@@ -509,7 +506,6 @@ static int display_end_segment(AVCodecContext *avctx, AVSubtitle *sub,
     memset(sub, 0, sizeof(*sub));
     sub->pts = pts;
     ctx->presentation.pts = AV_NOPTS_VALUE;
-    sub->forced             = ctx->presentation.object_forced;
     sub->start_display_time = 0;
     // There is no explicit end time for PGS subtitles.  The end time
     // is defined by the start of the next sub which may contain no

--- a/mythtv/libs/libmythtv/DVD/mythdvdbuffer.cpp
+++ b/mythtv/libs/libmythtv/DVD/mythdvdbuffer.cpp
@@ -1617,7 +1617,10 @@ bool MythDVDBuffer::DecodeSubtitles(AVSubtitle *Subtitle, int *GotSubtitles,
     {
         if (force_subtitle_display)
         {
-            Subtitle->forced = 1;
+            for (unsigned i = 0; i < Subtitle->num_rects; i++)
+            {
+                Subtitle->rects[i]->flags |= AV_SUBTITLE_FLAG_FORCED;
+            }
             LOG(VB_PLAYBACK, LOG_INFO, LOC + "Decoded forced subtitle");
         }
         return true;

--- a/mythtv/libs/libmythtv/captions/subtitlereader.cpp
+++ b/mythtv/libs/libmythtv/captions/subtitlereader.cpp
@@ -37,13 +37,19 @@ bool SubtitleReader::AddAVSubtitle(AVSubtitle &subtitle,
                                    bool allow_forced)
 {
     bool enableforced = false;
-    if (!m_avSubtitlesEnabled && !subtitle.forced)
+    bool forced = false;
+    for (unsigned i = 0; i < subtitle.num_rects; i++)
+    {
+        forced = forced || static_cast<bool>(subtitle.rects[i]->flags & AV_SUBTITLE_FLAG_FORCED);
+    }
+
+    if (!m_avSubtitlesEnabled && !forced)
     {
         FreeAVSubtitle(subtitle);
         return enableforced;
     }
 
-    if (!m_avSubtitlesEnabled && subtitle.forced)
+    if (!m_avSubtitlesEnabled && forced)
     {
         if (!allow_forced)
         {

--- a/mythtv/libs/libmythtv/captions/subtitlescreen.cpp
+++ b/mythtv/libs/libmythtv/captions/subtitlescreen.cpp
@@ -1911,7 +1911,7 @@ void SubtitleScreen::DisplayAVSubtitles(void)
                 {
                     bbox = QRect(0, 0, rect->w, uh);
                     uh = DisplayScaledAVSubtitles(rect, bbox, true, display,
-                                                  subtitle.forced,
+                                                  rect->flags & AV_SUBTITLE_FLAG_FORCED,
                                                   QString("avsub%1t").arg(i),
                                                   displayuntil, late);
                 }
@@ -1922,7 +1922,7 @@ void SubtitleScreen::DisplayAVSubtitles(void)
                 {
                     bbox = QRect(0, uh, rect->w, lh);
                     DisplayScaledAVSubtitles(rect, bbox, false, display,
-                                             subtitle.forced,
+                                             rect->flags & AV_SUBTITLE_FLAG_FORCED,
                                              QString("avsub%1b").arg(i),
                                              displayuntil, late);
                 }

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -4025,7 +4025,12 @@ bool AvFormatDecoder::ProcessSubtitlePacket(AVStream *curstream, AVPacket *pkt)
     if (gotSubtitles)
     {
         if (isForcedTrack)
-            subtitle.forced = static_cast<int>(true);
+        {
+            for (unsigned i = 0; i < subtitle.num_rects; i++)
+            {
+                subtitle.rects[i]->flags |= AV_SUBTITLE_FLAG_FORCED;
+            }
+        }
         LOG(VB_PLAYBACK | VB_TIMESTAMP, LOG_INFO, LOC +
             QString("subtl timecode %1 %2 %3 %4")
                 .arg(pkt->pts).arg(pkt->dts)


### PR DESCRIPTION
FFmpeg already has a method for detecting forced subtitles, so use that instead.  See commits for details.

I don't know if I have any DVDs with forced subtitles (and don't have a computer that can play Blu-rays), so I couldn't test it, but it should be equivalent to the prior behavior.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

