### PR TITLE
HEVCParser: fix parsing of st_ref_pic_set( stRpsIdx )

### DIFF
--- a/mythtv/libs/libmythtv/mpeg/HEVCParser.cpp
+++ b/mythtv/libs/libmythtv/mpeg/HEVCParser.cpp
@@ -1103,6 +1103,7 @@ static bool shortTermRefPicSet(BitReader& br, int stRPSIdx,
 
         for (int j = 0; j <= RefRPS->NumDeltaPocs; ++j)
         {
+            used_by_curr_pic_flag[j] = br.get_bits(1); // u(1)
             /*
               use_delta_flag[ j ] equal to 1 specifies that the
               j-th entry in the source candidate short-term RPS
@@ -1113,8 +1114,14 @@ static bool shortTermRefPicSet(BitReader& br, int stRPSIdx,
               short-term RPS. When use_delta_flag[ j ] is not
               present, its value is inferred to be equal to 1.
             */
-            bool val = br.get_bits(1);
-            use_delta_flag[j] = used_by_curr_pic_flag[j] ? val : true;
+            if (!used_by_curr_pic_flag[j])
+            {
+                use_delta_flag[j] = br.get_bits(1); // u(1)
+            }
+            else
+            {
+                use_delta_flag[j] = true;
+            }
         }
 
 


### PR DESCRIPTION
This caused the bitstream to become misaligned for the satelite channel FashionTV UHD, which then caused the framerate to become an incorrect value.

Fixes https://github.com/MythTV/mythtv/issues/650

---

I could only test with two HEVC samples, so further testing would be greatly appreciated.