### PR TITLE
MythMusic: add percent indicator to WaveForm and shrink and dim the font

### DIFF
--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -669,7 +669,7 @@ bool WaveForm::processUndisplayed(VisualNode *node)
         if (xx != m_lastx)   // draw one finished line of min/max/rms
         {
             if (m_lastx > xx - 1 || // REW seek or right to left edge wrap
-                m_lastx <= xx - 5 * m_duration / m_wfsize.width()) // FFWD
+                m_lastx < xx - 5)   // FFWD seek
             {
                 m_lastx = xx - 1;
             }

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -692,16 +692,16 @@ bool WaveForm::processUndisplayed(VisualNode *node)
                 //     QString("WF painting at %1,%2/%3").arg(x).arg(y).arg(yr));
 
                 // clear prior content of this column
-		if (m_stream)  // clear 5 seconds of future, with wrap
-		{
-		    painter.fillRect(x, 0, 32 * 5,
-				     m_wfsize.height(), Qt::black);
-		    painter.fillRect(x - m_wfsize.width(), 0, 32 * 5,
-				     m_wfsize.height(), Qt::black);
-		} else {	// preserve the future, if any
-		    painter.fillRect(x, 0, 1,
-				     m_wfsize.height(), Qt::black);
-		}
+                if (m_stream)  // clear 5 seconds of future, with wrap
+                {
+                    painter.fillRect(x, 0, 32 * 5,
+                                     m_wfsize.height(), Qt::black);
+                    painter.fillRect(x - m_wfsize.width(), 0, 32 * 5,
+                                     m_wfsize.height(), Qt::black);
+                } else {        // preserve the future, if any
+                    painter.fillRect(x, 0, 1,
+                                     m_wfsize.height(), Qt::black);
+                }
 
                 // Audacity uses 50,50,200 and 100,100,220 - I'm going
                 // darker to better contrast the StereoScope overlay

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -534,9 +534,6 @@ bool MonoScope::draw( QPainter *p, const QColor &back )
 ///////////////////////////////////////////////////////////////////////////////
 // WaveForm - see whole track - by twitham@sbcglobal.net, 2023/01
 
-// static class members survive size changes for continuous display
-QImage WaveForm::m_image {nullptr}; // picture of spectrogram
-
 WaveForm::~WaveForm()
 {
     saveload(nullptr);
@@ -600,7 +597,7 @@ unsigned long WaveForm::getDesiredSamples(void)
 {
     // could be an adjustable class member, but this hard code works well
     // return (unsigned long) WF_AUDIO_SIZE;  // Maximum we can be given
-    return 4096;           // maximum samples per update, may get less
+    return WFAudioSize;    // maximum samples per update, may get less
 }
 
 bool WaveForm::processUndisplayed(VisualNode *node)
@@ -743,11 +740,11 @@ bool WaveForm::draw( QPainter *p, const QColor &back )
     StereoScope::draw(p, Qt::green); // green == no clearing!
 
     p->fillRect(m_size.width() * m_offset / m_duration, 0,
-                1, m_size.height(), qRgb(128, 128, 128));
+                1, m_size.height(), Qt::darkGray);
 
     if (m_showtext && m_size.width() > 500) // metrics in corners
     {
-        p->setPen(qRgb(128, 128, 128)); // Qt::white);
+        p->setPen(Qt::darkGray);
         p->setFont(m_font);
         QRect text(5, 5, m_size.width() - 10, m_size.height() - 10);
         p->drawText(text, Qt::AlignTop | Qt::AlignLeft,

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -668,7 +668,8 @@ bool WaveForm::processUndisplayed(VisualNode *node)
         uint xx = m_wfsize.width() * m_offset / m_duration;
         if (xx != m_lastx)   // draw one finished line of min/max/rms
         {
-            if (m_lastx > xx - 1) // right to left wrap
+            if (m_lastx > xx - 1 || // REW seek or right to left edge wrap
+                m_lastx <= xx - 5 * m_duration / m_wfsize.width()) // FFWD
             {
                 m_lastx = xx - 1;
             }

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -140,10 +140,6 @@ class MonoScope : public StereoScope
 
 // WaveForm - see whole track - by twitham@sbcglobal.net, 2023/01
 
-#define WF_AUDIO_SIZE 4096     // maximum samples to process at a time
-#define WF_WIDTH 1920   // image cache size, will scale to any display
-#define WF_HEIGHT 1080
-
 class WaveForm : public StereoScope
 {
   public:
@@ -155,25 +151,26 @@ class WaveForm : public StereoScope
     bool process( VisualNode *node ) override;
     bool draw( QPainter *p, const QColor &back ) override;
     void handleKeyPress(const QString &action) override;
+    static QImage        m_image;      // picture of full track
 
   protected:
     bool process_all_types(VisualNode *node, bool displayed);
     void saveload(MusicMetadata *meta);
-    unsigned long m_offset {0}; // pass from process to draw
+    QSize         m_wfsize {1920, 1080}; // picture size
+    unsigned long m_offset {0};          // node offset for draw
     short         *m_right {nullptr};
     QFont         m_font;       // optional text overlay
     bool          m_showtext {true};
-    QImage        m_image;      // picture of full track
     MusicMetadata *m_currentMetadata {nullptr};
-    unsigned long m_duration {60000};
-    unsigned int  m_lastx    {WF_WIDTH}; // vert line tracker
-    unsigned int  m_position {0};        // location inside pixel
-    short int     m_minl     {0};        // left range
-    short int     m_maxl     {0};
-    unsigned long m_sqrl     {0}; // sum of squares, for RMS
-    short int     m_minr     {0}; // right range
-    short int     m_maxr     {0};
-    unsigned long m_sqrr     {0};
+    unsigned long m_duration {60000}; // file length in milliseconds
+    unsigned int  m_lastx    {1920};  // vert line tracker
+    unsigned int  m_position {0};     // location inside pixel
+    short int     m_minl     {0};     // left range minimum
+    short int     m_maxl     {0};     // left range maximum
+    unsigned long m_sqrl     {0};     // sum of squares, for RMS
+    short int     m_minr     {0};     // right range minimum
+    short int     m_maxr     {0};     // right range maximum
+    unsigned long m_sqrr     {0};     // sum of squares, for RMS
 };
 
 class LogScale

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -142,7 +142,8 @@ class MonoScope : public StereoScope
 
 class WaveForm : public StereoScope
 {
-    static constexpr unsigned long WFAudioSize { 4096 };
+    static constexpr unsigned long kWFAudioSize { 4096 };
+    static QImage s_image;	// picture of full track
 
 public:
     WaveForm() = default;
@@ -155,14 +156,12 @@ public:
     void handleKeyPress(const QString &action) override;
 
   protected:
-    bool process_all_types(VisualNode *node, bool displayed);
     void saveload(MusicMetadata *meta);
     QSize         m_wfsize {1920, 1080}; // picture size
     unsigned long m_offset {0};          // node offset for draw
     short         *m_right {nullptr};
     QFont         m_font;       // optional text overlay
     bool          m_showtext {true};
-    QImage        m_image;      // picture of full track
     MusicMetadata *m_currentMetadata {nullptr};
     unsigned long m_duration {60000}; // file length in milliseconds
     unsigned int  m_lastx    {1920};  // vert line tracker

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -172,6 +172,7 @@ public:
     short int     m_minr     {0};     // right range minimum
     short int     m_maxr     {0};     // right range maximum
     unsigned long m_sqrr     {0};     // sum of squares, for RMS
+    bool          m_stream   {false}; // true if radio stream
 };
 
 class LogScale

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -142,7 +142,9 @@ class MonoScope : public StereoScope
 
 class WaveForm : public StereoScope
 {
-  public:
+    static constexpr unsigned long WFAudioSize { 4096 };
+
+public:
     WaveForm() = default;
     ~WaveForm() override;
 
@@ -151,7 +153,6 @@ class WaveForm : public StereoScope
     bool process( VisualNode *node ) override;
     bool draw( QPainter *p, const QColor &back ) override;
     void handleKeyPress(const QString &action) override;
-    static QImage        m_image;      // picture of full track
 
   protected:
     bool process_all_types(VisualNode *node, bool displayed);
@@ -161,6 +162,7 @@ class WaveForm : public StereoScope
     short         *m_right {nullptr};
     QFont         m_font;       // optional text overlay
     bool          m_showtext {true};
+    QImage        m_image;      // picture of full track
     MusicMetadata *m_currentMetadata {nullptr};
     unsigned long m_duration {60000}; // file length in milliseconds
     unsigned int  m_lastx    {1920};  // vert line tracker


### PR DESCRIPTION
as the white was too bright.  Add 5 second gap to radio streams.

Also eliminate all #defines by moving the settings to class members.  Few other code cleanups that change no functionality.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

