### PR TITLE
Handle null timestamp or runtime fields in TvMaze data

### DIFF
--- a/mythtv/programs/scripts/metadata/Television/tvmaze.py
+++ b/mythtv/programs/scripts/metadata/Television/tvmaze.py
@@ -244,31 +244,43 @@ def buildNumbers(args, opts):
             early_match_list = []
             minTimeDelta = timedelta(minutes=60)
             for i, ep in enumerate(episodes):
-                epInTgtZone = datetime.fromIso(ep.timestamp, tz = posixtzinfo(show_tz))
-                durationDelta = timedelta(minutes=ep.duration)
+                if ep.timestamp:
+                    epInTgtZone = datetime.fromIso(ep.timestamp, tz = posixtzinfo(show_tz))
+                    if ep.duration:
+                        durationDelta = timedelta(minutes=ep.duration)
+                    else:
+                        durationDelta = timedelta(minutes=0)
 
-                # Consider it a match if the recording starts late, but within the duration of the show.
-                if epInTgtZone <= dtInTgtZone < epInTgtZone+durationDelta:
-                    # Recording start time is within the range of this episode
-                    if opts.debug:
-                        print('Recording in range of inetref %d, season %d, episode %d (%s ... %s)' \
+                    if epInTgtZone == dtInTgtZone:
+                        if opts.debug:
+                            print('Recording matches inetref %d, season %d, episode %d at %s' \
+                                % (inetref, ep.season, ep.number, epInTgtZone))
+                        time_match_list.append(i)
+                        minTimeDelta = timedelta(minutes=0)
+
+                    # Consider it a match if the recording starts late,
+                    # but within the duration of the show.
+                    elif epInTgtZone < dtInTgtZone < epInTgtZone+durationDelta:
+                        # Recording start time is within the range of this episode
+                        if opts.debug:
+                            print('Recording in range of inetref %d, season %d, episode %d (%s ... %s)' \
                                 % (inetref, ep.season, ep.number, epInTgtZone, epInTgtZone+durationDelta))
-                    time_match_list.append(i)
-                    minTimeDelta = timedelta(minutes=0)
-                # Consider it a match if the recording is a little bit early. This helps cases
-                # where you set up a rule to record, at say 9:00, and the broadcaster uses a
-                # slightly odd start time, like 9:05.
-                elif epInTgtZone-minTimeDelta <= dtInTgtZone < epInTgtZone:
-                    # Recording started earlier than this episode, so see if it's the closest match
-                    if epInTgtZone - dtInTgtZone == minTimeDelta:
-                        if opts.debug:
-                            print('adding episode to closest list', epInTgtZone - dtInTgtZone, '\n')
-                        early_match_list.append(i)
-                    elif epInTgtZone - dtInTgtZone < minTimeDelta:
-                        if opts.debug:
-                            print('this episode is new closest', epInTgtZone - dtInTgtZone, '\n')
-                        minTimeDelta = epInTgtZone - dtInTgtZone
-                        early_match_list = [i]
+                        time_match_list.append(i)
+                        minTimeDelta = timedelta(minutes=0)
+                    # Consider it a match if the recording is a little bit early. This helps cases
+                    # where you set up a rule to record, at say 9:00, and the broadcaster uses a
+                    # slightly odd start time, like 9:05.
+                    elif epInTgtZone-minTimeDelta <= dtInTgtZone < epInTgtZone:
+                        # Recording started earlier than this episode, so see if it's the closest match
+                        if epInTgtZone - dtInTgtZone == minTimeDelta:
+                            if opts.debug:
+                                print('adding episode to closest list', epInTgtZone - dtInTgtZone, '\n')
+                            early_match_list.append(i)
+                        elif epInTgtZone - dtInTgtZone < minTimeDelta:
+                            if opts.debug:
+                                print('this episode is new closest', epInTgtZone - dtInTgtZone, '\n')
+                            minTimeDelta = epInTgtZone - dtInTgtZone
+                            early_match_list = [i]
 
             if not time_match_list:
                 # No exact matches found, so use the list of the closest episode(s)

--- a/mythtv/programs/scripts/metadata/Television/tvmaze.py
+++ b/mythtv/programs/scripts/metadata/Television/tvmaze.py
@@ -227,10 +227,19 @@ def buildNumbers(args, opts):
                 if show_network is None:
                     show_network = show_info.streaming_service
                 show_country = show_network.get('country')
-                show_tz = show_country.get('timezone')
+                # Some webChannels don't specify country or timezone
+                if show_country:
+                    show_tz = show_country.get('timezone')
+                else:
+                    show_tz = None
                 dtInTgtZone = dtInLocalZone.astimezone(posixtzinfo(show_tz))
+                # For at least one timezone, the following exception may be thrown.
+                # UnboundLocalError: local variable 'ttmfmt' referenced before assignment
+                # Example:  tvmaze.py --debug -N "The Masked Singer" "2022-11-24 19:00:00"
 
-            except (ValueError, AttributeError) as e:
+            except (ValueError, AttributeError, UnboundLocalError) as e:
+                if opts.debug:
+                    print('show_tz =%s, except = %s' % (show_tz, e))
                 dtInTgtZone = None
 
         if dtInTgtZone:
@@ -253,18 +262,16 @@ def buildNumbers(args, opts):
 
                     if epInTgtZone == dtInTgtZone:
                         if opts.debug:
-                            print('Recording matches inetref %d, season %d, episode %d at %s' \
-                                % (inetref, ep.season, ep.number, epInTgtZone))
+                            print('Recording matches \'%s\' at %s' % (ep, epInTgtZone))
                         time_match_list.append(i)
                         minTimeDelta = timedelta(minutes=0)
-
                     # Consider it a match if the recording starts late,
                     # but within the duration of the show.
                     elif epInTgtZone < dtInTgtZone < epInTgtZone+durationDelta:
                         # Recording start time is within the range of this episode
                         if opts.debug:
-                            print('Recording in range of inetref %d, season %d, episode %d (%s ... %s)' \
-                                % (inetref, ep.season, ep.number, epInTgtZone, epInTgtZone+durationDelta))
+                            print('Recording in range of \'%s\' (%s ... %s)' \
+                                % (ep, epInTgtZone, epInTgtZone+durationDelta))
                         time_match_list.append(i)
                         minTimeDelta = timedelta(minutes=0)
                     # Consider it a match if the recording is a little bit early. This helps cases
@@ -274,11 +281,13 @@ def buildNumbers(args, opts):
                         # Recording started earlier than this episode, so see if it's the closest match
                         if epInTgtZone - dtInTgtZone == minTimeDelta:
                             if opts.debug:
-                                print('adding episode to closest list', epInTgtZone - dtInTgtZone, '\n')
+                                print('Adding episode \'%s\' to closest list. Offset = %s' \
+                                    % (ep, epInTgtZone - dtInTgtZone))
                             early_match_list.append(i)
                         elif epInTgtZone - dtInTgtZone < minTimeDelta:
                             if opts.debug:
-                                print('this episode is new closest', epInTgtZone - dtInTgtZone, '\n')
+                                print('Episode \'%s\' is new closest. Offset = %s' \
+                                    % (ep, epInTgtZone - dtInTgtZone))
                             minTimeDelta = epInTgtZone - dtInTgtZone
                             early_match_list = [i]
 

--- a/mythtv/programs/scripts/metadata/Television/tvmaze.py
+++ b/mythtv/programs/scripts/metadata/Television/tvmaze.py
@@ -233,11 +233,8 @@ def buildNumbers(args, opts):
                 else:
                     show_tz = None
                 dtInTgtZone = dtInLocalZone.astimezone(posixtzinfo(show_tz))
-                # For at least one timezone, the following exception may be thrown.
-                # UnboundLocalError: local variable 'ttmfmt' referenced before assignment
-                # Example:  tvmaze.py --debug -N "The Masked Singer" "2022-11-24 19:00:00"
 
-            except (ValueError, AttributeError, UnboundLocalError) as e:
+            except (ValueError, AttributeError) as e:
                 if opts.debug:
                     print('show_tz =%s, except = %s' % (show_tz, e))
                 dtInTgtZone = None


### PR DESCRIPTION
In rare cases, the TvMaze database provides null **timestamp** or **runtime** data fields. To make the metadata retrieval script more fault tolerant, null checks have been added for these values.

When the timestamp field is null, don't use it to generate a datetime to use in a search for a matching episode.

When the runtime duration field is null, the delta size is now set to zero minutes. The code which looks for an episode match has been updated to separate "on time" recordings from "a little late" recordings to accommodate the possible delta size of zero.

Refs: #654

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

