### PR TITLE
Fix BitReader

### DIFF
--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -45,7 +45,7 @@ class BitReader
     }
     ~BitReader() = default;
 
-    void skip_bits(unsigned n = 1)
+    void skip_bits(unsigned n)
     {
         if (m_cacheSize > n)
         {
@@ -83,7 +83,7 @@ class BitReader
     }
     bool next_bit() { return get_bits(1) == 1; }
     /// @brief Read 0-32 bits.
-    uint32_t get_bits(unsigned n = 1)
+    uint32_t get_bits(unsigned n)
     {
         uint32_t ret = show_bits(n);
         skip_bits(n);

--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -254,15 +254,16 @@ inline void BitReader::refill_cache(unsigned min_bits)
     {
         int shift = 64 - m_cacheSize;
         int bits = CHAR_BIT - m_bitIndex;
-        m_cache |= int64_t(*m_buffer & ((1 << bits) - 1)) << (shift - bits);
         if (shift > bits)
         {
+            m_cache |= int64_t(*m_buffer & ((1 << bits) - 1)) << (shift - bits);
             m_bitIndex   = 0;
             m_buffer++;
             m_cacheSize += bits;
         }
         else
         {
+            m_cache |= int64_t(*m_buffer & ((1 << bits) - 1)) >> (bits - shift);
             m_bitIndex  += shift;
             m_cacheSize += shift;
         }

--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -187,14 +187,6 @@ class BitReader
 #endif
     }
 
-    static constexpr uint64_t mask_upper(unsigned bits)
-    {
-        // protect against undefined behavior
-        if (bits ==  0) return  UINT64_C(0);
-        if (bits >  64) return ~UINT64_C(0);
-        return ~((UINT64_C(1) << (64 - bits)) - 1);
-    }
-
     static constexpr uint64_t get_upper_bits(uint64_t val, unsigned bits)
     {
         // protect against undefined behavior
@@ -206,7 +198,7 @@ class BitReader
         {
             return val;
         }
-        return (val & mask_upper(bits)) >> (64 - bits);
+        return val >> (64 - bits);
     }
 
     void refill_cache(unsigned min_bits);

--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -47,14 +47,16 @@ class BitReader
 
     void skip_bits(unsigned n = 1)
     {
-        if (m_cacheSize >= n)
+        if (m_cacheSize > n)
         {
             m_cache <<= n;
             m_cacheSize -= n;
         }
         else
         {
+            n -= m_cacheSize;
             m_cacheSize = 0;
+            m_cache      = 0;
             m_bitIndex += n;
             int quotient = m_bitIndex / CHAR_BIT;
             m_bitIndex %= CHAR_BIT;

--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -72,7 +72,7 @@ class BitReader
         }
         return uint32_t(get_upper_bits(m_cache, n));
     }
-    uint32_t show_bits64(unsigned n)
+    uint64_t show_bits64(unsigned n)
     {
         //assert(n <= 64);
         if (m_cacheSize < n)

--- a/mythtv/libs/libmythtv/mpeg/HEVCParser.cpp
+++ b/mythtv/libs/libmythtv/mpeg/HEVCParser.cpp
@@ -1295,7 +1295,7 @@ bool HEVCParser::parseSliceSegmentHeader(BitReader& br)
         br.get_ue_golomb(); // slice_type; // ue(v)
         if (pps->output_flag_present_flag)
         {
-            br.get_bits(); // pic_output_flag; // u(1)
+            br.get_bits(1); // pic_output_flag; // u(1)
         }
         if (sps->separate_colour_plane_flag)
         {

--- a/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
+++ b/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
@@ -134,9 +134,9 @@ void TestBitReader::get_bits64()
     auto br = BitReader(array.data(), array.size());
 
     br.skip_bits(4);
-    QCOMPARE(br.get_bits64(64), 0xDEAD'BEEF'DEAD'BEEFU);
+    QCOMPARE(br.get_bits64(64), UINT64_C(0xDEAD'BEEF'DEAD'BEEF));
     QCOMPARE(br.get_bits_left(), 68);
-    QCOMPARE(br.get_bits64(64), 0x3141'5926'5358'9793U);
+    QCOMPARE(br.get_bits64(64), UINT64_C(0x3141'5926'5358'9793));
     QCOMPARE(br.get_bits_left(), 4);
 }
 
@@ -149,7 +149,7 @@ void TestBitReader::get_bits64_aligned()
 
     auto br = BitReader(array.data(), array.size());
 
-    QCOMPARE(br.get_bits64(64), 0xDEAD'BEEF'DEAD'BEEFU);
+    QCOMPARE(br.get_bits64(64), UINT64_C(0xDEAD'BEEF'DEAD'BEEF));
     QCOMPARE(br.get_bits_left(), 0);
 
 }

--- a/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
+++ b/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
@@ -22,7 +22,7 @@
 #include <array>
 #include <cstdint>
 
-void TestBitReader::skip_bits_aligned()
+void TestBitReader::skip_bits_nonaligned()
 {
     constexpr std::array<uint8_t, 16> array =
     {
@@ -54,7 +54,7 @@ void TestBitReader::skip_bits_aligned()
     QCOMPARE(br.get_bits_left(),  0);
 }
 
-void TestBitReader::skip_bits_nonaligned()
+void TestBitReader::skip_bits_aligned()
 {
     constexpr std::array<uint8_t, 16> array =
     {

--- a/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
+++ b/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
@@ -46,10 +46,10 @@ void TestBitReader::skip_bits_aligned()
     QCOMPARE(br.get_bits_left(), 75);
     br.skip_bits(11);
     QCOMPARE(br.get_bits_left(), 64);
-    br.skip_bits(); // skip first bit for 15 zeroes
+    br.skip_bits(1); // skip first bit for 15 zeroes
     QCOMPARE(br.get_se_golomb(), -28502);
     QCOMPARE(br.get_bits_left(), 32);
-    br.skip_bits(); // skip first bit for 15 zeroes
+    br.skip_bits(1); // skip first bit for 15 zeroes
     QCOMPARE(br.get_se_golomb(), +28502);
     QCOMPARE(br.get_bits_left(),  0);
 }
@@ -76,10 +76,10 @@ void TestBitReader::skip_bits_nonaligned()
     QCOMPARE(br.get_bits_left(), 80);
     br.skip_bits(16);
     QCOMPARE(br.get_bits_left(), 64);
-    br.skip_bits(); // skip first bit for 15 zeroes
+    br.skip_bits(1); // skip first bit for 15 zeroes
     QCOMPARE(br.get_se_golomb(), -28502);
     QCOMPARE(br.get_bits_left(), 32);
-    br.skip_bits(); // skip first bit for 15 zeroes
+    br.skip_bits(1); // skip first bit for 15 zeroes
     QCOMPARE(br.get_se_golomb(), +28502);
     QCOMPARE(br.get_bits_left(),  0);
 }
@@ -107,7 +107,7 @@ void TestBitReader::get_bits()
     QCOMPARE(br.get_bits_left(), INT64_C(17));
 
     // start at byte index 2
-    br.skip_bits();
+    br.skip_bits(1);
     QCOMPARE(br.get_ue_golomb_31(), -1); // too big
     QCOMPARE(br.get_bits_left(), INT64_C(3));
     QCOMPARE(br.get_ue_golomb_31(), 0);
@@ -162,7 +162,7 @@ void TestBitReader::get_ue_golomb_long()
         0xDE, 0xAD, 0xBE, 0xEF, // 3735928558 + 1
     };
     auto br2 = BitReader(array2.data(), array2.size());
-    br2.skip_bits(); // skip first bit for 31 zeroes
+    br2.skip_bits(1); // skip first bit for 31 zeroes
     QCOMPARE(br2.get_ue_golomb_long(), 3735928558U);
     QCOMPARE(br2.get_bits_left(), INT64_C(0));
 }
@@ -177,10 +177,10 @@ void TestBitReader::get_se_golomb1()
         0xDE, 0xAD, 0xBE, 0xEE, // ((2 * 1867964279) - 1) + 1
     };
     auto br3 = BitReader(array3.data(), array3.size());
-    br3.skip_bits(); // skip first bit for 31 zeroes
+    br3.skip_bits(1); // skip first bit for 31 zeroes
     QCOMPARE(br3.get_se_golomb(), -1867964279);
     QCOMPARE(br3.get_bits_left(), INT64_C(64));
-    br3.skip_bits(); // skip first bit for 31 zeroes
+    br3.skip_bits(1); // skip first bit for 31 zeroes
     QCOMPARE(br3.get_se_golomb(), +1867964279);
     QCOMPARE(br3.get_bits_left(), INT64_C(0));
 }
@@ -195,10 +195,10 @@ void TestBitReader::get_se_golomb2()
         0xDE, 0xAC, // ((2 * 28502) - 1) + 1
     };
     auto br4 = BitReader(array4.data(), array4.size());
-    br4.skip_bits(); // skip first bit for 15 zeroes
+    br4.skip_bits(1); // skip first bit for 15 zeroes
     QCOMPARE(br4.get_se_golomb(), -28502);
     QCOMPARE(br4.get_bits_left(), INT64_C(32));
-    br4.skip_bits(); // skip first bit for 15 zeroes
+    br4.skip_bits(1); // skip first bit for 15 zeroes
     QCOMPARE(br4.get_se_golomb(), +28502);
     QCOMPARE(br4.get_bits_left(), INT64_C(0));
 }

--- a/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.h
+++ b/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.h
@@ -29,7 +29,11 @@ class TestBitReader : public QObject
     Q_OBJECT
 
   private slots:
+    static void skip_bits_aligned();
+    static void skip_bits_nonaligned();
     static void get_bits();
+    static void get_bits64();
+    static void get_bits64_aligned();
     static void get_ue_golomb_long();
     static void get_se_golomb1();
     static void get_se_golomb2();

--- a/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.h
+++ b/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.h
@@ -29,8 +29,8 @@ class TestBitReader : public QObject
     Q_OBJECT
 
   private slots:
-    static void skip_bits_aligned();
     static void skip_bits_nonaligned();
+    static void skip_bits_aligned();
     static void get_bits();
     static void get_bits64();
     static void get_bits64_aligned();


### PR DESCRIPTION
@jpoet The first three commits are fixes, then more unit tests, and some minor tidying up.

skip_bits() was broken for non aligned byte skips when the cache had data in it.  The new unit tests satisfy me that it works correctly now, but testing would be appreciated.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

