### PR TITLE
mythfrontend/guidegrid.cpp: prevent segmentation fault from no channels

### DIFF
--- a/mythtv/programs/mythfrontend/guidegrid.cpp
+++ b/mythtv/programs/mythfrontend/guidegrid.cpp
@@ -591,7 +591,7 @@ void GuideGrid::Load(void)
     setStartChannel((int)(m_currentStartChannel) - (m_channelCount / 2));
     m_channelCount = std::min(m_channelCount, maxchannel + 1);
 
-    for (int y = 0; y < m_channelCount; ++y)
+    for (int y = 0; y < m_channelCount && y < static_cast<int>(m_channelInfos.size()); ++y)
     {
         int chanNum = y + m_currentStartChannel;
         if (chanNum >= (int) m_channelInfos.size())


### PR DESCRIPTION
Tested with the bad MySQL and fewer channels than the guide displays. This had no noticeable change to the behavior of master (with the fixed MySQL).

Fixes https://github.com/MythTV/mythtv/issues/647

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

