### PR TITLE
Add metadata lookup by timestamp to tmdb3tv.py

### DIFF
--- a/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
@@ -317,6 +317,7 @@ def buildEpisode(args, opts):
     from lxml import etree
     from MythTV.tmdb3 import searchSeries
     from MythTV import datetime
+    from datetime import timedelta
 
     if query.isnumeric():
         inetref = query
@@ -346,7 +347,15 @@ def buildEpisode(args, opts):
         try:
             # The database provides air_date, but not air_time,
             # so extract the date part of the timestamp.
-            timeStampDate = datetime.strptime(subtitle, "%Y-%m-%d %H:%M:%S").date()
+            dtInLocalZone = datetime.strptime(subtitle, "%Y-%m-%d %H:%M:%S")
+            # To ensure that the episode airdates are in line with
+            # the dates used by TV guides and listings worldwide,
+            # episodes that start airing at or after midnight but
+            # before 5:00am are considered part of the previous day.
+            if dtInLocalZone.hour < 5:
+                timeStampDate = (dtInLocalZone - timedelta(days=1)).date()
+            else:
+                timeStampDate = dtInLocalZone.date()
         except ValueError:
             timeStampDate = None
     else:


### PR DESCRIPTION
This change adds **lookup by timestamp** syntax options:

```
    tmdb3tv.py -N <title> <date time>
    tmdb3tv.py -N <inetref> <date time>
```

For example:

```
tmdb3tv.py -N "The Blacklist" "2021-01-29 19:00:00"
<?xml version='1.0' encoding='UTF-8'?>
<metadata>
  <item>
    <title>The Blacklist</title>
    <subtitle>Elizabeth Keen</subtitle>
    <description>As Red and the task force search for Liz, she sets a new plan in motion that has catastrophic consequences.</description>
    <season>8</season>
    <episode>4</episode>
    <inetref>46952</inetref>
    <collectionref>46952</collectionref>
    <language>en</language>
    <releasedate>2021-01-29</releasedate>
    ...
  </item>
</metadata>
```
In the above example, by specifying the start of the recording time, we were able to acquire the Season, Episode, Subtitle, and Description. Without this new capability, the -N invocation would fail, and would be followed by a -M invocation, which would provide only a generic description of the TV series.

Please note that the TMDB database only stores the date, and not the time, of the initial airing. The match cannot be as precise as in a TvMaze lookup, which has access to the date, time, and timezone. If there are multiple episodes aired on a single date, the TMDB script will generate a list with all the episodes matching the date in the given timestamp.

Resolves: #700

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

