### PR TITLE
Remove unnecessary python imports in tvmaze.py

### DIFF
--- a/mythtv/programs/scripts/metadata/Television/tvmaze.py
+++ b/mythtv/programs/scripts/metadata/Television/tvmaze.py
@@ -68,8 +68,7 @@ def get_show_art_lists(tvmaze_show_id):
 def buildList(tvtitle, opts):
     # option -M title
     from lxml import etree
-    from MythTV import VideoMetadata, datetime
-    from MythTV.utility import levenshtein
+    from MythTV import VideoMetadata
     from MythTV.tvmaze import tvmaze_api as tvmaze
     from MythTV.tvmaze import locales
 
@@ -354,10 +353,7 @@ def buildSingle(args, opts, tvmaze_episode_id=None):
     # option -D inetref season episode
 
     from lxml import etree
-    from MythTV import VideoMetadata, datetime
-    from MythTV.utility import levenshtein
     from MythTV.tvmaze import tvmaze_api as tvmaze
-    from MythTV.tvmaze import locales
 
     if opts.debug:
         dstr = "Function 'buildSingle' called with arguments: " + \
@@ -507,8 +503,7 @@ def buildSingleItem(inetref, season, episode_id):
 def buildCollection(tvinetref, opts):
     # option -C inetref
     from lxml import etree
-    from MythTV import VideoMetadata, datetime
-    from MythTV.utility import levenshtein
+    from MythTV import VideoMetadata
     from MythTV.tvmaze import tvmaze_api as tvmaze
     from MythTV.tvmaze import locales
 


### PR DESCRIPTION
The tool **pylint** reported several unnecessary includes in tvmaze.py. These have been removed to make the script run a little bit faster.

Refs: #654

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

