### PR TITLE
MythMusic: WaveForm visualization of whole track

### DIFF
--- a/mythplugins/mythmusic/mythmusic/mainvisual.cpp
+++ b/mythplugins/mythmusic/mythmusic/mainvisual.cpp
@@ -218,7 +218,7 @@ void MainVisual::timeout()
                 break;
 
             if (m_vis)
-                m_vis->processUndisplayed(node);
+                m_vis->processUndisplayed(m_nodes.first());
 
             delete m_nodes.first();
             m_nodes.removeFirst();

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -562,7 +562,7 @@ void WaveForm::saveload(MusicMetadata *meta)
         }
         filename = QString("%1/%2.png").arg(cache)
             .arg(stream ? 0 : m_currentMetadata->ID());
-        LOG(VB_GENERAL, LOG_INFO, QString("WF saving to %1").arg(filename));
+        // LOG(VB_GENERAL, LOG_INFO, QString("WF saving to %1").arg(filename));
         if (!m_image.save(filename))
         {
             LOG(VB_GENERAL, LOG_ERR,
@@ -573,7 +573,7 @@ void WaveForm::saveload(MusicMetadata *meta)
     if (meta)                   // load previous work from cache
     {
         filename = QString("%1/%2.png").arg(cache).arg(stream ? 0 : meta->ID());
-        LOG(VB_GENERAL, LOG_INFO, QString("WF loading from %1").arg(filename));
+        // LOG(VB_GENERAL, LOG_INFO, QString("WF loading from %1").arg(filename));
         if (!m_image.load(filename))
         {
             LOG(VB_GENERAL, LOG_WARNING,
@@ -675,8 +675,10 @@ bool WaveForm::process_all_types(VisualNode *node, bool displayed)
             int y = WF_HEIGHT / 4;  // left zero line
             int yr = WF_HEIGHT * 3 / 4; // right  zero line
             if (!m_right)
-            {
-                y = yr; // mono - drop full waveform below StereoScope now time
+            {           // mono - drop full waveform below StereoScope
+                y = yr;
+                // if we opted for commented MonoScope below, then we
+                // would set y = WF_HEIGHT / 2 here
             }
             // This "loop" runs only once except for short tracks or
             // low sample rates that need some of the virtual "pixels"
@@ -694,7 +696,7 @@ bool WaveForm::process_all_types(VisualNode *node, bool displayed)
                 painter.drawLine(x, 0, x, WF_HEIGHT);
 
                 // Audacity uses 50,50,200 and 100,100,220 - I'm going
-                // darker to better contrast the SteroScope overlay
+                // darker to better contrast the StereoScope overlay
                 painter.setPen(qRgb(25, 25, 150)); // peak-to-peak
                 painter.drawLine(x, y - h * m_maxl / 32768,
                                  x, y - h * m_minl / 32768);
@@ -724,7 +726,9 @@ bool WaveForm::process_all_types(VisualNode *node, bool displayed)
             m_lastx = xx;
         }
     }
-    // return m_right ? StereoScope::process(node) : MonoScope::process(node);
+    // return m_right
+    //     ? StereoScope::process(node)
+    //     : MonoScope::process(node);
     return StereoScope::process(node);
 }
 

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -146,7 +146,7 @@ class MonoScope : public StereoScope
 
 class WaveForm : public MonoScope
 {
-public:
+  public:
     WaveForm() = default;
     ~WaveForm() override;
 
@@ -156,7 +156,7 @@ public:
     bool draw( QPainter *p, const QColor &back ) override;
     void handleKeyPress(const QString &action) override;
 
-protected:
+  protected:
     bool process_all_types(VisualNode *node, bool displayed);
     void saveload(MusicMetadata *meta);
     unsigned long m_offset {0}; // pass from process to draw
@@ -166,14 +166,14 @@ protected:
     QImage        m_image;      // picture of full track
     MusicMetadata *m_currentMetadata {nullptr};
     unsigned long m_duration {60000};
-    unsigned int  m_lastx    {0}; // pixel tracker
-    unsigned int  m_position {0}; // location inside pixel
-    short int     m_minl {0};     // left range
-    short int     m_maxl {0};
-    unsigned long m_sqrl {0};   // sum of squares, for RMS
-    short int     m_minr {0};   // right range
-    short int     m_maxr {0};
-    unsigned long m_sqrr {0};
+    unsigned int  m_lastx    {WF_WIDTH}; // vert line tracker
+    unsigned int  m_position {0};        // location inside pixel
+    short int     m_minl     {0};        // left range
+    short int     m_maxl     {0};
+    unsigned long m_sqrl     {0}; // sum of squares, for RMS
+    short int     m_minr     {0}; // right range
+    short int     m_maxr     {0};
+    unsigned long m_sqrr     {0};
 };
 
 class LogScale

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -103,8 +103,9 @@ class VisFactory
     VisFactory*        m_pNextVisFactory {nullptr};
 };
 
+
 #define RUBBERBAND 0 // NOLINT(cppcoreguidelines-macro-usage)
-#define TWOCOLOUR 0 // NOLINT(cppcoreguidelines-macro-usage)
+#define TWOCOLOUR 1 // NOLINT(cppcoreguidelines-macro-usage)
 
 class StereoScope : public VisualBase
 {
@@ -119,7 +120,7 @@ class StereoScope : public VisualBase
         {(void) action;}
 
   protected:
-    QColor         m_startColor  {Qt::green};
+    QColor         m_startColor  {Qt::yellow};
     QColor         m_targetColor {Qt::red};
     std::vector<double> m_magnitudes  {};
     QSize          m_size;
@@ -135,6 +136,44 @@ class MonoScope : public StereoScope
 
     bool process( VisualNode *node ) override; // StereoScope
     bool draw( QPainter *p, const QColor &back ) override; // StereoScope
+};
+
+// WaveForm - see whole track - by twitham@sbcglobal.net, 2023/01
+
+#define WF_AUDIO_SIZE 4096     // maximum samples to process at a time
+#define WF_WIDTH 1920   // image cache size, will scale to any display
+#define WF_HEIGHT 1080
+
+class WaveForm : public MonoScope
+{
+public:
+    WaveForm() = default;
+    ~WaveForm() override;
+
+    unsigned long getDesiredSamples(void) override;
+    bool processUndisplayed(VisualNode *node) override;
+    bool process( VisualNode *node ) override;
+    bool draw( QPainter *p, const QColor &back ) override;
+    void handleKeyPress(const QString &action) override;
+
+protected:
+    bool process_all_types(VisualNode *node, bool displayed);
+    void saveload(MusicMetadata *meta);
+    unsigned long m_offset {0}; // pass from process to draw
+    short         *m_right {nullptr};
+    QFont         m_font;       // optional text overlay
+    bool          m_showtext {1};
+    QImage        m_image;      // picture of full track
+    MusicMetadata *m_currentMetadata {nullptr};
+    unsigned long m_duration {60000};
+    unsigned int  m_lastx    {0}; // pixel tracker
+    unsigned int  m_position {0}; // location inside pixel
+    short int     m_minl {0};     // left range
+    short int     m_maxl {0};
+    unsigned long m_sqrl {0};   // sum of squares, for RMS
+    short int     m_minr {0};   // right range
+    short int     m_maxr {0};
+    unsigned long m_sqrr {0};
 };
 
 class LogScale


### PR DESCRIPTION
Hello,

I always loved StereoScope of MythMusic because I like to see what the sound looks like.  But I started thinking: what does this whole song look like?  Loud or soft?  Does it change much?  When will changes happen?

Here is a new "WaveForm" visualization for MythMusic.  It is StereoScope in front of a "picture" of the current track showing peak-to-peak and RMS over time.  The high resolution image is drawn in real-time the first time a track is played and cached to $HOME/.mythtv/MythMusic/WaveForm/.  This costs < 50 KBytes per track.  All replays can now see the future of the song as the progress line moves across the wave form.

Radio streams reuse just one file to show the last 1 minute of sound.

This works for me on fixes/32.  Other ideas maybe not worth the effort:

* A separate program could pre-generate any or all images.  If you just draw the picture, it only takes a few seconds per track.
* These pictures could be useful on the server side.  Server could send them to clients so clients don't need to draw or store them.  They could optionally show them in music browser, with or instead of album covers.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors 
   (only tested on fixes/32, I can't compile master, but only diff is in new #include paths of master)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)
  (this is squashed here for this single new feature - my detailed development commits are at https://github.com/twitham1/mythtv/commits/visualize-waveform if needed)