### PR TITLE
Allow IPTV tuning from HDHomeRun video source

### DIFF
--- a/mythtv/libs/libmythtv/channelscan/iptvchannelfetcher.cpp
+++ b/mythtv/libs/libmythtv/channelscan/iptvchannelfetcher.cpp
@@ -533,11 +533,28 @@ static bool parse_extinf(const QString &line,
         }
     }
 
+    // Parse extension, HDHomeRun style
+    // EG. #EXTINF:-1 channel-id="22" channel-number="22" tvg-name="Omroep Brabant",22 Omroep Brabant
+    static const QRegularExpression chanNumName6
+        { R"(^-?\d+\s+channel-id=\"([^\"]+)\"\s+channel-number=\"([^\"]+)\"\s+tvg-name=\"([^\"]+)\".*$)" };
+    match = chanNumName6.match(line);
+    if (match.hasMatch())
+    {
+        channum = match.captured(2).simplified();
+        name = match.captured(3).simplified();
+        bool ok = false;
+        int channel_number = channum.toInt (&ok);
+        if (ok && (channel_number > 0))
+        {
+            return true;
+        }
+    }
+
     // Parse extension portion, https://github.com/iptv-org/iptv/blob/master/channels/ style
     // EG. #EXTINF:-1 tvg-id="" tvg-name="" tvg-logo="https://i.imgur.com/VejnhiB.png" group-title="News",BBC News
-    static const QRegularExpression chanNumName6
+    static const QRegularExpression chanNumName7
         { "(^-?\\d+)\\s+[^,]*[^,]*,(.*)$" };
-    match = chanNumName6.match(line);
+    match = chanNumName7.match(line);
     if (match.hasMatch())
     {
         channum = match.captured(1).simplified();

--- a/mythtv/libs/libmythtv/tv_rec.cpp
+++ b/mythtv/libs/libmythtv/tv_rec.cpp
@@ -1868,7 +1868,7 @@ bool TVRec::SetupDTVSignalMonitor(bool EITscan)
 
     // Check if this is an DVB channel
     int progNum = dtvchan->GetProgramNumber();
-    if ((progNum >= 0) && (tuningmode == "dvb") && (m_genOpt.m_inputType != "VBOX"))
+    if ((progNum >= 0) && (tuningmode == "dvb") && CardUtil::IsChannelReusable(m_genOpt.m_inputType))
     {
         int netid   = dtvchan->GetOriginalNetworkID();
         int tsid    = dtvchan->GetTransportID();

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -1796,7 +1796,10 @@ class IPTVHost : public CaptureCardTextEditSetting
         setValue("http://mafreebox.freebox.fr/freeboxtv/playlist.m3u");
         setLabel(QObject::tr("M3U URL"));
         setHelpText(
-            QObject::tr("URL of M3U containing RTSP/RTP/UDP channel URLs."));
+            QObject::tr("URL of M3U file containing RTSP/RTP/UDP/HTTP channel URLs,"
+            " example for HDHomeRun: http://<ipv4>/lineup.m3u and for Freebox:"
+            " http://mafreebox.freebox.fr/freeboxtv/playlist.m3u."
+            ));
     }
 };
 


### PR DESCRIPTION
Allow IPTV (FREEBOX) tuning even when DVB tuning data for transport stream interfaces such as transport id is available. A HDHomeRun video source can be populated from an XML file with the "HDHomeRun Channel Import" function.
This loads the tuning data for the libhdhomerun interface but also an URL that can be used for HTTP streaming.
Recording HDHomeRun channels with HTTP streaming can be done by creating an IPTV (FREEBOX) capture card and connecting that capture card to the video source already populated by the HDHomeRun capture card.
The HDHomeRun capture card can then be disconnected from that video source to insure only HTTP streaming is used. Note that HDHomeRun HTTP streaming does not pass EIT data.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ ] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

