### PR TITLE
Fix setting of TvMaze show runtime

### DIFF
--- a/mythtv/bindings/python/tvmaze/show.py
+++ b/mythtv/bindings/python/tvmaze/show.py
@@ -47,7 +47,10 @@ class Show(object):
         self.language = show.get('language')
         self.genres = show.get('genres')
         self.status = show.get('status')
-        self.num_episodes = show.get('runtime')
+        self.runtime = show.get('runtime')
+        # Sometimes runtime is empty, but averageRuntime is not
+        if self.runtime is None:
+            self.runtime = show.get('averageRuntime')
         self.seasons = {}
         self._episode_list = []
         self.specials = {}

--- a/mythtv/programs/scripts/metadata/Television/tvmaze.py
+++ b/mythtv/programs/scripts/metadata/Television/tvmaze.py
@@ -446,7 +446,8 @@ def buildSingleItem(inetref, season, episode_id):
     elif show_info.premiere_date:
         m.releasedate = check_item(m, ("releasedate", show_info.premiere_date))
         m.year = check_item(m, ("year", show_info.premiere_date.year))
-    m.runtime = check_item(m, ("runtime", int(ep_info.duration)))
+    if ep_info.duration:
+        m.runtime = check_item(m, ("runtime", int(ep_info.duration)))
 
     for actor in show_info.cast:
         try:

--- a/mythtv/programs/scripts/metadata/Television/tvmaze.py
+++ b/mythtv/programs/scripts/metadata/Television/tvmaze.py
@@ -541,6 +541,7 @@ def buildCollection(tvinetref, opts):
     m.imdb = check_item(m, ("imdb", str(show_info.external_ids['imdb'])))
     m.language = check_item(m, ("language", str(locales.Language.getstored(show_info.language))))
     m.userrating = check_item(m, ("userrating", show_info.rating['average']))
+    m.runtime = check_item(m, ("runtime", show_info.runtime))
     try:
         m.popularity = check_item(m, ("popularity", float(show_info.weight)), ignore=False)
     except (TypeError, ValueError):


### PR DESCRIPTION
The script tvmaze/show.py had a line which retrieved the episode duration from the metadata provider, but then assigned it to **num_episodes**, which makes no sense. There is no code looking for **num_episodes**, but there is code looking for **runtime**, so the line has been fixed to assign to **runtime**.

Using the TVmaze service for metadata lookup, there are rare cases where the 'runtime' field is empty, but 'averageRuntime' is not. This happened when looking up metadata for a TV show called "Everything's Trash". Note that the database entry for this show was subsequently updated to include the missing 'runtime' field. But on the night it was recorded, and for several days later, that field was null.

Here's an excerpt of the original metadata for "Everything's Trash":

"id":60518,
"url":"https://www.tvmaze.com/shows/60518/everythings-trash",
"name":"Everything's Trash",
"type":"Scripted",
"language":"English",
"genres":[],
"status":"Running",
"runtime":**null**,
"averageRuntime":**30**,

To handle this type of scenario, when the 'runtime' field is null, read the duration from the 'averageRuntime' field. If both are null, then avoid trying to cast that value to an integer in tvmaze.py.

Refs: #654

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

