### PR TITLE
Default to last channel used in Manual Record rule

### DIFF
--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -2941,6 +2941,19 @@ static GlobalTextEditSetting *SortPrefixExceptions()
     return gc;
 }
 
+static GlobalComboBoxSetting *ManualRecordStartChanType()
+{
+    auto *gc = new GlobalComboBoxSetting("ManualRecordStartChanType");
+
+    gc->setLabel(GeneralSettings::tr("Starting channel for Manual Record"));
+    gc->addSelection(GeneralSettings::tr("Guide Starting Channel"), "1", true);
+    gc->addSelection(GeneralSettings::tr("Last Manual Record Channel"), "2");
+    gc->setHelpText(GeneralSettings::tr(
+                        "When entering a new Manual Record Rule, "
+                        "the starting channel will default to this."));
+    return gc;
+}
+
 // General RecPriorities settings
 
 static GlobalComboBoxSetting *GRSchedOpenEnd()
@@ -4121,6 +4134,7 @@ MainGeneralSettings::MainGeneralSettings()
         general->addChild(stripPrefixes);
         stripPrefixes->addTargetedChild("1", SortPrefixExceptions());
     }
+    general->addChild(ManualRecordStartChanType());
     addChild(general);
 
     addChild(EnableMediaMon());

--- a/mythtv/programs/mythfrontend/manualschedule.cpp
+++ b/mythtv/programs/mythfrontend/manualschedule.cpp
@@ -56,6 +56,8 @@ bool ManualSchedule::Create(void)
 
     QString startchan = gCoreContext->GetSetting("DefaultTVChannel", "");
     QString chanorder = gCoreContext->GetSetting("ChannelOrdering", "channum");
+    QString lastManualRecordChan = gCoreContext->GetSetting("LastManualRecordChan", startchan);
+    int manStartChanType = gCoreContext->GetNumSetting("ManualRecordStartChanType", 1);
     ChannelInfoList channels = ChannelUtil::GetChannels(0, true, "channum,callsign");
     ChannelUtil::SortChannels(channels, chanorder);
 
@@ -67,17 +69,25 @@ bool ManualSchedule::Create(void)
         InfoMap infomap;
         channels[i].ToMap(infomap);
         item->SetTextFromMap(infomap);
-        if (channels[i].m_chanNum == startchan)
+        if (manStartChanType == 1)
         {
-            m_channelList->SetItemCurrent(i);
-            startchan = "";
+            // Use DefaultTVChannel as starting channel
+            if (channels[i].m_chanNum == startchan)
+            {
+                m_channelList->SetItemCurrent(i);
+                startchan = "";
+            }
+        }
+        else
+        {
+            // Use LastManualRecordChan as starting channel
+            if (channels[i].m_chanNum == lastManualRecordChan)
+            {
+                m_channelList->SetItemCurrent(i);
+                lastManualRecordChan = "";
+            }
         }
         m_chanids.push_back(channels[i].m_chanId);
-    }
-
-    if (s_lastChannelIndex != -1)
-    {
-        m_channelList->SetItemCurrent(s_lastChannelIndex);
     }
 
     for (uint index = 0; index <= 60; index++)
@@ -213,7 +223,10 @@ void ManualSchedule::recordClicked(void)
                   m_chanids[m_channelList->GetCurrentPos()],
                   m_startDateTime, endts);
 
-    s_lastChannelIndex = m_channelList->GetCurrentPos();
+    // Save the channel because we might want to use it as the
+    // starting channel for the next Manual Record rule.
+    gCoreContext->SaveSetting("LastManualRecordChan",
+        ChannelUtil::GetChanNum(m_chanids[m_channelList->GetCurrentPos()]));
 
     auto *record = new RecordingRule();
     record->LoadByProgram(&p);

--- a/mythtv/programs/mythfrontend/manualschedule.cpp
+++ b/mythtv/programs/mythfrontend/manualschedule.cpp
@@ -21,6 +21,8 @@
 #include "manualschedule.h"
 #include "scheduleeditor.h"
 
+int ManualSchedule::last_manual_chan = -1;
+
 ManualSchedule::ManualSchedule(MythScreenStack *parent)
     : MythScreenType(parent, "ManualSchedule"),
       m_nowDateTime(MythDate::current()),
@@ -74,6 +76,9 @@ bool ManualSchedule::Create(void)
         }
         m_chanids.push_back(channels[i].m_chanId);
     }
+
+    if (last_manual_chan != -1)
+        m_channelList->SetItemCurrent(last_manual_chan);
 
     for (uint index = 0; index <= 60; index++)
     {
@@ -207,6 +212,8 @@ void ManualSchedule::recordClicked(void)
     ProgramInfo p(m_titleEdit->GetText().trimmed(),
                   m_chanids[m_channelList->GetCurrentPos()],
                   m_startDateTime, endts);
+
+    last_manual_chan = m_channelList->GetCurrentPos();
 
     auto *record = new RecordingRule();
     record->LoadByProgram(&p);

--- a/mythtv/programs/mythfrontend/manualschedule.cpp
+++ b/mythtv/programs/mythfrontend/manualschedule.cpp
@@ -21,8 +21,6 @@
 #include "manualschedule.h"
 #include "scheduleeditor.h"
 
-int ManualSchedule::last_manual_chan = -1;
-
 ManualSchedule::ManualSchedule(MythScreenStack *parent)
     : MythScreenType(parent, "ManualSchedule"),
       m_nowDateTime(MythDate::current()),
@@ -77,8 +75,10 @@ bool ManualSchedule::Create(void)
         m_chanids.push_back(channels[i].m_chanId);
     }
 
-    if (last_manual_chan != -1)
-        m_channelList->SetItemCurrent(last_manual_chan);
+    if (s_lastChannelIndex != -1)
+    {
+        m_channelList->SetItemCurrent(s_lastChannelIndex);
+    }
 
     for (uint index = 0; index <= 60; index++)
     {
@@ -213,7 +213,7 @@ void ManualSchedule::recordClicked(void)
                   m_chanids[m_channelList->GetCurrentPos()],
                   m_startDateTime, endts);
 
-    last_manual_chan = m_channelList->GetCurrentPos();
+    s_lastChannelIndex = m_channelList->GetCurrentPos();
 
     auto *record = new RecordingRule();
     record->LoadByProgram(&p);

--- a/mythtv/programs/mythfrontend/manualschedule.h
+++ b/mythtv/programs/mythfrontend/manualschedule.h
@@ -60,6 +60,7 @@ class ManualSchedule : public MythScreenType
     QString m_startString;
     QString m_chanidString;
 
+    static int last_manual_chan; /* Channel used in the last manual schedule */
 };
 
 #endif

--- a/mythtv/programs/mythfrontend/manualschedule.h
+++ b/mythtv/programs/mythfrontend/manualschedule.h
@@ -60,6 +60,8 @@ class ManualSchedule : public MythScreenType
     QString m_startString;
     QString m_chanidString;
 
+    /// Index of channel used in the last Manual Schedule rule.
+    /** Special value -1 indicates there is no previous rule. */
     inline static int s_lastChannelIndex = -1;
 };
 

--- a/mythtv/programs/mythfrontend/manualschedule.h
+++ b/mythtv/programs/mythfrontend/manualschedule.h
@@ -60,7 +60,7 @@ class ManualSchedule : public MythScreenType
     QString m_startString;
     QString m_chanidString;
 
-    static int last_manual_chan; /* Channel used in the last manual schedule */
+    inline static int s_lastChannelIndex = -1;
 };
 
 #endif

--- a/mythtv/programs/mythfrontend/manualschedule.h
+++ b/mythtv/programs/mythfrontend/manualschedule.h
@@ -60,9 +60,6 @@ class ManualSchedule : public MythScreenType
     QString m_startString;
     QString m_chanidString;
 
-    /// Index of channel used in the last Manual Schedule rule.
-    /** Special value -1 indicates there is no previous rule. */
-    inline static int s_lastChannelIndex = -1;
 };
 
 #endif


### PR DESCRIPTION
When a user is entering a number of Manual Record rules in a row, it would be nice if the previously used channel was remembered and used as the default for the current rule. For example, if you wanted to enter rules to record Chicago Med, Chicago Fire, and Chicago P.D., which are all on the same channel, it would save time on the second and third rules, to default to the common channel.

To implement this, when a Manual Record rule is entered, store the channel number such that it can be set as the default channel for the next Manual Record rule.

Fixes #655

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

