### PR TITLE
HDHomeRun Channel Import

### DIFF
--- a/mythtv/libs/libmythtv/channelscan/channelscanner.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner.cpp
@@ -404,6 +404,30 @@ bool ChannelScanner::ImportExternRecorder(uint cardid, const QString &inputname,
 #endif
 }
 
+bool ChannelScanner::ImportHDHR(uint cardid, const QString &inputname, uint sourceid,
+                                ServiceRequirements serviceType)
+{
+    m_sourceid = sourceid;
+#ifdef USING_HDHOMERUN
+    if (!m_scanMonitor)
+        m_scanMonitor = new ScanMonitor(this);
+
+    // Create a HDHomeRun scan object
+    m_hdhrScanner = new HDHRChannelFetcher(cardid, inputname, sourceid, serviceType, m_scanMonitor);
+
+    MonitorProgress(false, false, false, false);
+
+    m_hdhrScanner->Scan();
+
+    return true;
+#else
+    (void) cardid;
+    (void) inputname;
+    (void) serviceType;
+    return false;
+#endif
+}
+
 void ChannelScanner::PreScanCommon(
     int scantype,
     uint cardid,

--- a/mythtv/libs/libmythtv/channelscan/channelscanner.h
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner.h
@@ -49,6 +49,10 @@
 #include "externrecscanner.h"
 #endif
 
+#ifdef USING_HDHOMERUN
+#include "hdhrchannelfetcher.h"
+#endif
+
 class ScanMonitor;
 class IPTVChannelFetcher;
 class ExternRecChannelFetcher;
@@ -101,6 +105,8 @@ class MTV_PUBLIC ChannelScanner
                             bool ftaOnly, ServiceRequirements serviceType);
     virtual bool ImportExternRecorder(uint cardid, const QString &inputname,
                                       uint sourceid);
+    virtual bool ImportHDHR(uint cardid, const QString &inputname, uint sourceid,
+                            ServiceRequirements serviceType);
 
   protected:
     virtual void Teardown(void);
@@ -135,6 +141,10 @@ class MTV_PUBLIC ChannelScanner
 #endif
 #if !defined( USING_MINGW ) && !defined( _MSC_VER )
     ExternRecChannelScanner *m_externRecScanner    {nullptr};
+#endif
+    // HDHomeRun channel list import
+#ifdef USING_HDHOMERUN
+    HDHRChannelFetcher      *m_hdhrScanner         {nullptr};
 #endif
 
     /// Only fta channels desired post scan?

--- a/mythtv/libs/libmythtv/channelscan/channelscanner_gui.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner_gui.cpp
@@ -88,6 +88,9 @@ void ChannelScannerGUI::HandleEvent(const ScannerEvent *scanEvent)
 #if !defined( USING_MINGW ) && !defined( _MSC_VER )
         success |= (m_externRecScanner != nullptr);
 #endif
+#ifdef USING_HDHOMERUN
+        success |= (m_hdhrScanner != nullptr);
+#endif
 
         Teardown();
 

--- a/mythtv/libs/libmythtv/channelscan/hdhrchannelfetcher.cpp
+++ b/mythtv/libs/libmythtv/channelscan/hdhrchannelfetcher.cpp
@@ -1,0 +1,449 @@
+// Std C headers
+#include <cmath>
+#include <unistd.h>
+#include <utility>
+
+// Qt headers
+#include <QFile>
+#include <QTextStream>
+#include <QString>
+#include <QStringList>
+#include <QDomDocument>
+
+#ifdef USING_HDHOMERUN
+#include HDHOMERUN_HEADERFILE
+#endif
+
+// MythTV headers
+#include "libmythbase/mythdownloadmanager.h"
+#include "libmythbase/mythlogging.h"
+#include "cardutil.h"
+#include "channelutil.h"
+#include "libmyth/mythcontext.h"
+#include "scanmonitor.h"
+#include "hdhrchannelfetcher.h"
+
+#define LOC QString("HDHRChanFetch: ")
+
+namespace {
+
+constexpr const char* QUERY_CHANNELS
+{ "http://{IP}/lineup.xml?tuning" };
+
+QString getFirstText(QDomElement &element)
+{
+    for (QDomNode dname = element.firstChild(); !dname.isNull();
+         dname = dname.nextSibling())
+    {
+        QDomText t = dname.toText();
+        if (!t.isNull())
+            return t.data();
+    }
+    return {};
+}
+
+QString getStrValue(const QDomElement &element, const QString &name, int index=0)
+{
+    QDomNodeList nodes = element.elementsByTagName(name);
+    if (!nodes.isEmpty())
+    {
+        if (index >= nodes.count())
+            index = 0;
+        QDomElement e = nodes.at(index).toElement();
+        return getFirstText(e);
+    }
+    return {};
+}
+
+int getIntValue(const QDomElement &element, const QString &name, int index=0)
+{
+    QString value = getStrValue(element, name, index);
+    return value.toInt();
+}
+
+bool sendQuery(const QString& query, QDomDocument* xmlDoc)
+{
+    QByteArray result;
+
+    if (!GetMythDownloadManager()->download(query, &result, true))
+        return false;
+
+    QString errorMsg;
+    int errorLine = 0;
+    int errorColumn = 0;
+
+    if (!xmlDoc->setContent(result, false, &errorMsg, &errorLine, &errorColumn))
+    {
+        LOG(VB_GENERAL, LOG_ERR, LOC +
+                QString("Error parsing: %1\nat line: %2  column: %3 msg: %4").
+                arg(query).arg(errorLine).arg(errorColumn).arg(errorMsg));
+        return false;
+    }
+
+    // Check for a status or error element
+    QDomNodeList statusNodes = xmlDoc->elementsByTagName("Status");
+
+    if (!statusNodes.count())
+        statusNodes = xmlDoc->elementsByTagName("Error");
+
+    if (statusNodes.count())
+    {
+        QDomElement elem = statusNodes.at(0).toElement();
+        if (!elem.isNull())
+        {
+            int errorCode = getIntValue(elem, "ErrorCode");
+            QString errorDesc = getStrValue(elem, "ErrorDescription");
+
+            if (errorCode == 0 /* SUCCESS */)
+                return true;
+
+            LOG(VB_GENERAL, LOG_ERR, LOC +
+                QString("API Error: %1 - %2, Query was: %3").arg(errorCode).arg(errorDesc, query));
+
+            return false;
+        }
+    }
+
+    // No error detected so assume we got a valid xml result
+    return true;
+}
+
+hdhr_chan_map_t *getChannels(QString ip)
+{
+    auto *result = new hdhr_chan_map_t;
+    auto *xmlDoc = new QDomDocument();
+    QString query = QUERY_CHANNELS;
+
+    query.replace("{IP}", ip);
+
+    if (!sendQuery(query, xmlDoc))
+    {
+        delete xmlDoc;
+        delete result;
+        return nullptr;
+    }
+
+    QDomNodeList chanNodes = xmlDoc->elementsByTagName("Program");
+
+    for (int x = 0; x < chanNodes.count(); x++)
+    {
+        QDomElement chanElem = chanNodes.at(x).toElement();
+        QString guideName = getStrValue(chanElem, "GuideName");
+        QString guideNumber = getStrValue(chanElem, "GuideNumber");
+        QString url = getStrValue(chanElem, "URL");
+        QString modulation = getStrValue(chanElem, "Modulation");
+        QString videoCodec = getStrValue(chanElem, "VideoCodec");
+        QString audioCodec = getStrValue(chanElem, "AudioCodec");
+        uint frequency = getStrValue(chanElem, "Frequency").toUInt();
+        uint serviceID = getStrValue(chanElem, "ProgramNumber").toUInt();
+        uint transportID = getStrValue(chanElem, "TransportStreamID").toUInt();
+        QString onid = getStrValue(chanElem, "OriginalNetworkID");
+
+        // Fixup: Remove leading colon in network ID:
+        // <OriginalNetworkID>:8720</OriginalNetworkID>
+        // This looks a bug in the XML representation, N.B. bug not present in JSON.
+        onid.replace(":", "");
+        uint originalNetworkID = onid.toUInt();
+
+        LOG(VB_CHANSCAN, LOG_DEBUG, LOC + QString("ONID/TID/SID %1 %2 %3")
+            .arg(originalNetworkID).arg(transportID).arg(serviceID));
+
+        HDHRChannelInfo chanInfo(guideName, guideNumber, url, modulation, videoCodec,
+            audioCodec, frequency, serviceID, originalNetworkID, transportID);
+
+        result->insert(guideNumber, chanInfo);
+    }
+    return result;
+}
+
+QString HDHRIPv4Address(const QString &device)
+{
+#ifdef USING_HDHOMERUN
+    hdhomerun_device_t *hdhr =
+        hdhomerun_device_create_from_str(device.toLatin1(), nullptr);
+    if (!hdhr)
+        return {};
+
+    uint32_t ipv4 = hdhomerun_device_get_device_ip(hdhr);
+    hdhomerun_device_destroy(hdhr);
+
+    if (!ipv4)
+        return {};
+
+    return QString("%1.%2.%3.%4").arg(ipv4>>24&0xff).arg(ipv4>>16&0xff).arg(ipv4>>8&0xff).arg(ipv4&0xff);
+#else
+    (void) device;
+    return {};
+#endif
+}
+
+// Examples of hdhrmod values: a8qam64-6875 a8qam256-6900 t8dvbt2
+QString HDHRMod2Modsys(const QString hdhrmod)
+{
+    if (hdhrmod.contains("dvbt2"))
+        return DTVModulationSystem(DTVModulationSystem::kModulationSystem_DVBT2).toString();
+    if (hdhrmod.contains("dvbt"))
+        return DTVModulationSystem(DTVModulationSystem::kModulationSystem_DVBT).toString();
+    if (hdhrmod.startsWith("a8qam"))
+        return DTVModulationSystem(DTVModulationSystem::kModulationSystem_DVBC_ANNEX_A).toString();
+    return DTVModulationSystem(DTVModulationSystem::kModulationSystem_UNDEFINED).toString();
+}
+
+signed char HDHRMod2Bandwidth(const QString hdhrmod)
+{
+    if (hdhrmod.startsWith("t8") || hdhrmod.startsWith("a8"))
+        return '8';
+    if (hdhrmod.startsWith("t7") || hdhrmod.startsWith("a7"))
+        return '7';
+    if (hdhrmod.startsWith("t6") || hdhrmod.startsWith("a6"))
+        return '6';
+    return 'a';
+}
+
+uint HDHRMod2SymbolRate(const QString hdhrmod)
+{
+    QRegularExpression re(R"(^(a8qam\d+-)(\d+))");
+    QRegularExpressionMatch match = re.match(hdhrmod);
+    if (match.hasMatch())
+    {
+        QString matched = match.captured(2);
+        return matched.toUInt() * 1000;
+    }
+    return 0;
+}
+
+QString HDHRMod2Modulation(const QString hdhrmod)
+{
+    if (hdhrmod.contains("qam64"))
+        return DTVModulation(DTVModulation::kModulationQAM64).toString();
+    if (hdhrmod.contains("qam256"))
+        return DTVModulation(DTVModulation::kModulationQAM256).toString();
+    return DTVModulation(DTVModulation::kModulationQAMAuto).toString();
+}
+
+} // namespace
+
+HDHRChannelFetcher::HDHRChannelFetcher(uint cardid, QString inputname, uint sourceid,
+                                       ServiceRequirements serviceType, ScanMonitor *monitor) :
+    m_scanMonitor(monitor),
+    m_cardId(cardid),
+    m_inputName(std::move(inputname)),
+    m_sourceId(sourceid),
+    m_serviceType(serviceType),
+    m_thread(new MThread("HDHRChannelFetcher", this))
+{
+    LOG(VB_CHANSCAN, LOG_INFO, LOC + QString("Has ScanMonitor %1")
+        .arg(monitor?"true":"false"));
+}
+
+HDHRChannelFetcher::~HDHRChannelFetcher()
+{
+    Stop();
+    delete m_thread;
+    m_thread = nullptr;
+    delete m_channels;
+    m_channels = nullptr;
+}
+
+/** \fn HDHRChannelFetcher::Stop(void)
+ *  \brief Stops the scanning thread running
+ */
+void HDHRChannelFetcher::Stop(void)
+{
+    m_lock.lock();
+
+    while (m_threadRunning)
+    {
+        m_stopNow = true;
+        m_lock.unlock();
+        m_thread->wait(5ms);
+        m_lock.lock();
+    }
+
+    m_lock.unlock();
+
+    m_thread->wait();
+}
+
+hdhr_chan_map_t HDHRChannelFetcher::GetChannels(void)
+{
+    while (!m_thread->isFinished())
+        m_thread->wait(500ms);
+
+    LOG(VB_CHANSCAN, LOG_INFO, LOC + QString("Found %1 channels")
+        .arg(m_channels->size()));
+    return *m_channels;
+}
+
+void HDHRChannelFetcher::Scan(void)
+{
+    Stop();
+    m_stopNow = false;
+    m_thread->start();
+}
+
+void HDHRChannelFetcher::run(void)
+{
+    m_lock.lock();
+    m_threadRunning = true;
+    m_lock.unlock();
+
+    // Step 1/3 : Get the IP of the HDHomeRun to query
+    QString dev = CardUtil::GetVideoDevice(m_cardId);
+    QString ip = HDHRIPv4Address(dev);
+
+    if (m_stopNow || ip.isEmpty())
+    {
+        LOG(VB_CHANNEL, LOG_INFO, LOC +
+            QString("Failed to get IP address from videodev (%1)").arg(dev));
+        QMutexLocker locker(&m_lock);
+        m_threadRunning = false;
+        m_stopNow = true;
+        return;
+    }
+    LOG(VB_CHANNEL, LOG_INFO, LOC + QString("HDHomeRun IP: %1").arg(ip));
+
+    // Step 2/3 : Download
+    if (m_scanMonitor)
+    {
+        m_scanMonitor->ScanPercentComplete(5);
+        m_scanMonitor->ScanAppendTextToLog(tr("Downloading Channel List"));
+    }
+
+    delete m_channels;
+    m_channels = getChannels(ip);
+
+    if (m_stopNow || !m_channels)
+    {
+        if (!m_channels && m_scanMonitor)
+        {
+            m_scanMonitor->ScanAppendTextToLog(QCoreApplication::translate("(Common)", "Error"));
+            m_scanMonitor->ScanPercentComplete(100);
+            m_scanMonitor->ScanErrored(tr("Downloading Channel List Failed"));
+        }
+        QMutexLocker locker(&m_lock);
+        m_threadRunning = false;
+        m_stopNow = true;
+        return;
+    }
+
+    // Step 3/3 : Process
+    if (m_scanMonitor)
+    {
+        m_scanMonitor->ScanPercentComplete(35);
+        m_scanMonitor->ScanAppendTextToLog(tr("Adding Channels"));
+    }
+    SetTotalNumChannels(m_channels->size());
+    LOG(VB_CHANSCAN, LOG_INFO, LOC + QString("Found %1 channels").arg(m_channels->size()));
+
+    // Add the channels to the DB
+    hdhr_chan_map_t::const_iterator it = m_channels->cbegin();
+    for (uint i = 1; it != m_channels->cend(); ++it, ++i)
+    {
+        QString channum     = it.key();
+        QString name        = (*it).m_name;
+        uint serviceID      = (*it).m_serviceID;
+        QString channelType = (*it).m_channelType;
+        QString hdhrmod     = (*it).m_modulation;
+        uint networkID      = (*it).m_networkID;
+        uint transportID    = (*it).m_transportID;
+        uint frequency      = (*it).m_frequency;
+
+        QString modsys = HDHRMod2Modsys(hdhrmod);
+        QString modulation = HDHRMod2Modulation(hdhrmod);
+        uint symbolrate = HDHRMod2SymbolRate(hdhrmod);
+        signed char bandwidth = HDHRMod2Bandwidth(hdhrmod);
+        uint atsc_major_channel = 0;
+        uint atsc_minor_channel = 0;
+        bool use_on_air_guide = true;
+
+        QString msg = tr("%1 channel %2: %3").arg(channelType).arg(channum, -5, QChar(' ')).arg(name, -15, QChar(' '));
+        LOG(VB_CHANSCAN, LOG_INFO, QString("Found %1").arg(msg));
+
+        if ((channelType == "Radio") && (m_serviceType & kRequireVideo))
+        {
+            // Ignore this radio channel
+            if (m_scanMonitor)
+            {
+                m_scanMonitor->ScanAppendTextToLog(tr("Ignoring %1").arg(msg));
+            }
+        }
+        else if ((channelType == "Data") && (m_serviceType != kRequireNothing))
+        {
+            // Ignore this data channel
+            if (m_scanMonitor)
+            {
+                m_scanMonitor->ScanAppendTextToLog(tr("Ignoring %1").arg(msg));
+            }
+        }
+        else
+        {
+            // This is a TV channel or another channel type that we want
+            int chanid = ChannelUtil::GetChanID(m_sourceId, channum);
+            bool adding_channel = chanid <= 0;
+
+            if (adding_channel)
+                chanid = ChannelUtil::CreateChanID(m_sourceId, channum);
+
+            if (m_scanMonitor)
+            {
+                if (adding_channel)
+                {
+                    m_scanMonitor->ScanAppendTextToLog(tr("Adding %1").arg(msg));
+                }
+                else
+                {
+                    m_scanMonitor->ScanAppendTextToLog(tr("Updating %1").arg(msg));
+                }
+            }
+
+            // A new dtv_multiplex entry will be created if necessary, otherwise an existing one is returned
+            uint mplexID = ChannelUtil::CreateMultiplex(m_sourceId, "dvb", frequency, modulation,
+                                                        transportID, networkID, symbolrate, bandwidth,
+                                                        'v', 'a', 'a', QString(), QString(), 'a', QString(),
+                                                        QString(), QString(), modsys, "0.35");
+
+            if (adding_channel)
+            {
+                ChannelUtil::CreateChannel(mplexID, m_sourceId, chanid, name, name,
+                                           channum, serviceID, atsc_major_channel, atsc_minor_channel,
+                                           use_on_air_guide, kChannelVisible, QString(),
+                                           QString(), "Default", QString());
+
+                ChannelUtil::CreateIPTVTuningData(chanid, (*it).m_tuning);
+            }
+            else
+            {
+                ChannelUtil::UpdateChannel(mplexID, m_sourceId, chanid, name, name,
+                                           channum, serviceID, atsc_major_channel, atsc_minor_channel,
+                                           use_on_air_guide, kChannelVisible, QString(),
+                                           QString(), "Default", QString());
+
+                ChannelUtil::UpdateIPTVTuningData(chanid, (*it).m_tuning);
+            }
+            LOG(VB_GENERAL, LOG_INFO, QString("%1 sid:%2 freq:%3 url:%4")
+                .arg(msg).arg(serviceID, -5, 10, QChar(' ')).arg(frequency).arg((*it).m_tuning.GetDataURL().toString()));
+        }
+        SetNumChannelsInserted(i);
+    }
+
+    if (m_scanMonitor)
+    {
+        m_scanMonitor->ScanAppendTextToLog(tr("Done"));
+        m_scanMonitor->ScanPercentComplete(100);
+        m_scanMonitor->ScanComplete();
+    }
+
+    QMutexLocker locker(&m_lock);
+    m_threadRunning = false;
+    m_stopNow = true;
+}
+
+void HDHRChannelFetcher::SetNumChannelsInserted(uint val)
+{
+    uint minval = 70;
+    uint range = 100 - minval;
+    uint pct = minval + (uint) truncf((((float)val) / m_chanCnt) * range);
+    if (m_scanMonitor)
+        m_scanMonitor->ScanPercentComplete(pct);
+}

--- a/mythtv/libs/libmythtv/channelscan/hdhrchannelfetcher.h
+++ b/mythtv/libs/libmythtv/channelscan/hdhrchannelfetcher.h
@@ -1,0 +1,127 @@
+#ifndef HDHRCHANNELFETCHER_H
+#define HDHRCHANNELFETCHER_H
+
+#include <utility>
+
+// Qt headers
+#include <QCoreApplication>
+#include <QMap>
+#include <QMutex>
+#include <QObject>
+#include <QRunnable>
+#include <QString>
+
+// MythTV headers
+#include "libmythbase/mthread.h"
+#include "libmythtv/iptvtuningdata.h"
+
+#include "channelscantypes.h"
+
+class ScanMonitor;
+class HDHRChannelFetcher;
+
+class HDHRChannelInfo
+{
+    Q_DECLARE_TR_FUNCTIONS(HDHRChannelInfo)
+
+  public:
+    HDHRChannelInfo() = default;
+    HDHRChannelInfo(QString name,
+                    QString number,
+                    QString url,
+                    QString modulation,
+                    QString videoCodec,
+                    QString audioCodec,
+                    uint frequency,
+                    uint serviceID,
+                    uint networkID,
+                    uint transportID):
+        m_name(std::move(name)),
+        m_number(std::move(number)),
+        m_tuning(url, IPTVTuningData::http_ts),
+        m_modulation(std::move(modulation)),
+        m_videoCodec(std::move(videoCodec)),
+        m_audioCodec(std::move(audioCodec)),
+        m_frequency(frequency),
+        m_serviceID(serviceID),
+        m_networkID(networkID),
+        m_transportID(transportID)
+    {
+        // Determine channel type from presence of audio and video codecs
+        if (m_videoCodec.isEmpty())
+        {
+            if (m_audioCodec.isEmpty())
+            {
+                // No video, no audio, then it is Data
+                m_channelType = "Data";
+            }
+            else
+            {
+                // Only audio channel then it is Radio
+                m_channelType = "Radio";
+            }
+        }
+        else
+        {
+            // Video with or without audio is always TV
+            m_channelType = "TV";
+        }
+    }
+
+    bool IsValid(void) const
+    {
+        return !m_name.isEmpty() && m_tuning.IsValid();
+    }
+
+  public:
+    QString        m_name;
+    QString        m_number;
+    IPTVTuningData m_tuning;
+    QString        m_channelType;     // TV/Radio/Data
+    QString        m_modulation;
+    QString        m_videoCodec;
+    QString        m_audioCodec;
+    uint           m_frequency;
+    uint           m_serviceID   {0};
+    uint           m_networkID   {0};
+    uint           m_transportID {0};
+    bool           m_fta         {true};
+};
+using hdhr_chan_map_t = QMap<QString,HDHRChannelInfo>;
+
+class HDHRChannelFetcher : public QRunnable
+{
+    Q_DECLARE_TR_FUNCTIONS(HDHRChannelFetcher);
+
+  public:
+    HDHRChannelFetcher(uint cardid, QString inputname, uint sourceid,
+                       ServiceRequirements serviceType, ScanMonitor *monitor = nullptr);
+    ~HDHRChannelFetcher() override;
+
+    void Scan(void);
+    void Stop(void);
+    hdhr_chan_map_t GetChannels(void);
+
+  private:
+    void SetTotalNumChannels(uint val) { m_chanCnt = (val) ? val : 1; }
+    void SetNumChannelsInserted(uint val);
+
+  protected:
+    void run(void) override; // QRunnable
+
+  private:
+    ScanMonitor         *m_scanMonitor    {nullptr};
+    uint                 m_cardId;
+    QString              m_inputName;
+    uint                 m_sourceId;
+    bool                 m_ftaOnly;
+    ServiceRequirements  m_serviceType;
+    hdhr_chan_map_t     *m_channels       {nullptr};
+    uint                 m_chanCnt        {1};
+    bool                 m_threadRunning  {false};
+    bool                 m_stopNow        {false};
+    MThread             *m_thread         {nullptr};
+    QMutex               m_lock;
+};
+
+#endif // HDHRCHANNELFETCHER_H

--- a/mythtv/libs/libmythtv/channelscan/scanwizardconfig.cpp
+++ b/mythtv/libs/libmythtv/channelscan/scanwizardconfig.cpp
@@ -325,10 +325,14 @@ void ScanTypeSetting::SetInput(const QString &cardids_inputname)
                 setHelpText(fullScanHelpTextDVBT2);
             }
             else
+            {
                 addSelection(tr("Full Scan"),
                              QString::number(FullScan_ATSC), true);
+            }
 //             addSelection(tr("Import channels.conf"),
 //                          QString::number(DVBUtilsImport));
+            addSelection(tr("HDHomeRun Channel Import"),
+                         QString::number(HDHRImport));
             addSelection(tr("Import existing scan"),
                          QString::number(ExistingScanImport));
             break;

--- a/mythtv/libs/libmythtv/channelscan/scanwizardconfig.h
+++ b/mythtv/libs/libmythtv/channelscan/scanwizardconfig.h
@@ -103,7 +103,9 @@ class ScanTypeSetting : public TransMythUIComboBoxSetting
         // Import using the VBox API to get the channel list
         VBoxImport,
         // Import using the ExternalRecorder API to get the channel list
-        ExternRecImport
+        ExternRecImport,
+        // Import using the HDHomeRun API to get the channel list
+        HDHRImport
     };
 
     ScanTypeSetting()

--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -961,6 +961,10 @@ using_backend {
         SOURCES += recorders/hdhrrecorder.cpp
         SOURCES += recorders/hdhrstreamhandler.cpp
 
+        # HDHomeRun channel list import
+        HEADERS += channelscan/hdhrchannelfetcher.h
+        SOURCES += channelscan/hdhrchannelfetcher.cpp
+
         HEADERS *= recorders/streamhandler.h
         SOURCES *= recorders/streamhandler.cpp
 

--- a/mythtv/libs/libmythtv/scanwizard.cpp
+++ b/mythtv/libs/libmythtv/scanwizard.cpp
@@ -72,7 +72,7 @@ void ScanWizard::Scan()
     if (scantype == ScanTypeSetting::DVBUtilsImport)
     {
         m_scannerPane->ImportDVBUtils(sourceid, m_lastHWCardType,
-                                    GetFilename());
+                                      GetFilename());
     }
     else if (scantype == ScanTypeSetting::NITAddScan_DVBT)
     {
@@ -108,13 +108,19 @@ void ScanWizard::Scan()
     {
         do_scan = false;
         m_scannerPane->ImportVBox(cardid, inputname, sourceid,
-                                DoFreeToAirOnly(),
-                                GetServiceRequirements());
+                                  DoFreeToAirOnly(),
+                                  GetServiceRequirements());
     }
     else if (scantype == ScanTypeSetting::ExternRecImport)
     {
         do_scan = false;
         m_scannerPane->ImportExternRecorder(cardid, inputname, sourceid);
+    }
+    else if (scantype == ScanTypeSetting::HDHRImport)
+    {
+        do_scan = false;
+        m_scannerPane->ImportHDHR(cardid, inputname, sourceid,
+                                  GetServiceRequirements());
     }
     else if (scantype == ScanTypeSetting::IPTVImportMPTS)
     {


### PR DESCRIPTION
Add the option "HDHomeRun Channel Import" to get the channel list directly from the HDHomeRun. The HDHomeRun does a channel scan all by itself and the list of channels can now be read by mythtv-setup. Also the http url for each channel is read and stored in the database although this is not yet used in MythTV.
There is enough information read from the HDHomeRun to fill database tables channel and dtv_multiplex so that recording can be done with libhdhomerun. This feature has only been tested in The Netherlands and it is expected that it works with all European DVB-T/T2 and DVB-C signals. Support for reading USA/ATSC channel lists is to be added. The actual code is shamelessly copied from the channel import for the VBox and adapted where needed.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ ] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

