### PR TITLE
Remove the check for the oauth library for mythnetvision

### DIFF
--- a/mythplugins/configure
+++ b/mythplugins/configure
@@ -637,7 +637,6 @@ if enabled netvision; then
     check_py_lib lxml    || disable_netvision "Python lxml library (lxml)"
     check_py_lib xml     || disable_netvision "Python XML library (xml)"
     check_py_lib urllib  || disable_netvision "Python URL library (urllib)"
-    check_py_lib oauth   || disable_netvision "Python OAuth library (oauth)"
 
     disabled netvision && echo "Disabling MythNetvision due to missing dependencies."
 fi


### PR DESCRIPTION
Per analysis of Roland Ernst, mythnetvision is using it's own oauth implementation.  Remove the dependency check in the mythplugins configure script for an external library

Fixes: #713

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

