### PR TITLE
Replace QRandomGenerator with MythRandom

### DIFF
--- a/mythtv/programs/mythfrontend/gallerytransitions.cpp
+++ b/mythtv/programs/mythfrontend/gallerytransitions.cpp
@@ -3,8 +3,7 @@
 #include <utility>
 
 #include "libmythbase/mythcorecontext.h"
-
-#include <QRandomGenerator>
+#include "libmythbase/mythrandom.h"
 
 #define LOC QString("Transition: ")
 
@@ -406,7 +405,7 @@ void TransitionSpin::Finalise()
 void TransitionRandom::Start(Slide &from, Slide &to, bool forwards, float speed)
 {
     // Select a random peer.
-    int rand = QRandomGenerator::global()->bounded(m_peers.size());
+    int rand = MythRandom(0, m_peers.size() - 1);
     m_current = m_peers[rand];
     // Invoke peer
     connect(m_current, &Transition::finished, this, &TransitionRandom::Finished);

--- a/mythtv/programs/mythfrontend/galleryviews.cpp
+++ b/mythtv/programs/mythfrontend/galleryviews.cpp
@@ -1,10 +1,11 @@
 #include "galleryviews.h"
 
-#include <algorithm>
-#include <cmath> // for qsrand
+#include <algorithm> // std::shuffle, upper_bound
+#include <cmath>     // std::pow
+#include <iterator>  // std::distance
 #include <random>
 
-#include <QRandomGenerator>
+#include "libmythbase/mythrandom.h"
 
 #define LOC QString("Galleryviews: ")
 
@@ -246,20 +247,25 @@ void FlatView::Populate(ImageList &files)
         }
         else if (m_order == kRandom)
         {
-            QVector<quint32> rands;
-            rands.resize(files.size());
-            QRandomGenerator::global()->fillRange(rands.data(), rands.size());
-
             // An image is not a valid candidate for its successor
+            // add files.size() elements from files in a random order
+            // to m_sequence allowing non-consecutive repetition
+            int size  = files.size();
             int range = files.size() - 1;
-            int index = range;
-            for (int count = 0; count < files.size(); ++count)
+            int last  = size; // outside of the random interval [0, size)
+            int count = 0;
+            while (count < size)
             {
-                int rand = rands[count] % range;
+                int rand = MythRandom(0, range);
 
                 // Avoid consecutive repeats
-                index = (rand < index) ? rand : rand + 1;
-                m_sequence.append(files.at(index)->m_id);
+                if (last == rand)
+                {
+                    continue;
+                }
+                last = rand;
+                m_sequence.append(files.at(rand)->m_id);
+                count++;
             }
         }
         else if (m_order == kSeasonal)
@@ -267,12 +273,14 @@ void FlatView::Populate(ImageList &files)
             WeightList weights   = CalculateSeasonalWeights(files);
             double     maxWeight = weights.last();
 
-            auto *randgen = QRandomGenerator::global();
+            static std::random_device rd;
+            static auto generator = MythRandomGenerator_32(rd());
+            auto distrib = std::uniform_real_distribution(0.0, maxWeight);
+            // TODO use fixed not floating point
 
             for (int count = 0; count < files.size(); ++count)
             {
-                // generateDouble() returns in the range [0, 1)
-                double randWeight = randgen->generateDouble() * maxWeight;
+                double randWeight = distrib(generator);
                 WeightList::iterator it =
                         std::upper_bound(weights.begin(), weights.end(), randWeight);
                 int    index      = std::distance(weights.begin(), it);


### PR DESCRIPTION
Also, convert "uniform" random floating point to uniform random integers, due to the issues with random floating point implementations.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

