### PR TITLE
Use Recording Type in GuessLookupType

### DIFF
--- a/mythtv/libs/libmythmetadata/metadatafactory.cpp
+++ b/mythtv/libs/libmythmetadata/metadatafactory.cpp
@@ -679,11 +679,19 @@ LookupType GuessLookupType(ProgramInfo *pginfo)
         // weird combination of both, we've got to try everything.
         auto *rule = new RecordingRule();
         rule->m_recordID = pginfo->GetRecordingRuleID();
+        // Load rule information from the database
         rule->Load();
         int ruleepisode = rule->m_episode;
+        RecordingType rulerectype = rule->m_type;
         delete rule;
 
-        if (ruleepisode == 0 && pginfo->GetEpisode() == 0 &&
+        // If recording rule is periodic, it's probably a TV show.
+        if ((rulerectype == kDailyRecord) ||
+            (rulerectype == kWeeklyRecord))
+        {
+            ret = kProbableTelevision;
+        }
+        else if (ruleepisode == 0 && pginfo->GetEpisode() == 0 &&
             pginfo->GetSubtitle().isEmpty())
             ret = kProbableMovie;
         else if (ruleepisode > 0 && pginfo->GetSubtitle().isEmpty())
@@ -735,6 +743,8 @@ LookupType GuessLookupType(RecordingRule *recrule)
         return ret;
 
     if (recrule->m_season > 0 || recrule->m_episode > 0 ||
+        (recrule->m_type == kDailyRecord) ||
+        (recrule->m_type == kWeeklyRecord) ||
         !recrule->m_subtitle.isEmpty())
         ret = kProbableTelevision;
     else


### PR DESCRIPTION
To improve the accuracy of GuessLookupType(), the Recording Type is now factored in. If the recording type is Daily, or Weekly, then it's probably a television show.

Refs #656

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x ] code compiles successfully without errors
- [x ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x ] documentation added/updated/removed where necessary
- [x ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

