### PR TITLE
Set Subtitle in Change Recording Metadata Search

### DIFF
--- a/mythtv/programs/mythfrontend/playbackbox.cpp
+++ b/mythtv/programs/mythfrontend/playbackbox.cpp
@@ -5307,7 +5307,7 @@ void RecMetadataEdit::QueryComplete(MetadataLookup *lookup)
     m_episodeSpin->SetValue(lookup->GetEpisode());
     if (!lookup->GetSubtitle().isEmpty())
     {
-        m_descriptionEdit->SetText(lookup->GetSubtitle());
+        m_subtitleEdit->SetText(lookup->GetSubtitle());
     }
     if (!lookup->GetDescription().isEmpty())
     {


### PR DESCRIPTION
After a metadata Search within the 'Edit Recording Metadata'
screen, the subtitle value is mistakenly written to the Description
field. Then that value is usually immediately overwritten by the
real description value.

This code change fixes the problem by properly
writing to the Subtitle field.

Resolves #667

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

