### PR TITLE
Fix big endian linking issues

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutpututil.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutpututil.cpp
@@ -212,9 +212,9 @@ char *AudioOutputUtil::GeneratePinkFrames(char *frames, int channels,
                     static_cast<float>(0x03fffffff);
                 int32_t ires = res;
                 if (bits == 16)
-                    *samp16++ = qToLittleEndian<int16_t>(ires >> 16);
+                    *samp16++ = qToLittleEndian<qint16>(ires >> 16);
                 else
-                    *samp32++ = qToLittleEndian<int32_t>(ires);
+                    *samp32++ = qToLittleEndian<qint32>(ires);
             }
             else
             {

--- a/mythtv/libs/libmyth/audio/eldutils.cpp
+++ b/mythtv/libs/libmyth/audio/eldutils.cpp
@@ -257,11 +257,11 @@ int eld::update_eld(const char *buf, int size)
     m_e.aud_synch_delay = GRAB_BITS(buf, 6, 0, 8) * 2;
     m_e.spk_alloc       = GRAB_BITS(buf, 7, 0, 7);
 
-    m_e.port_id         = qFromLittleEndian<uint64_t>(buf + 8);
+    m_e.port_id         = qFromLittleEndian<quint64>(buf + 8);
 
     /* not specified, but the spec's tendency is little endian */
-    m_e.manufacture_id  = qFromLittleEndian<uint16_t>(buf + 16);
-    m_e.product_id      = qFromLittleEndian<uint16_t>(buf + 18);
+    m_e.manufacture_id  = qFromLittleEndian<quint16>(buf + 16);
+    m_e.product_id      = qFromLittleEndian<quint16>(buf + 18);
 
     if (ELD_FIXED_BYTES + mnl > size)
     {

--- a/mythtv/libs/libmythtv/io/mythavformatwriter.cpp
+++ b/mythtv/libs/libmythtv/io/mythavformatwriter.cpp
@@ -270,7 +270,7 @@ int MythAVFormatWriter::WriteAudioFrame(unsigned char *Buffer, int /*FrameNumber
 #if (Q_BYTE_ORDER == Q_BIG_ENDIAN)
     auto buf16 = reinterpret_cast<uint16_t *>(Buffer);
     for (int i = 0; i < m_audioChannels * m_audioFrameSize; i++)
-        buf16[i] = qFromLittleEndian<uint16_t>(buf16[i]);
+        buf16[i] = qFromLittleEndian<quint16>(buf16[i]);
 #endif
 
     AVCodecContext *avctx   = m_codecMap.GetCodecContext(m_audioStream);

--- a/mythtv/libs/libmythtv/recorders/NuppelVideoRecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/NuppelVideoRecorder.cpp
@@ -2558,7 +2558,7 @@ void NuppelVideoRecorder::WriteAudio(unsigned char *buf, int fnum, std::chrono::
 #if (Q_BYTE_ORDER == Q_BIG_ENDIAN)
         auto buf16 = reinterpret_cast<uint16_t *>(buf);
         for (int i = 0; i < m_audioChannels * sample_cnt; i++)
-            buf16[i] = qToLittleEndian<uint16_t>(buf16[i]);
+            buf16[i] = qToLittleEndian<quint16>(buf16[i]);
 #endif
         if (m_audioChannels == 2)
         {


### PR DESCRIPTION
This code would compile but due to the way C++ handles templated types, it would look for this inlined routine to be exported at link time since the only templated types defined are Qt flavored integers.

Ideally this is generating single instruction byteswaps similar to what happens when you use compiler builtins but admittedly I never checked.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

