### PR TITLE
Support displaying bookmark state and watched progress in video manager

### DIFF
--- a/mythtv/libs/libmythtv/tv_play.cpp
+++ b/mythtv/libs/libmythtv/tv_play.cpp
@@ -2724,6 +2724,17 @@ void TV::PrepareToExitPlayer(int Line)
             at_end = true;
         }
 
+        // Save total frames for video file if not already present
+        if (m_playerContext.m_playingInfo->IsVideoFile())
+        {
+            auto totalFrames = m_playerContext.m_playingInfo->QueryTotalFrames();
+            if (!totalFrames)
+            {
+                totalFrames = m_playerContext.m_player->GetCurrentFrameCount();
+                m_playerContext.m_playingInfo->SaveTotalFrames(totalFrames);
+            }
+        }
+
         // Clear/Save play position without notification
         // The change must be broadcast when file is no longer in use
         // to update previews, ie. with the MarkNotInUse notification

--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -1881,6 +1881,22 @@ static HostCheckBoxSetting *AutomaticSetWatched()
     return gc;
 }
 
+static HostCheckBoxSetting *AlwaysShowWatchedProgress()
+{
+    auto *gc = new HostCheckBoxSetting("AlwaysShowWatchedProgress");
+
+    gc->setLabel(PlaybackSettings::tr("Always show watched percent progress bar"));
+
+    gc->setValue(false);
+
+    gc->setHelpText(PlaybackSettings::tr("If enabled, shows the watched percent "
+                                         "progress bar even if the recording or "
+                                         "video is marked as watched. "
+                                         "Having a watched percent progress bar at "
+                                         "all depends on the currently used theme."));
+    return gc;
+}
+
 static HostSpinBoxSetting *LiveTVIdleTimeout()
 {
     auto *gs = new HostSpinBoxSetting("LiveTVIdleTimeout", 0, 3600, 1);
@@ -4407,6 +4423,7 @@ void PlaybackSettings::Load(void)
     general->addChild(JumpToProgramOSD());
     general->addChild(UseProgStartMark());
     general->addChild(AutomaticSetWatched());
+    general->addChild(AlwaysShowWatchedProgress());
     general->addChild(ContinueEmbeddedTVPlay());
     general->addChild(LiveTVIdleTimeout());
 

--- a/mythtv/programs/mythfrontend/mythfrontend.cpp
+++ b/mythtv/programs/mythfrontend/mythfrontend.cpp
@@ -243,6 +243,7 @@ namespace
         {
             QString msg = tr("DVD/Video contains a bookmark");
 
+            m_videoDlg = dynamic_cast<VideoDialog*>(GetScreenStack()->GetTopScreen());
             auto *popup = new MythDialogBox(msg, GetScreenStack(), "bookmarkdialog");
             if (!popup->Create())
             {
@@ -283,9 +284,21 @@ namespace
             else if (buttonText == m_btnPlayBegin)
                 TV::StartTV(m_pgi, kStartTVIgnoreLastPlayPos | kStartTVIgnoreBookmark);
             else if (buttonText == m_btnClearBookmark)
+            {
                 m_pgi->SaveBookmark(0);
+                if (m_videoDlg)
+                {
+                    m_videoDlg->playbackStateChanged(m_pgi->GetBasename());
+                }
+            }
             else if (buttonText == m_btnClearLast)
+            {
                 m_pgi->SaveLastPlayPos(0);
+                if (m_videoDlg)
+                {
+                    m_videoDlg->playbackStateChanged(m_pgi->GetBasename());
+                }
+            }
             delete m_pgi;
         }
 
@@ -298,6 +311,7 @@ namespace
         QString      m_btnPlayBegin;
         QString      m_btnPlayLast;
         QString      m_btnClearLast;
+        VideoDialog  *m_videoDlg        {nullptr};
     };
 
     void cleanup()

--- a/mythtv/programs/mythfrontend/mythfrontend.pro
+++ b/mythtv/programs/mythfrontend/mythfrontend.pro
@@ -90,6 +90,9 @@ SOURCES += services/mythfrontendservice.cpp
 HEADERS += progdetails.h proginfolist.h
 SOURCES += progdetails.cpp proginfolist.cpp
 
+HEADERS += playbackstate.h
+SOURCES += playbackstate.cpp
+
 macx {
     mac_bundle {
         CONFIG -= console  # Force behaviour of producing .app bundle

--- a/mythtv/programs/mythfrontend/playbackbox.cpp
+++ b/mythtv/programs/mythfrontend/playbackbox.cpp
@@ -465,6 +465,8 @@ PlaybackBox::PlaybackBox(MythScreenStack *parent, const QString& name,
 
     fillRecGroupPasswordCache();
 
+    m_alwaysShowWatchedProgress = gCoreContext->GetBoolSetting("AlwaysShowWatchedProgress", false);
+
     // misc setup
     gCoreContext->addListener(this);
 
@@ -1039,8 +1041,9 @@ void PlaybackBox::ItemVisible(MythUIButtonListItem *item)
     // Flagging status (queued, running, no, yes)
     item->DisplayState(extract_commflag_state(*pginfo), "commflagged");
 
-    item->SetProgress1(0, pginfo->IsWatched() ? 0 : 100,
-                       pginfo->GetWatchedPercent());
+    const auto watchedPercent = pginfo->GetWatchedPercent();
+    const bool showProgress = watchedPercent && (m_alwaysShowWatchedProgress || !pginfo->IsWatched());
+    item->SetProgress1(0, showProgress ? 100 : 0, watchedPercent);
     item->SetProgress2(0, 100, pginfo->GetRecordedPercent());
 
     MythUIButtonListItem *sel_item = item->parent()->GetItemCurrent();

--- a/mythtv/programs/mythfrontend/playbackbox.h
+++ b/mythtv/programs/mythfrontend/playbackbox.h
@@ -466,6 +466,7 @@ class PlaybackBox : public ScheduleCommon
     bool                m_groupSelected       {false};
     bool                m_passwordEntered     {false};
 
+    bool                m_alwaysShowWatchedProgress {false};
     // This class caches the contents of the jobqueue table to avoid excessive
     // DB queries each time the PBB selection changes (currently 4 queries per
     // displayed item).  The cache remains valid for 15 seconds

--- a/mythtv/programs/mythfrontend/playbackstate.cpp
+++ b/mythtv/programs/mythfrontend/playbackstate.cpp
@@ -1,0 +1,118 @@
+#include "playbackstate.h"
+#include "libmythbase/mythdb.h"
+#include "libmythbase/mythdbcon.h"
+#include "libmythbase/mythlogging.h"
+#include "libmythbase/programtypes.h"
+#include "libmythmetadata/videometadata.h"
+
+void PlaybackState::Initialize()
+{
+    LOG(VB_GENERAL, LOG_INFO, "Query playback state for all videos from database");
+
+    m_fileMarkup.clear();
+
+    QueryData();
+
+    LOG(VB_GENERAL, LOG_INFO, QString("Collected playbackstate for %1 videos").arg(m_fileMarkup.count()));
+}
+
+void PlaybackState::Update(const QString &filename)
+{
+    if (!filename.isEmpty())
+    {
+        QueryData(filename);
+    }
+}
+
+void PlaybackState::QueryData(const QString &filterFilename)
+{
+    MSqlQuery query(MSqlQuery::InitCon());
+
+    if (filterFilename.isEmpty())
+    {
+        query.prepare("SELECT filename, type, mark, `offset` "
+                    "FROM filemarkup "
+                    "WHERE type IN (:BOOKMARK, :FRAMES, :PLAYPOS) "
+                    "ORDER BY filename");
+    }
+    else
+    {
+        query.prepare("SELECT filename, type, mark, `offset` "
+                    "FROM filemarkup "
+                    "WHERE type IN (:BOOKMARK, :FRAMES, :PLAYPOS) "
+                    "AND filename = :FILENAME "
+                    "ORDER BY filename");
+        query.bindValue(":FILENAME", filterFilename);
+    }
+    query.bindValue(":BOOKMARK", MARK_BOOKMARK);
+    query.bindValue(":FRAMES", MARK_TOTAL_FRAMES);
+    query.bindValue(":PLAYPOS", MARK_UTIL_LASTPLAYPOS);
+
+    if (!query.exec())
+    {
+        MythDB::DBError("PlaybackState", query);
+        return;
+    }
+
+    QString lastFilename;
+    Markup currMarks;
+    while (query.next())
+    {
+        const QString filename = query.value(0).toString();
+        if (!lastFilename.isEmpty() && filename != lastFilename)
+        {
+            m_fileMarkup[lastFilename] = currMarks;
+            currMarks = Markup();
+        }
+        switch(query.value(1).toInt())
+        {
+            case MARK_BOOKMARK:
+                currMarks.bookmarkPos = query.value(2).toLongLong();
+                break;
+            case MARK_TOTAL_FRAMES:
+                currMarks.totalFrames = query.value(3).toLongLong();
+                break;
+            case MARK_UTIL_LASTPLAYPOS:
+                currMarks.lastPlayPos = query.value(2).toLongLong();
+                break;
+        }
+        lastFilename = filename;
+    }
+    m_fileMarkup[lastFilename] = currMarks;
+}
+
+bool PlaybackState::HasBookmark(const QString &filename) const
+{
+    auto it = m_fileMarkup.constFind(filename);
+    if (it == m_fileMarkup.constEnd())
+    {
+        return false;
+    }
+    return (it.value().bookmarkPos > 0) ? true : false;
+}
+
+uint64_t PlaybackState::GetLastPlayPos(const QString &filename) const
+{
+    auto it = m_fileMarkup.constFind(filename);
+    if (it == m_fileMarkup.constEnd())
+    {
+        return 0;
+    }
+    return it.value().lastPlayPos;
+}
+
+uint PlaybackState::GetWatchedPercent(const QString &filename) const
+{
+    auto it = m_fileMarkup.constFind(filename);
+    if (it == m_fileMarkup.constEnd())
+    {
+        return 0;
+    }
+    const auto pos = it.value().lastPlayPos;
+    const auto total = it.value().totalFrames;
+    if (0 == total)
+    {
+        return 0;
+    }
+    return std::clamp(100 * pos / total, (uint64_t)0, (uint64_t)100);
+}

--- a/mythtv/programs/mythfrontend/playbackstate.cpp
+++ b/mythtv/programs/mythfrontend/playbackstate.cpp
@@ -1,9 +1,17 @@
 #include "playbackstate.h"
+
+// MythTV
+#include "libmyth/mythcontext.h"
 #include "libmythbase/mythdb.h"
 #include "libmythbase/mythdbcon.h"
 #include "libmythbase/mythlogging.h"
 #include "libmythbase/programtypes.h"
 #include "libmythmetadata/videometadata.h"
+
+PlaybackState::PlaybackState()
+{
+    m_alwaysShowWatchedProgress = gCoreContext->GetBoolSetting("AlwaysShowWatchedProgress", false);
+}
 
 void PlaybackState::Initialize()
 {
@@ -115,4 +123,9 @@ uint PlaybackState::GetWatchedPercent(const QString &filename) const
         return 0;
     }
     return std::clamp(100 * pos / total, (uint64_t)0, (uint64_t)100);
+}
+
+bool PlaybackState::AlwaysShowWatchedProgress() const
+{
+    return m_alwaysShowWatchedProgress;
 }

--- a/mythtv/programs/mythfrontend/playbackstate.h
+++ b/mythtv/programs/mythfrontend/playbackstate.h
@@ -11,7 +11,7 @@
 class PlaybackState
 {
 public:
-    PlaybackState() = default;
+    PlaybackState();
 
     /// Initializes playback state from database
     void Initialize();
@@ -28,6 +28,9 @@ public:
     /// Query watched percent of video with the specified filename
     uint GetWatchedPercent(const QString &filename) const;
 
+    /// Returns cached setting "AlwaysShowWatchedProgress"
+    bool AlwaysShowWatchedProgress() const;
+
 private:
     /// Query playback state from database, only for single video if a filename is specified
     void QueryData(const QString &filterFilename = QString());
@@ -40,6 +43,7 @@ private:
     };
 
     QMap<QString, Markup> m_fileMarkup; ///< maps filename to markup
+    bool m_alwaysShowWatchedProgress {false};
 };
 
 #endif // PLAYBACKSTATE_H_

--- a/mythtv/programs/mythfrontend/playbackstate.h
+++ b/mythtv/programs/mythfrontend/playbackstate.h
@@ -1,0 +1,45 @@
+#ifndef PLAYBACKSTATE_H_
+#define PLAYBACKSTATE_H_
+
+// POSIX headers
+#include <cstdint> // for [u]int[32,64]_t
+
+#include <QMap>
+#include <QString>
+
+/// Utility class to query playback state from database
+class PlaybackState
+{
+public:
+    PlaybackState() = default;
+
+    /// Initializes playback state from database
+    void Initialize();
+
+    /// Updates playback state of video with specified filename
+    void Update(const QString &filename);
+
+    /// Query bookmark of video with the specified filename
+    bool HasBookmark(const QString &filename) const;
+
+    /// Query last playback position of video with the specified filename
+    uint64_t GetLastPlayPos(const QString &filename) const;
+
+    /// Query watched percent of video with the specified filename
+    uint GetWatchedPercent(const QString &filename) const;
+
+private:
+    /// Query playback state from database, only for single video if a filename is specified
+    void QueryData(const QString &filterFilename = QString());
+
+    /// Markup for a video file
+    struct Markup {
+        uint64_t totalFrames = 0;   ///< total frames
+        uint64_t lastPlayPos = 0;   ///< last playing position
+        uint64_t bookmarkPos = 0;   ///< bookmark position
+    };
+
+    QMap<QString, Markup> m_fileMarkup; ///< maps filename to markup
+};
+
+#endif // PLAYBACKSTATE_H_

--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -921,7 +921,9 @@ void VideoDialog::OnPlaybackStopped()
         m_d->m_playbackState.Update(metadata->GetFilename());
     }
     UpdateText(item);
+    UpdateWatchedState(item);
 }
+
 
 VideoDialog::~VideoDialog()
 {
@@ -2335,6 +2337,34 @@ void VideoDialog::UpdateText(MythUIButtonListItem *item)
 
     if (node)
         node->becomeSelectedChild();
+}
+
+/** \fn VideoDialog::UpdateWatchedState(MythUIButtonListItem *item)
+ *  \brief Update the watched state for a given ButtonListItem from the database.
+ *  \return void.
+ * 
+ *  The player could have updated the watched state of a video after watching.
+ *  We load the metadata of the current item from the database and sync the
+ *  watched state of the current item if it was changed by the player.
+ */
+void VideoDialog::UpdateWatchedState(MythUIButtonListItem *item)
+{
+    if (!gCoreContext->GetBoolSetting("AutomaticSetWatched", false))
+        return;
+
+    if (!item)
+        return;
+
+    VideoMetadata *metadata = GetMetadata(item);
+    if (!metadata)
+        return;
+
+    auto metadataNew = m_d->m_videoList->getListCache().loadOneFromDatabase(metadata->GetID());
+    if (metadata->GetWatched() != metadataNew->GetWatched())
+    {
+        metadata->SetWatched(metadataNew->GetWatched());
+        item->DisplayState(WatchedToState(metadata->GetWatched()), "watchedstate");
+    }
 }
 
 /** \fn VideoDialog::VideoMenu()

--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -40,11 +40,13 @@
 #include "libmythui/mythuibuttontree.h"
 #include "libmythui/mythuihelper.h"
 #include "libmythui/mythuiimage.h"
+#include "libmythui/mythuiprogressbar.h"
 #include "libmythui/mythuistatetype.h"
 #include "libmythui/mythuitext.h"
 
 // MythFrontend
 #include "editvideometadata.h"
+#include "playbackstate.h"
 #include "videodlg.h"
 #include "videofileassoc.h"
 #include "videofilter.h"
@@ -560,7 +562,36 @@ namespace
         h.handleState("watchedstate");
         h.handleState("videolevel");
     }
+
+    void CopyPlaybackStateToUI(const PlaybackState &playbackState,
+            const VideoMetadata *metadata,
+            MythUIButtonListItem *item = nullptr,
+            MythScreenType *screen = nullptr)
+    {
+        if (!metadata || (!item && !screen))
+        {
+            return;
+        }
+
+        const auto bookmarkState = playbackState.HasBookmark(metadata->GetFilename()) ? "yes" : "no";
+        const auto watchedPercent = playbackState.GetWatchedPercent(metadata->GetFilename());
+        if (item)
+        {
+            item->DisplayState(bookmarkState, "bookmarkstate");
+            item->SetProgress1(0, watchedPercent ? 100 : 0, watchedPercent);
+        }
+        if (screen)
+        {
+            CheckedSet(screen, "bookmarkstate", bookmarkState);
+            auto watchedProgress = dynamic_cast<MythUIProgressBar *>(screen->GetChild("watchedprogressbar"));
+            if (watchedProgress)
+            {
+                watchedProgress->Set(0, 100, watchedPercent);
+            }
+        }
+    }
 }
+
 
 class ItemDetailPopup : public MythScreenType
 {
@@ -575,9 +606,9 @@ class ItemDetailPopup : public MythScreenType
 
   public:
     ItemDetailPopup(MythScreenStack *lparent, VideoMetadata *metadata,
-            const VideoMetadataListManager &listManager) :
+            const VideoMetadataListManager &listManager, PlaybackState &playbackState) :
         MythScreenType(lparent, kWindowName), m_metadata(metadata),
-        m_listManager(listManager)
+        m_listManager(listManager), m_playbackState(playbackState)
     {
     }
 
@@ -606,6 +637,7 @@ class ItemDetailPopup : public MythScreenType
 
         ScreenCopyDest dest(this);
         CopyMetadataToUI(m_metadata, dest);
+        CopyPlaybackStateToUI(m_playbackState, m_metadata, nullptr, this);
 
         return true;
     }
@@ -661,6 +693,7 @@ class ItemDetailPopup : public MythScreenType
     static const char * const kWindowName;
     VideoMetadata *m_metadata   {nullptr};
     const VideoMetadataListManager &m_listManager;
+    PlaybackState &m_playbackState;
 
     MythUIButton  *m_playButton {nullptr};
     MythUIButton  *m_doneButton {nullptr};
@@ -794,6 +827,8 @@ class VideoDialogPrivate
     QString m_lastTreeNodePath;
     QMap<QString, int> m_notifications;
 
+    PlaybackState m_playbackState;
+
   private:
     parental_level_map m_ratingToPl;
 };
@@ -861,6 +896,20 @@ VideoDialog::VideoDialog(MythScreenStack *lparent, const QString& lname,
 
     StorageGroup::ClearGroupToUseCache();
     MythCoreContext::ClearBackendServerPortCache();
+    // Get notified when playback stopped, so we can update watched progress
+    connect(gCoreContext, &MythCoreContext::TVPlaybackStopped, this, &VideoDialog::OnPlaybackStopped);
+    connect(gCoreContext, &MythCoreContext::TVPlaybackAborted, this, &VideoDialog::OnPlaybackStopped);
+}
+
+void VideoDialog::OnPlaybackStopped()
+{
+    auto *item = GetItemCurrent();
+    const auto *metadata = GetMetadata(item);
+    if (metadata)
+    {
+        m_d->m_playbackState.Update(metadata->GetFilename());
+    }
+    UpdateText(item);
 }
 
 VideoDialog::~VideoDialog()
@@ -1000,6 +1049,7 @@ bool VideoDialog::Create()
     UIUtilW::Assign(this, m_parentalLevelState, "parentallevel");
     UIUtilW::Assign(this, m_watchedState, "watchedstate");
     UIUtilW::Assign(this, m_studioState, "studiostate");
+    UIUtilW::Assign(this, m_bookmarkState, "bookmarkstate");
 
     if (err)
     {
@@ -1011,6 +1061,7 @@ bool VideoDialog::Create()
     CheckedSet(m_parentalLevelState, "None");
     CheckedSet(m_watchedState, "None");
     CheckedSet(m_studioState, "None");
+    CheckedSet(m_bookmarkState, "None");
 
     BuildFocusList();
 
@@ -1024,6 +1075,8 @@ bool VideoDialog::Create()
                 this, &VideoDialog::UpdateText);
         connect(m_videoButtonTree, &MythUIButtonTree::nodeChanged,
                 this, &VideoDialog::SetCurrentNode);
+        connect(m_videoButtonTree, &MythUIButtonTree::itemVisible,
+                this, &VideoDialog::UpdateVisible);
     }
     else
     {
@@ -1033,6 +1086,8 @@ bool VideoDialog::Create()
                 this, &VideoDialog::handleSelect);
         connect(m_videoButtonList, &MythUIButtonList::itemSelected,
                 this, &VideoDialog::UpdateText);
+        connect(m_videoButtonList, &MythUIButtonList::itemVisible,
+                this, &VideoDialog::UpdateVisible);
     }
 
     return true;
@@ -1234,6 +1289,7 @@ void VideoDialog::UpdateItem(MythUIButtonListItem *item)
 
     MythUIButtonListItemCopyDest dest(item);
     CopyMetadataToUI(metadata, dest);
+    CopyPlaybackStateToUI(m_d->m_playbackState, metadata, item, nullptr);
 
     MythGenericTree *parent = node->getParent();
 
@@ -1311,6 +1367,7 @@ void VideoDialog::UpdateItem(MythUIButtonListItem *item)
  */
 void VideoDialog::fetchVideos()
 {
+    m_d->m_playbackState.Initialize();
     MythGenericTree *oldroot = m_d->m_rootNode;
     if (!m_d->m_treeLoaded)
     {
@@ -2185,13 +2242,29 @@ void VideoDialog::UpdatePosition()
                                     .arg(currentList->GetCount()));
 }
 
+/** \fn VideoDialog::UpdateVisible(MythUIButtonListItem *item)
+ *  \brief Update playback state for for a given visible ButtonListItem
+ *  \return void.
+ */
+void VideoDialog::UpdateVisible(MythUIButtonListItem *item)
+{
+    if (!item)
+        return;
+
+    VideoMetadata *metadata = GetMetadata(item);
+    if (!metadata)
+        return;
+
+    CopyPlaybackStateToUI(m_d->m_playbackState, metadata, item, nullptr);
+}
+
 /** \fn VideoDialog::UpdateText(MythUIButtonListItem *item)
  *  \brief Update the visible text values for a given ButtonListItem.
  *  \return void.
  */
 void VideoDialog::UpdateText(MythUIButtonListItem *item)
 {
-    if (!item)
+    if (!item || !item->isVisible())
         return;
 
     MythUIButtonList *currentList = item->parent();
@@ -2221,6 +2294,7 @@ void VideoDialog::UpdateText(MythUIButtonListItem *item)
 
     ScreenCopyDest dest(this);
     CopyMetadataToUI(metadata, dest);
+    CopyPlaybackStateToUI(m_d->m_playbackState, metadata, item, m_d->m_currentNode ? this : nullptr);
 
     if (node->getInt() == kSubFolder && !metadata)
     {
@@ -2862,7 +2936,7 @@ bool VideoDialog::DoItemDetailShow()
     {
         MythScreenStack *mainStack = GetMythMainWindow()->GetMainStack();
         auto *idp = new ItemDetailPopup(mainStack, metadata,
-                m_d->m_videoList->getListCache());
+                m_d->m_videoList->getListCache(), m_d->m_playbackState);
 
         if (idp->Create())
         {

--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -901,6 +901,17 @@ VideoDialog::VideoDialog(MythScreenStack *lparent, const QString& lname,
     connect(gCoreContext, &MythCoreContext::TVPlaybackAborted, this, &VideoDialog::OnPlaybackStopped);
 }
 
+void VideoDialog::playbackStateChanged(const QString &filename)
+{
+    m_d->m_playbackState.Update(filename);
+    auto *item = GetItemCurrent();
+    const auto *metadata = GetMetadata(item);
+    if (metadata && metadata->GetFilename() == filename)
+    {
+        UpdateText(item);
+    }
+}
+
 void VideoDialog::OnPlaybackStopped()
 {
     auto *item = GetItemCurrent();

--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -575,10 +575,11 @@ namespace
 
         const auto bookmarkState = playbackState.HasBookmark(metadata->GetFilename()) ? "yes" : "no";
         const auto watchedPercent = playbackState.GetWatchedPercent(metadata->GetFilename());
+        const bool showProgress = watchedPercent && (playbackState.AlwaysShowWatchedProgress() || !metadata->GetWatched());
         if (item)
         {
             item->DisplayState(bookmarkState, "bookmarkstate");
-            item->SetProgress1(0, watchedPercent ? 100 : 0, watchedPercent);
+            item->SetProgress1(0, showProgress ? 100 : 0, watchedPercent);
         }
         if (screen)
         {
@@ -586,7 +587,7 @@ namespace
             auto watchedProgress = dynamic_cast<MythUIProgressBar *>(screen->GetChild("watchedprogressbar"));
             if (watchedProgress)
             {
-                watchedProgress->Set(0, 100, watchedPercent);
+                watchedProgress->Set(0, showProgress ? 100 : 0, watchedPercent);
             }
         }
     }

--- a/mythtv/programs/mythfrontend/videodlg.h
+++ b/mythtv/programs/mythfrontend/videodlg.h
@@ -68,6 +68,7 @@ class VideoDialog : public MythScreenType
 
   private slots:
     void UpdatePosition();
+    void UpdateVisible(MythUIButtonListItem *item);
     void UpdateText(MythUIButtonListItem *item);
     void handleSelect(MythUIButtonListItem *item);
     void SetCurrentNode(MythGenericTree *node);
@@ -184,6 +185,7 @@ class VideoDialog : public MythScreenType
 
     void OnVideoImageSetDone(VideoMetadata *metadata);
     void OnVideoSearchDone(MetadataLookup *lookup);
+    void OnPlaybackStopped();
 
   private:
     MythDialogBox    *m_menuPopup          {nullptr};
@@ -211,6 +213,7 @@ class VideoDialog : public MythScreenType
     MythUIStateType  *m_userRatingState    {nullptr};
     MythUIStateType  *m_watchedState       {nullptr};
     MythUIStateType  *m_studioState        {nullptr};
+    MythUIStateType  *m_bookmarkState      {nullptr};
 
     MetadataFactory *m_metadataFactory     {nullptr};
 

--- a/mythtv/programs/mythfrontend/videodlg.h
+++ b/mythtv/programs/mythfrontend/videodlg.h
@@ -70,6 +70,7 @@ class VideoDialog : public MythScreenType
   private slots:
     void UpdatePosition();
     void UpdateVisible(MythUIButtonListItem *item);
+    void UpdateWatchedState(MythUIButtonListItem *item);
     void UpdateText(MythUIButtonListItem *item);
     void handleSelect(MythUIButtonListItem *item);
     void SetCurrentNode(MythGenericTree *node);

--- a/mythtv/programs/mythfrontend/videodlg.h
+++ b/mythtv/programs/mythfrontend/videodlg.h
@@ -61,6 +61,7 @@ class VideoDialog : public MythScreenType
 
   public slots:
     void searchComplete(const QString& string);
+    void playbackStateChanged(const QString &filename);
 
   protected slots:
     void Init() override; /// Called after the screen is created by MythScreenStack


### PR DESCRIPTION
This adds support of displaying the bookmark state and the watched progress
within the video manager.
I have added preliminary support to display bookmark state and watched progress to the Monochrome theme
as seen in the image below:
![Bookmark_and_WatchedProgress_in_VideoManager_annotated](https://user-images.githubusercontent.com/6901566/229840896-3d614fd9-d28d-4b16-90bb-1c5205b2209a.png)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

