### PR TITLE
OSX: Handle constants deprecated for macOS 11.7 (fixes/33)

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutputca.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputca.cpp
@@ -26,9 +26,9 @@
 #include "libmythbase/mythcorecontext.h"
 #include "audiooutputca.h"
 
-#if !defined(MAC_OS_VERSION_12_0)
-#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
-#endif
+// kAudioObjectPropertyElementMaster was depracated in OS_X 12
+// kAudioObjectPropertyElementMaster defaults to a main/master port value of 0
+static constexpr int8_t darwin_default_master_port { 0 };
 
 #define LOC QString("CoreAudio: ")
 
@@ -551,7 +551,7 @@ AudioDeviceID CoreAudioData::GetDeviceWithName(const QString &deviceName)
     {
 	kAudioHardwarePropertyDevices,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     OSStatus err = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &pa,
@@ -605,7 +605,7 @@ AudioDeviceID CoreAudioData::GetDefaultOutputDevice()
     {
 	kAudioHardwarePropertyDefaultOutputDevice,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     // Find the ID of the default Device
@@ -633,7 +633,7 @@ int CoreAudioData::GetTotalOutputChannels()
     {
 	kAudioDevicePropertyStreamConfiguration,
 	kAudioDevicePropertyScopeOutput, // Scope needs to be set to output to find output streams
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     OSStatus err = AudioObjectGetPropertyDataSize(mDeviceID, &pa,
@@ -677,7 +677,7 @@ QString *CoreAudioData::GetName()
     {
 	kAudioObjectPropertyName,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     CFStringRef name;
@@ -705,7 +705,7 @@ bool CoreAudioData::GetAutoHogMode()
     {
 	kAudioHardwarePropertyHogModeIsAllowed,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     OSStatus err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &pa, 0, nullptr, &size, &val);
@@ -725,7 +725,7 @@ void CoreAudioData::SetAutoHogMode(bool enable)
     {
 	kAudioHardwarePropertyHogModeIsAllowed,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     OSStatus err = AudioObjectSetPropertyData(kAudioObjectSystemObject, &pa, 0, nullptr,
@@ -745,7 +745,7 @@ pid_t CoreAudioData::GetHogStatus()
     {
 	kAudioDevicePropertyHogMode,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     OSStatus err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &pa, 0, nullptr,
@@ -767,7 +767,7 @@ bool CoreAudioData::SetHogStatus(bool hog)
     {
 	kAudioDevicePropertyHogMode,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     // According to Jeff Moore (Core Audio, Apple), Setting kAudioDevicePropertyHogMode
@@ -831,7 +831,7 @@ bool CoreAudioData::SetMixingSupport(bool mix)
     {
 	kAudioDevicePropertySupportsMixing,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
     OSStatus err = AudioObjectSetPropertyData(mDeviceID, &pa, 0, nullptr,
 					      sizeof(mixEnable), &mixEnable);
@@ -857,7 +857,7 @@ bool CoreAudioData::GetMixingSupport()
     {
 	kAudioDevicePropertySupportsMixing,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
     OSStatus err = AudioObjectGetPropertyData(mDeviceID, &pa, 0, nullptr,
 					      &size, &val);
@@ -879,7 +879,7 @@ AudioStreamIDVec CoreAudioData::StreamsList(AudioDeviceID d)
     {
 	kAudioDevicePropertyStreams,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     err = AudioObjectGetPropertyDataSize(d, &pa,
@@ -925,7 +925,7 @@ AudioStreamRangedVec CoreAudioData::FormatsList(AudioStreamID s)
         // Bugfix: kAudioStreamPropertyPhysicalFormats, is meant to only give array of AudioStreamBasicDescription
         kAudioStreamPropertyAvailablePhysicalFormats, // gives array of AudioStreamRangedDescription
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMain
+        darwin_default_master_port
     };
 
     // Retrieve all the stream formats supported by this output stream
@@ -987,7 +987,7 @@ RatesVec CoreAudioData::RatesList(AudioDeviceID d)
     {
 	kAudioDevicePropertyAvailableNominalSampleRates,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     // retrieve size of rate list
@@ -1119,7 +1119,7 @@ int CoreAudioData::OpenAnalog()
     {
 	kAudioHardwarePropertyDevices,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     Debug("OpenAnalog: Entering");
@@ -1511,7 +1511,7 @@ bool CoreAudioData::OpenSPDIF()
 	{
 	    kAudioStreamPropertyPhysicalFormat,
 	    kAudioObjectPropertyScopeGlobal,
-	    kAudioObjectPropertyElementMain
+	    darwin_default_master_port
 	};
 
         // Retrieve the original format of this stream first
@@ -1628,7 +1628,7 @@ int CoreAudioData::AudioStreamChangeFormat(AudioStreamID               s,
     {
 	kAudioStreamPropertyPhysicalFormat,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
     OSStatus err = AudioObjectSetPropertyData(s, &pa, 0, nullptr,
 					      sizeof(format), &format);
@@ -1682,7 +1682,7 @@ void CoreAudioData::ResetAudioDevices()
     {
 	kAudioHardwarePropertyDevices,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     OSStatus err = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &pa,
@@ -1728,7 +1728,7 @@ void CoreAudioData::ResetStream(AudioStreamID s)
     {
 	kAudioStreamPropertyPhysicalFormat,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
 
@@ -1777,7 +1777,7 @@ QMap<QString, QString> *AudioOutputCA::GetDevices(const char */*type*/)
     {
 	kAudioHardwarePropertyDevices,
 	kAudioObjectPropertyScopeGlobal,
-	kAudioObjectPropertyElementMain
+	darwin_default_master_port
     };
 
     OSStatus err = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &pa,

--- a/mythtv/libs/libmythbase/platforms/mythpowerosx.cpp
+++ b/mythtv/libs/libmythbase/platforms/mythpowerosx.cpp
@@ -8,9 +8,9 @@
 #include <IOKit/ps/IOPSKeys.h>
 #include <AvailabilityMacros.h>
 
-#if !defined(MAC_OS_VERSION_12_0)
-#define kIOMainPortDefault kIOMasterPortDefault
-#endif
+// kIOMainPortDefault was depracated in OS_X 12
+// kIOMainPortDefault defaults to a main/master port value of 0
+static constexpr int8_t darwin_default_master_port { 0 };
 
 #define LOC QString("PowerOSX: ")
 
@@ -65,7 +65,7 @@ void MythPowerOSX::Init(void)
 
     // Is there a battery?
     CFArrayRef batteryinfo = NULL;
-    if (IOPMCopyBatteryInfo(kIOMainPortDefault, &batteryinfo) == kIOReturnSuccess)
+    if (IOPMCopyBatteryInfo(darwin_default_master_port, &batteryinfo) == kIOReturnSuccess)
     {
         CFRelease(batteryinfo);
 

--- a/mythtv/libs/libmythui/devices/AppleRemote.cpp
+++ b/mythtv/libs/libmythui/devices/AppleRemote.cpp
@@ -23,9 +23,9 @@
 
 #include "libmythbase/mythlogging.h"
 
-#if !defined(MAC_OS_VERSION_12_0)
-#define kIOMainPortDefault kIOMasterPortDefault
-#endif
+// kIOMainPortDefault was depracated in OS_X 12
+// kIOMainPortDefault defaults to a main/master port value of 0
+static constexpr int8_t darwin_default_master_port { 0 };
 
 AppleRemote*    AppleRemote::_instance = nullptr;
 
@@ -193,7 +193,7 @@ static io_object_t _findAppleRemoteDevice(const char *devName)
     hidMatchDictionary = IOServiceMatching(devName);
 
     // check for matching devices
-    ioReturnValue = IOServiceGetMatchingServices(kIOMainPortDefault,
+    ioReturnValue = IOServiceGetMatchingServices(darwin_default_master_port,
                                                  hidMatchDictionary,
                                                  &hidObjectIterator);
 

--- a/mythtv/libs/libmythui/platforms/mythutilscocoa.mm
+++ b/mythtv/libs/libmythui/platforms/mythutilscocoa.mm
@@ -6,9 +6,9 @@
 #import <IOKit/graphics/IOGraphicsLib.h>
 #include <AvailabilityMacros.h>
 
-#if !defined(MAC_OS_VERSION_12_0)
-#define kIOMainPortDefault kIOMasterPortDefault
-#endif
+// kIOMainPortDefault was depracated in OS_X 12
+// kIOMainPortDefault defaults to a main/master port value of 0
+static constexpr int8_t darwin_default_master_port { 0 };
 
 CGDirectDisplayID GetOSXCocoaDisplay(void* View)
 {
@@ -44,7 +44,7 @@ QByteArray GetOSXEDID(CGDirectDisplayID Display)
     CFMutableDictionaryRef matching = IOServiceMatching("IODisplayConnect");
 
     io_iterator_t iter;
-    if (IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter))
+    if (IOServiceGetMatchingServices(darwin_default_master_port, matching, &iter))
       return result;
 
     io_service_t service = 0;


### PR DESCRIPTION
  - Fixes regression cause by early depreication of contants by Apple in 11.5.7.
  - Initial fix for macOS 12 introduced in commit 3787583

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

