### PR TITLE
Manual Recordings: restore date time subtitle

### DIFF
--- a/mythtv/programs/mythbackend/scheduler.cpp
+++ b/mythtv/programs/mythbackend/scheduler.cpp
@@ -3789,7 +3789,9 @@ void Scheduler::UpdateManuals(uint recordid)
             query.bindValue(":STARTTIME", startdt);
             query.bindValue(":ENDTIME", startdt.addSecs(duration));
             query.bindValue(":TITLE", title);
-            query.bindValue(":SUBTITLE", subtitle);
+            query.bindValue(":SUBTITLE",
+                            !subtitle.isEmpty() ? subtitle :
+                            MythDate::toString(startdt, MythDate::kDatabase | MythDate::kOverrideLocal));
             query.bindValue(":DESCRIPTION", description);
             query.bindValue(":SEASON", season);
             query.bindValue(":EPISODE", episode);


### PR DESCRIPTION
Apparently removed in 5f6697ecfaf9bd7175aaf99b3ef07f884d5af65c

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

