### PR TITLE
Fix translation of schedule filter entries

### DIFF
--- a/mythtv/programs/mythfrontend/scheduleeditor.cpp
+++ b/mythtv/programs/mythfrontend/scheduleeditor.cpp
@@ -2239,8 +2239,8 @@ void FilterOptMixin::Load(void)
         {
             while (query.next())
             {
-                m_descriptions << QObject::tr(query.value(1).toString()
-                                              .toUtf8().constData());
+                m_descriptions << QCoreApplication::translate("SchedFilterEditor",
+                                    query.value(1).toString().toUtf8().constData());
             }
         }
         m_loaded = true;


### PR DESCRIPTION
This commit uses 'QCoreApplication::translate' to translate the entries of the schedule filter list as this allows to pass a translation context which is needed to find the translations of these entries.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ x] code compiles successfully without errors
- [x ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

