### PR TITLE
Fix detection of optical drives

### DIFF
--- a/mythtv/libs/libmyth/mediamonitor-unix.cpp
+++ b/mythtv/libs/libmyth/mediamonitor-unix.cpp
@@ -191,11 +191,7 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
 {
     QDBusInterface block(UDISKS2_SVC, entry.path(), UDISKS2_SVC_BLOCK,
                          QDBusConnection::systemBus() );
-#if 0
-    QString devraw = block.property("Device").toString();
-    LOG(VB_MEDIA, LOG_DEBUG, LOC +
-        "DetectDevice: Raw Device found: " + devraw);
-#endif
+
     if (!block.property("HintSystem").toBool() &&
         !block.property("HintIgnore").toBool())
     {
@@ -229,12 +225,6 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
             QString("DetectDevice: Found drive '%1'").arg(desc));
         const auto media = DriveProperty(drivePath, "MediaCompatibility").toStringList();
         const bool isOptical = !media.filter("optical", Qt::CaseInsensitive).isEmpty();
-#if 0
-        LOG(VB_MEDIA, LOG_DEBUG, LOC + QString("DetectDevice:Drive:Optical : %1")
-                .arg(DriveProperty(drivePath, "Optical").toString()));
-        LOG(VB_MEDIA, LOG_DEBUG, LOC + QString("DetectDevice:Drive:OpticalBlank : %1")
-                .arg(DriveProperty(drivePath, "OpticalBlank").toString()));
-#endif
 
         if (DriveProperty(drivePath, "Removable").toBool())
         {

--- a/mythtv/libs/libmyth/mediamonitor-unix.cpp
+++ b/mythtv/libs/libmyth/mediamonitor-unix.cpp
@@ -179,7 +179,8 @@ static QVariant DriveProperty(const QDBusObjectPath& o, const std::string& kszPr
     {
         v = iface.property(kszProperty.c_str());
         LOG(VB_MEDIA, LOG_DEBUG, LOC +
-            "Udisks2:Drive:" + kszProperty.c_str() + " : " + v.toString() );
+            "Udisks2:Drive:" + kszProperty.c_str() + " : " + 
+            (v.canConvert<QStringList>() ? v.toStringList().join(", ") : v.toString()) );
     }
     return v;
 }
@@ -193,18 +194,18 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
 #if 0
     QString devraw = block.property("Device").toString();
     LOG(VB_MEDIA, LOG_DEBUG, LOC +
-        "CheckMountable: Raw Device found: " + devraw);
+        "DetectDevice: Raw Device found: " + devraw);
 #endif
     if (!block.property("HintSystem").toBool() &&
         !block.property("HintIgnore").toBool())
     {
         dev = block.property("Device").toString();
         LOG(VB_MEDIA, LOG_DEBUG, LOC +
-            "CheckMountable: Device found: " + dev);
+            "DetectDevice: Device found: " + dev);
 
         bool readonly = block.property("ReadOnly").toBool();
         LOG(VB_MEDIA, LOG_DEBUG, LOC +
-            QString("CheckMountable: Device:ReadOnly '%1'").arg(readonly));
+            QString("DetectDevice: Device:ReadOnly '%1'").arg(readonly));
 
         // ignore floppies, too slow
         if (dev.startsWith("/dev/fd"))
@@ -219,7 +220,7 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
         bool isfsmountable = (properties.lastError().type() == QDBusError::NoError);
 
         LOG(VB_MEDIA, LOG_DEBUG, LOC +
-            QString("     CheckMountable:Entry:isfsmountable : %1").arg(isfsmountable));
+            QString("     DetectDevice:Entry:isfsmountable : %1").arg(isfsmountable));
 
         // Get properties of the corresponding drive
         // Note: the properties 'Optical' and 'OpticalBlank' needs a medium inserted
@@ -229,17 +230,19 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
             desc += " ";
         desc += DriveProperty(drivePath, "Model").toString();
         LOG(VB_MEDIA, LOG_DEBUG, LOC +
-            QString("CheckMountable: Found drive '%1'").arg(desc));
+            QString("DetectDevice: Found drive '%1'").arg(desc));
+        const auto media = DriveProperty(drivePath, "MediaCompatibility").toStringList();
+        const bool isOptical = !media.filter("optical", Qt::CaseInsensitive).isEmpty();
 #if 0
-        LOG(VB_MEDIA, LOG_DEBUG, LOC + QString("CheckMountable:Drive:Optical : %1")
+        LOG(VB_MEDIA, LOG_DEBUG, LOC + QString("DetectDevice:Drive:Optical : %1")
                 .arg(DriveProperty(drivePath, "Optical").toString()));
-        LOG(VB_MEDIA, LOG_DEBUG, LOC + QString("CheckMountable:Drive:OpticalBlank : %1")
+        LOG(VB_MEDIA, LOG_DEBUG, LOC + QString("DetectDevice:Drive:OpticalBlank : %1")
                 .arg(DriveProperty(drivePath, "OpticalBlank").toString()));
 #endif
 
         if (DriveProperty(drivePath, "Removable").toBool())
         {
-            if (readonly && !isfsmountable)
+            if (readonly && isOptical)
             {
                 device = UDisks2DVD;
                 return true;

--- a/mythtv/libs/libmyth/mediamonitor-unix.cpp
+++ b/mythtv/libs/libmyth/mediamonitor-unix.cpp
@@ -203,10 +203,6 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
         LOG(VB_MEDIA, LOG_DEBUG, LOC +
             "DetectDevice: Device found: " + dev);
 
-        bool readonly = block.property("ReadOnly").toBool();
-        LOG(VB_MEDIA, LOG_DEBUG, LOC +
-            QString("DetectDevice: Device:ReadOnly '%1'").arg(readonly));
-
         // ignore floppies, too slow
         if (dev.startsWith("/dev/fd"))
             return false;
@@ -242,7 +238,7 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
 
         if (DriveProperty(drivePath, "Removable").toBool())
         {
-            if (readonly && isOptical)
+            if (isOptical)
             {
                 device = UDisks2DVD;
                 return true;


### PR DESCRIPTION
Checking for mount points is not reliable to determine if a block device is an optical drive. This commit uses the 'MediaCompatibility' property of the 'org.freedesktop.UDisks2.Drive' DBUS interface to check if the drive supports optical media.
Also changes the function name in the log messages to match the function they are called from.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x ] code compiles successfully without errors
- [x ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

