### PR TITLE
Show "Input name" field only for analog inputs

### DIFF
--- a/mythtv/libs/libmythtv/v4l2util.cpp
+++ b/mythtv/libs/libmythtv/v4l2util.cpp
@@ -40,7 +40,7 @@ bool V4L2util::Open(const QString& dev_name, const QString& vbi_dev_name)
     m_fd = open(dev_name.toLatin1().constData(), O_RDWR);
     if (m_fd < 0)
     {
-        LOG(VB_GENERAL, LOG_ERR, LOC +
+        LOG(VB_CHANNEL, LOG_INFO, LOC +
             QString("Could not open '%1': ").arg(dev_name) + ENO);
         return false;
     }

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -3206,7 +3206,7 @@ CardInput::CardInput(const QString & cardtype, const QString & device,
         ds->setValue(CardUtil::GetDeliverySystemFromDB(_cardid));
         addChild(ds);
     }
-    else
+    else if (CardUtil::IsV4L(cardtype))
     {
         addChild(m_inputName);
     }

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -2435,10 +2435,10 @@ void HDPVRConfigurationGroup::probeCard(const QString &device)
         else if (!dn.isEmpty())
             ci = cn + "  [" + dn + "]";
         close(videofd);
+        m_audioInput->fillSelections(device);
     }
 
     m_cardInfo->setValue(ci);
-    m_audioInput->fillSelections(device);
 }
 
 V4L2encGroup::V4L2encGroup(CaptureCard &parent, CardType& cardtype) :


### PR DESCRIPTION
Fix a defect in mythtv-setup found by Peter when creating the WebApp configuration utility.

