### PR TITLE
Fix Pythons import/export of metadata

### DIFF
--- a/mythtv/bindings/python/MythTV/__init__.py
+++ b/mythtv/bindings/python/MythTV/__init__.py
@@ -15,7 +15,7 @@ __all_data__        = ['Record', 'Recorded', 'RecordedProgram', 'OldRecorded', \
                        'InternetContent', 'InternetContentArticles', \
                        'InternetSource', 'Song', 'Album', 'Artist', \
                        'MusicPlaylist', 'MusicDirectory', 'RecordedArtwork', \
-                       'RecordedFile']
+                       'RecordedFile', 'InetrefGrabber']
 
 __all_method__      = ['MythBE', 'BEEventMonitor', 'MythSystemEvent', \
                        'Frontend', 'MythDB', 'MythXML', 'MythMusic', \

--- a/mythtv/bindings/python/MythTV/dataheap.py
+++ b/mythtv/bindings/python/MythTV/dataheap.py
@@ -602,10 +602,15 @@ class Recorded( CMPRecord, DBDataWrite ):
             else:
                 metadata.people.append(OrdDict((('name', name), ('job', role))))
 
-#        for arttype in ['coverart', 'fanart', 'banner']:
-#            art = getattr(self.artwork, arttype)
-#            if art:
-#                metadata.images.append(OrdDict((('type',arttype), ('filename',art))))
+        # pull artworks
+        for arttype in ['coverart', 'fanart', 'banner']:
+            art = getattr(self.artwork, arttype)
+            if art:
+                # process URI (myth://<group>@<host>[:<port>]/<path/to/file>)
+                # should we use for hostname 'art.hostname' or 'localhost'?
+                url = "myth://%s@%s/%s" % (art.imagetype, art.hostname, str(art))
+                metadata.images.append \
+                    (OrdDict((('type', arttype), ('filename', str(art)), ('url', url))))
 
         return metadata
 
@@ -1235,10 +1240,14 @@ class Video( CMPVideo, VideoSchema, DBDataWrite ):
             metadata.countries.append(country.country)
 
         # pull images
-#        for arttype in ['coverart', 'fanart', 'banner', 'screenshot']:
-#            art = getattr(self, arttype)
-#            if art:
-#                metadata.images.append(OrdDict((('type',arttype), ('filename',art))))
+        for arttype in ['coverart', 'fanart', 'banner', 'screenshot']:
+            art = getattr(self, arttype)
+            if art:
+                # process URI (myth://<group>@<host>[:<port>]/<path/to/file>)
+                # should we use for hostname 'art.hostname' or 'localhost'?
+                url = "myth://%s@%s/%s" % (art.imagetype, art.hostname, str(art))
+                metadata.images.append \
+                    (OrdDict((('type', arttype), ('filename', str(art)), ('url', url))))
 
         return metadata
 

--- a/mythtv/bindings/python/MythTV/dataheap.py
+++ b/mythtv/bindings/python/MythTV/dataheap.py
@@ -492,14 +492,24 @@ class Recorded( CMPRecord, DBDataWrite ):
                                         cast.job.lower().replace(' ','_'))))
 
         # pull images
+        founddict = { 'banner'  : False,
+                      'coverart': False,
+                      'fanart'  : False }
+
         for image in metadata.images:
             if not hasattr(self.artwork, image.type):
-                pass
-            if getattr(self.artwork, image.type, ''):
                 continue
-            setattr(self.artwork, image.type, image.filename)
+            # use only the first valid artwork when overwriting:
+            if (overwrite or not getattr(self.artwork, image.type, '')) \
+                    and not founddict[image.type]:
+                founddict[image.type] = True
+            else:
+                continue
+            filename = "%s_%s" % (self.inetref.replace('.', '_'), image.filename)
+            setattr(self.artwork, image.type, filename)
             getattr(self.artwork, image.type).downloadFrom(image.url)
 
+        self.artwork.update()
         self.update()
 
     def exportMetadata(self):

--- a/mythtv/bindings/python/MythTV/static.py
+++ b/mythtv/bindings/python/MythTV/static.py
@@ -116,6 +116,20 @@ class SUBTITLE_TYPES( object ):
     SUB_ONSCREEN        = 0x04
     SUB_SIGNED          = 0x08
 
+class CAST_ROLES( object ):
+    UNKNOWN            = 0x0000
+    ACTOR              = 0x0001
+    DIRECTOR           = 0x0002
+    PRODUCER           = 0x0004
+    EXECUTIVE_PRODUCER = 0x0008
+    WRITER             = 0x0010
+    GUEST_STAR         = 0x0020
+    HOST               = 0x0040
+    ADAPTER            = 0x0080
+    PRESENTER          = 0x0100
+    COMMENTATOR        = 0x0200
+    GUEST              = 0x0400
+
 class JOBTYPE( object ):
     NONE         = 0x0000
     SYSTEMJOB    = 0x00ff


### PR DESCRIPTION
Python Bindings allow to export and import metadata providing an easy way to move recordings to the 'Videos' storagegroup.
This feature provides also an export to xml, which can be used to generate 'mxml' files on the fly.
The commits in this pull request make the import/export feature of recordings and videos consistent.
Additionally, it implements a metadata-grabber that runs on given inetref, providing exact and unique metadata data.

For details about the metadata, see
https://www.mythtv.org/wiki/MythTV_Universal_Metadata_Format

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

