### PR TITLE
MythMusic: Spectrogram (and SpectrumDetail) visualization

### DIFF
--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -998,23 +998,24 @@ bool Spectrogram::processUndisplayed(VisualNode *node)
         int count = 0;
         for (auto j = prev + 1; j <= index; j++)
         {    // for the freqency bins of this pixel, find peak or mean
-
-            // // linear magnitude:
-            // tmp = sqrt(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
-
-            // power spectrum (dBm):
-            tmp = 10 * log10(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
+            tmp = sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]);
             left  = m_binpeak ? (tmp > left  ? tmp : left ) : left  + tmp;
-            tmp = 10 * log10(sq(m_dftR[2 * j]) + sq(m_dftR[2 * j + 1]));
+            tmp = sq(m_dftR[2 * j]) + sq(m_dftR[2 * j + 1]);
             right = m_binpeak ? (tmp > right ? tmp : right) : right + tmp;
             count++;
         }
         if (!m_binpeak)
-        {			// mean of the frequency bins
+        {                       // mean of the frequency bins
             (count > 0) || (count = 1);
             left /= count;
             right /= count;
         }
+        // linear magnitude:           sqrt(sq(real) + sq(im));
+        // left = sqrt(left);
+        // right = sqrt(right);
+        // power spectrum (dBm): 10 * log10(sq(real) + sq(im));
+        left = 10 * log10(left);
+        right = 10 * log10(right);
 
         // float bw = 1. / (16384. / 44100.);
         // float freq = bw * index;

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -107,11 +107,6 @@ LogScale::LogScale(int maxscale, int maxrange)
     setMax(maxscale, maxrange);
 }
 
-LogScale::~LogScale()
-{
-    delete [] m_indices;
-}
-
 void LogScale::setMax(int maxscale, int maxrange)
 {
     if (maxscale == 0 || maxrange == 0)
@@ -120,17 +115,14 @@ void LogScale::setMax(int maxscale, int maxrange)
     m_s = maxscale;
     m_r = maxrange;
 
-    delete [] m_indices;
-
     auto domain = (long double) maxscale;
     auto range  = (long double) maxrange;
     long double x  = 1.0;
     long double dx = 1.0;
     long double e4 = 1.0E-8;
 
-    m_indices = new int[maxrange];
-    for (int i = 0; i < maxrange; i++)
-        m_indices[i] = 0;
+    m_indices.clear();
+    m_indices.resize(maxrange, 0);
 
     // initialize log scale
     for (uint i=0; i<10000 && (std::abs(dx) > e4); i++)

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -922,9 +922,18 @@ Spectrogram::Spectrogram(bool hist)
     {
         s_image = QImage(
             m_sgsize.width(), m_sgsize.height(), QImage::Format_RGB32);
+        s_image.fill(Qt::black);
     }
-    m_image = m_history ? &s_image : new QImage(
-        m_sgsize.width(), m_sgsize.height(), QImage::Format_RGB32);
+    if (m_history)
+    {
+	m_image = &s_image;
+    }
+    else
+    {
+        m_image = new QImage(
+	    m_sgsize.width(), m_sgsize.height(), QImage::Format_RGB32);
+        m_image->fill(Qt::black);
+    }
 
     m_dftL = static_cast<FFTSample*>(av_malloc(sizeof(FFTSample) * m_fftlen));
     m_dftR = static_cast<FFTSample*>(av_malloc(sizeof(FFTSample) * m_fftlen));

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -859,7 +859,8 @@ static class WaveFormFactory : public VisFactory
 // but only recent time has high amplitude.  This nicely displays even
 // quick sounds of a few milliseconds.
 
-// static class members survive size changes for continuous display
+// Static class members survive size changes for continuous display.
+// See the comment about s_image in WaveForm
 QImage Spectrogram::s_image {nullptr}; // picture of spectrogram
 int    Spectrogram::s_offset {0};      // position on screen
 
@@ -925,7 +926,8 @@ template<typename T> T sq(T a) { return a*a; };
 
 unsigned long Spectrogram::getDesiredSamples(void)
 {
-    return 4096;           // maximum samples per update, may get less
+    // maximum samples per update, may get less
+    return (unsigned long)kSGAudioSize;
 }
 
 bool Spectrogram::process(VisualNode */*node*/)
@@ -935,6 +937,8 @@ bool Spectrogram::process(VisualNode */*node*/)
 
 bool Spectrogram::processUndisplayed(VisualNode *node)
 {
+    // as of v33, this processes *all* samples, see WaveForm
+
     int i = 0;
     int w = m_sgsize.width();   // drawing size
     int h = m_sgsize.height();
@@ -967,7 +971,7 @@ bool Spectrogram::processUndisplayed(VisualNode *node)
         }
         // LOG(VB_PLAYBACK, LOG_DEBUG,
         //     QString("SG 0=%1,%2\t%3=%4,%5").arg(node->m_left[0]).arg(node->m_left[1]).arg(i-1).arg(node->m_left[i-2]).arg(node->m_left[i-1]));
-        int end = m_fftlen / 20; // ramp window ends down to zero crossing
+        int end = m_fftlen / 40; // ramp window ends down to zero crossing
         for (int k = 0; k < m_fftlen; k++)
         {
             float mult = k < end ? k / end : k > m_fftlen - end ?

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -991,22 +991,30 @@ bool Spectrogram::processUndisplayed(VisualNode *node)
     int prev = 0;               // previous frequency
     float gain = 5.0;           // compensate for window function loss
     for (i = 1; i < h / 2; i++)
-    {
+    {                           // for each pixel of the spectrogram...
         float left = 0;
         float right = 0;
+        float tmp = 0;
         int count = 0;
-        for (auto j = prev + 1; j <= index; j++) {
+        for (auto j = prev + 1; j <= index; j++)
+        {    // for the freqency bins of this pixel, find peak or mean
+
             // // linear magnitude:
-            // left   += sqrt(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
-            // right  += sqrt(sq(m_dftR[2 * j]) + sq(m_dftR[2 * j + 1]));
+            // tmp = sqrt(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
+
             // power spectrum (dBm):
-            left  += 10 * log10(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
-            right += 10 * log10(sq(m_dftR[2 * j]) + sq(m_dftR[2 * j + 1]));
+            tmp = 10 * log10(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
+            left  = m_binpeak ? (tmp > left  ? tmp : left ) : left  + tmp;
+            tmp = 10 * log10(sq(m_dftR[2 * j]) + sq(m_dftR[2 * j + 1]));
+            right = m_binpeak ? (tmp > right ? tmp : right) : right + tmp;
             count++;
         }
-        (count > 0) || (count = 1);
-        left /= count;          // mean of bucket of values, or peak?
-        right /= count;
+        if (!m_binpeak)
+        {			// mean of the frequency bins
+            (count > 0) || (count = 1);
+            left /= count;
+            right /= count;
+        }
 
         // float bw = 1. / (16384. / 44100.);
         // float freq = bw * index;

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -987,8 +987,8 @@ bool Spectrogram::processUndisplayed(VisualNode *node)
     painter.fillRect(s_offset,     0, 256, h, Qt::black);
     painter.fillRect(s_offset - w, 0, 256, h, Qt::black);
 
-    int index = 1;              // frequency index
-    int prev = 0;               // previous frequency
+    int index = 1;              // frequency index of this pixel
+    int prev = 0;               // frequency index of previous pixel
     float gain = 5.0;           // compensate for window function loss
     for (i = 1; i < h / 2; i++)
     {                           // for each pixel of the spectrogram...
@@ -1047,8 +1047,8 @@ bool Spectrogram::processUndisplayed(VisualNode *node)
             painter.setPen(qRgb(mag, mag, mag));
         painter.drawPoint(s_offset, h - i);
 
-        prev = index;
-        index = m_scale[i];
+        prev = index;           // next pixel is FFT bins from here
+        index = m_scale[i];     // to the next bin by LOG scale
         (prev < index) || (prev = index -1);
     }
     if (++s_offset >= w)

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -922,6 +922,7 @@ void Spectrogram::resize(const QSize &newsize)
     m_size = newsize;
 }
 
+// this moved up from Spectrum so both can use it
 template<typename T> T sq(T a) { return a*a; };
 
 unsigned long Spectrogram::getDesiredSamples(void)
@@ -1154,10 +1155,16 @@ void Spectrum::resize(const QSize &newsize)
                     log( static_cast<double>(FFTW_N) );
 }
 
+// this moved up to Spectrogram so both can use it
 // template<typename T> T sq(T a) { return a*a; };
 
 bool Spectrum::process(VisualNode *node)
 {
+    // Take a bunch of data in *node
+    // and break it down into spectrum
+    // values
+    bool allZero = true;
+
     uint i = 0;
     long w = 0;
     QRect *rectsp = m_rects.data();
@@ -1179,7 +1186,7 @@ bool Spectrum::process(VisualNode *node)
     for (auto k = i; k < FFTW_N; k++)
     {
         m_dftL[k] = (FFTComplex){ .re = 0, .im = 0 };
-        m_dftR[k] = (FFTComplex){ .re = 0, .im = 0 };
+        m_dftL[k] = (FFTComplex){ .re = 0, .im = 0 };
     }
     av_fft_permute(m_fftContextForward, m_dftL);
     av_fft_calc(m_fftContextForward, m_dftL);
@@ -1237,6 +1244,11 @@ bool Spectrum::process(VisualNode *node)
             magR = 1.;
         }
 
+        if (magR != 1 || magL != 1)
+        {
+            allZero = false;
+        }
+
         magnitudesp[i] = magL;
         magnitudesp[i + m_scale.range()] = magR;
         rectsp[i].setTop( m_size.height() / 2 - int( magL ) );
@@ -1245,6 +1257,7 @@ bool Spectrum::process(VisualNode *node)
         index = m_scale[i];
     }
 
+    Q_UNUSED(allZero);
     return false;
 }
 

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -107,6 +107,11 @@ LogScale::LogScale(int maxscale, int maxrange)
     setMax(maxscale, maxrange);
 }
 
+LogScale::~LogScale()
+{
+    delete [] m_indices;
+}
+
 void LogScale::setMax(int maxscale, int maxrange)
 {
     if (maxscale == 0 || maxrange == 0)
@@ -115,14 +120,17 @@ void LogScale::setMax(int maxscale, int maxrange)
     m_s = maxscale;
     m_r = maxrange;
 
+    delete [] m_indices;
+
     auto domain = (long double) maxscale;
     auto range  = (long double) maxrange;
     long double x  = 1.0;
     long double dx = 1.0;
     long double e4 = 1.0E-8;
 
-    m_indices.clear();
-    m_indices.resize(maxrange, 0);
+    m_indices = new int[maxrange];
+    for (int i = 0; i < maxrange; i++)
+        m_indices[i] = 0;
 
     // initialize log scale
     for (uint i=0; i<10000 && (std::abs(dx) > e4); i++)
@@ -849,6 +857,249 @@ static class WaveFormFactory : public VisFactory
 }WaveFormFactory;
 
 ///////////////////////////////////////////////////////////////////////////////
+// Spectrogram - by twitham@sbcglobal.net, 2023/05
+//
+// A spectrogram needs the entire sound signal.  A wide sliding window
+// is needed to detect low frequencies, 2^14 = 16384 works great.  But
+// then the detected frequencies can linger up to 16384/44100=372
+// milliseconds!  We solve this by shrinking the signal amplitude over
+// time within the window.  This way all frequencies are still there
+// but only recent time has high amplitude.  This nicely displays even
+// quick sounds of a few milliseconds.
+
+// static class members survive size changes for continuous display
+QImage Spectrogram::s_image {nullptr}; // picture of spectrogram
+int    Spectrogram::s_offset {0};      // position on screen
+
+Spectrogram::Spectrogram()
+{
+    LOG(VB_GENERAL, LOG_INFO, QString("Spectrogram : Being Initialised"));
+
+    m_fps = 15;                 // needed?  right?
+
+    m_dftL = static_cast<FFTSample*>(av_malloc(sizeof(FFTSample) * m_fftlen));
+    m_dftR = static_cast<FFTSample*>(av_malloc(sizeof(FFTSample) * m_fftlen));
+
+    m_rdftContext = av_rdft_init(std::log2(m_fftlen), DFT_R2C);
+
+    m_scale.setMax(m_fftlen / 2, m_sgsize.height() / 2);
+    m_sigL.resize(m_fftlen);
+    m_sigR.resize(m_fftlen);
+
+    // cache a continuous color spectrum:
+    // 0000ff blue
+    // 00ffff cyan
+    // 00ff00 green
+    // ffff00 yellow
+    // ff0000 red
+    // ff00ff magenta
+    // 0000ff blue
+    int red[]   = {0, 0, 9, 1, 1, 8}; // 8 = ramp down
+    int green[] = {9, 1, 1, 8, 0, 0}; // 9 = ramp up
+    int blue[]  = {1, 8, 0, 0, 9, 1};
+    m_red   = (int *) malloc(sizeof(int) * 257 * 6);
+    m_green = (int *) malloc(sizeof(int) * 257 * 6);
+    m_blue  = (int *) malloc(sizeof(int) * 257 * 6);
+    for (int i = 0; i < 6; i++)
+    {
+        int r = red[i];
+        int g = green[i];
+        int b = blue[i];
+        for (int u = 0; u < 256; u++) { // u ramps up
+            int d = 256 - u;            // d ramps down
+            m_red[  i * 256 + u] = r == 9 ? u : r == 8 ? d : r * 255;
+            m_green[i * 256 + u] = g == 9 ? u : g == 8 ? d : g * 255;
+            m_blue[ i * 256 + u] = b == 9 ? u : b == 8 ? d : b * 255;
+        }
+    }
+}
+
+Spectrogram::~Spectrogram()
+{
+    av_freep(&m_dftL);
+    av_freep(&m_dftR);
+    av_rdft_end(m_rdftContext);
+    if (m_red)   free(m_red);
+    if (m_green) free(m_green);
+    if (m_blue)  free(m_blue);
+}
+
+void Spectrogram::resize(const QSize &newsize)
+{
+    m_size = newsize;
+}
+
+template<typename T> T sq(T a) { return a*a; };
+
+unsigned long Spectrogram::getDesiredSamples(void)
+{
+    return 4096;           // maximum samples per update, may get less
+}
+
+bool Spectrogram::process(VisualNode */*node*/)
+{
+    return false;
+}
+
+bool Spectrogram::processUndisplayed(VisualNode *node)
+{
+    int i = 0;
+    int w = m_sgsize.width();   // drawing size
+    int h = m_sgsize.height();
+    if (s_image.isNull())
+    {
+        s_image = QImage(w, h, QImage::Format_RGB32);
+        s_image.fill(qRgb(0, 0, 0));
+        s_offset = 0;
+    }
+    if (node)     // shift previous samples left, then append new node
+    {
+        i = node->m_length;
+        (i <= m_fftlen) || (i = m_fftlen);
+        int start = m_fftlen - i;
+        for (int k = 0; k < start; k++)
+        {
+            float mult = 0.8F;  // decay older sound by this much
+            if (k > start - i)  // prior set ramps from mult to 1.0
+            {
+                mult = mult + (1 - mult) * (1 - (start - k) / (start - i));
+            }
+            m_sigL[k] = mult * m_sigL[i + k];
+            m_sigR[k] = mult * m_sigR[i + k];
+        }
+        for (uint k = 0; k < node->m_length; k++) // append current samples
+        {
+            m_sigL[start + k] = node->m_left[k] / 32768.; // +/- 1 peak-to-peak
+            if (node->m_right)
+                m_sigR[start + k] = node->m_right[k] / 32768.;
+        }
+        // LOG(VB_PLAYBACK, LOG_DEBUG,
+        //     QString("SG 0=%1,%2\t%3=%4,%5").arg(node->m_left[0]).arg(node->m_left[1]).arg(i-1).arg(node->m_left[i-2]).arg(node->m_left[i-1]));
+        int end = m_fftlen / 20; // ramp window ends down to zero crossing
+        for (int k = 0; k < m_fftlen; k++)
+        {
+            float mult = k < end ? k / end : k > m_fftlen - end ?
+                (m_fftlen - k) / end : 1;
+            m_dftL[k] = m_sigL[k] * mult;
+            m_dftR[k] = m_sigR[k] * mult;
+        }
+    }
+    av_rdft_calc(m_rdftContext, m_dftL); // run the real FFT!
+    av_rdft_calc(m_rdftContext, m_dftR);
+
+    QPainter painter(&s_image);
+    painter.setPen(Qt::black);  // clear prior content
+    painter.fillRect(s_offset,     0, 256, h, Qt::black);
+    painter.fillRect(s_offset - w, 0, 256, h, Qt::black);
+
+    long index = 1;             // frequency index
+    int prev = 0;               // previous frequency
+    float gain = 5.0;           // compensate for window function loss
+    for (i = 0; (int)i < h / 2; i++)
+    {
+        float left = 0;
+        float right = 0;
+        int count = 0;
+        for (auto j = prev + 1; j <= index; j++) {
+            // // linear magnitude:
+            // left   += sqrt(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
+            // right  += sqrt(sq(m_dftR[2 * j]) + sq(m_dftR[2 * j + 1]));
+            // power spectrum (dBm):
+            left  += 10 * log10(sq(m_dftL[2 * j]) + sq(m_dftL[2 * j + 1]));
+            right += 10 * log10(sq(m_dftR[2 * j]) + sq(m_dftR[2 * j + 1]));
+            count++;
+        }
+        left /= count;          // mean of bucket of values, or peak?
+        right /= count;
+        prev = index;
+
+        // LOG(VB_PLAYBACK, LOG_DEBUG,
+        //     QString("SG i=%1, index=%2 (%3)\tleft=%4,\tmag=%5").arg(i).arg(index).arg(count).arg(left).arg(magL));
+
+        left *= gain;
+        float mag = clamp(left, 255, 0);
+        int z = (int)(mag * 6);
+        h = m_sgsize.height() / 2;
+        left > 255 ? painter.setPen(Qt::white) :
+            painter.setPen(qRgb(m_red[z], m_green[z], m_blue[z]));
+        painter.drawLine(s_offset,     h - i, s_offset     + mag, h - i);
+        painter.drawLine(s_offset - w, h - i, s_offset - w + mag, h - i);
+        left > 255 ? painter.setPen(Qt::yellow) :
+            painter.setPen(qRgb(mag, mag, mag));
+        painter.drawPoint(s_offset, h - i);
+
+        right *= gain;          // copy of above, s/left/right/g
+        mag = clamp(right, 255, 0);
+        z = (int)(mag * 6);
+        h = m_sgsize.height();
+        right > 255 ? painter.setPen(Qt::white) :
+            painter.setPen(qRgb(m_red[z], m_green[z], m_blue[z]));
+        painter.drawLine(s_offset,     h - i, s_offset     + mag, h - i);
+        painter.drawLine(s_offset - w, h - i, s_offset - w + mag, h - i);
+        right > 255 ? painter.setPen(Qt::yellow) :
+            painter.setPen(qRgb(mag, mag, mag));
+        painter.drawPoint(s_offset, h - i);
+
+        index = m_scale[i];
+    }
+    if (++s_offset >= w)
+    {
+        s_offset = 0;
+    }
+    return false;
+}
+
+double Spectrogram::clamp(double cur, double max, double min)
+{
+    if (isnan(cur)) return 0;
+    if (cur > max) cur = max;
+    if (cur < min) cur = min;
+    return cur;
+}
+
+bool Spectrogram::draw(QPainter *p, const QColor &back)
+{
+    p->fillRect(0, 0, 0, 0, back); // no clearing, here to suppress warning
+    if (!s_image.isNull())
+    {                        // background, updated by ::process above
+        p->drawImage(0, 0, s_image.scaled(m_size,
+                                          Qt::IgnoreAspectRatio,
+                                          Qt::SmoothTransformation));
+    }
+    // // DEBUG: see the whole signal going into the FFT:
+    // if (m_size.height() > 1000) {
+    //  p->setPen(Qt::yellow);
+    //  float h = m_size.height() / 10;
+    //  for (int j = 0; j < m_fftlen; j++) {
+    //      p->drawPoint(j % m_size.width(), int(j / m_size.width()) * h + h - h * m_sigL[j]);
+    //  }
+    // }
+    return true;
+}
+
+static class SpectrogramFactory : public VisFactory
+{
+  public:
+    const QString &name(void) const override // VisFactory
+    {
+        static QString s_name = QCoreApplication::translate("Visualizers",
+                                                            "Spectrogram");
+        return s_name;
+    }
+
+    uint plugins(QStringList *list) const override // VisFactory
+    {
+        *list << name();
+        return 1;
+    }
+
+    VisualBase *create(MainVisual */*parent*/, const QString &/*pluginName*/) const override // VisFactory
+    {
+        return new Spectrogram();
+    }
+}SpectrogramFactory;
+
+///////////////////////////////////////////////////////////////////////////////
 // Spectrum
 //
 
@@ -907,15 +1158,10 @@ void Spectrum::resize(const QSize &newsize)
                     log( static_cast<double>(FFTW_N) );
 }
 
-template<typename T> T sq(T a) { return a*a; };
+// template<typename T> T sq(T a) { return a*a; };
 
 bool Spectrum::process(VisualNode *node)
 {
-    // Take a bunch of data in *node
-    // and break it down into spectrum
-    // values
-    bool allZero = true;
-
     uint i = 0;
     long w = 0;
     QRect *rectsp = m_rects.data();
@@ -937,7 +1183,7 @@ bool Spectrum::process(VisualNode *node)
     for (auto k = i; k < FFTW_N; k++)
     {
         m_dftL[k] = (FFTComplex){ .re = 0, .im = 0 };
-        m_dftL[k] = (FFTComplex){ .re = 0, .im = 0 };
+        m_dftR[k] = (FFTComplex){ .re = 0, .im = 0 };
     }
     av_fft_permute(m_fftContextForward, m_dftL);
     av_fft_calc(m_fftContextForward, m_dftL);
@@ -995,11 +1241,6 @@ bool Spectrum::process(VisualNode *node)
             magR = 1.;
         }
 
-        if (magR != 1 || magL != 1)
-        {
-            allZero = false;
-        }
-
         magnitudesp[i] = magL;
         magnitudesp[i + m_scale.range()] = magR;
         rectsp[i].setTop( m_size.height() / 2 - int( magL ) );
@@ -1008,7 +1249,6 @@ bool Spectrum::process(VisualNode *node)
         index = m_scale[i];
     }
 
-    Q_UNUSED(allZero);
     return false;
 }
 

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -769,7 +769,7 @@ bool WaveForm::draw( QPainter *p, const QColor &back )
 {
     p->fillRect(0, 0, 0, 0, back); // no clearing, here to suppress warning
     if (!m_image.isNull())
-    {			     // background, updated by ::process above
+    {                        // background, updated by ::process above
         p->drawImage(0, 0, m_image.scaled(m_size,
                                           Qt::IgnoreAspectRatio,
                                           Qt::SmoothTransformation));
@@ -926,12 +926,12 @@ Spectrogram::Spectrogram(bool hist)
     }
     if (m_history)
     {
-	m_image = &s_image;
+        m_image = &s_image;
     }
     else
     {
         m_image = new QImage(
-	    m_sgsize.width(), m_sgsize.height(), QImage::Format_RGB32);
+            m_sgsize.width(), m_sgsize.height(), QImage::Format_RGB32);
         m_image->fill(Qt::black);
     }
 

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -180,7 +180,6 @@ class LogScale
 {
   public:
     explicit LogScale(int maxscale = 0, int maxrange = 0);
-    ~LogScale();
 
     int scale() const { return m_s; }
     int range() const { return m_r; }
@@ -191,7 +190,7 @@ class LogScale
 
 
   private:
-    int *m_indices {nullptr};
+    std::vector<int> m_indices;
     int  m_s       {0};
     int  m_r       {0};
 };

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -70,6 +70,7 @@ class VisualBase
 
     // this is called on nodes that will not be displayed :: Not needed for most visualizations
     // (i.e. between the displayed frames, if you need the whole audio stream)
+    // as of v33, this processes *all* samples, see the comments in WaveForm
     virtual bool processUndisplayed( VisualNode */*node*/ )
     {
         return true; // By default this does nothing : Ignore the in-between chunks of audio data
@@ -195,6 +196,20 @@ class LogScale
     int  m_r       {0};
 };
 
+class MelScale
+{
+  public:
+    explicit MelScale(int maxscale = 0, int maxrange = 0, int maxfreq = 0);
+
+    void setMax(int maxscale, int maxrange, int maxfreq);
+    double hz2mel(double hz);
+    double mel2hz(double mel);
+    int operator[](int index);
+
+  private:
+    std::vector<int> m_indices;
+};
+
 // Spectrogram - by twitham@sbcglobal.net, 2023/05
 
 class Spectrogram : public VisualBase
@@ -211,8 +226,8 @@ class Spectrogram : public VisualBase
     bool processUndisplayed(VisualNode *node) override;
     bool process( VisualNode *node ) override;
     bool draw(QPainter *p, const QColor &back = Qt::black) override;
-    void handleKeyPress(const QString &action) override
-        {(void) action;}
+    void handleKeyPress(const QString &action) override;
+    // {(void) action;}
     static QImage s_image;      // picture of spectrogram
     static int    s_offset;     // position on screen
 
@@ -221,7 +236,7 @@ class Spectrogram : public VisualBase
     QImage         *m_image;              // picture in use
     QSize          m_sgsize {1920, 1080}; // picture size
     QSize          m_size;                // displayed dize
-    LogScale       m_scale;               // Y-axis
+    MelScale       m_scale;               // Y-axis
     int            m_fftlen {16 * 1024}; // window width
     QVector<float> m_sigL;               // decaying signal window
     QVector<float> m_sigR;

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -217,18 +217,19 @@ class Spectrogram : public VisualBase
 
   protected:
     static inline double clamp(double cur, double max, double min);
-    QSize              m_sgsize {1920, 1080}; // picture size
-    QSize              m_size;                // displayed dize
-    LogScale           m_scale;
-    int                m_fftlen {16 * 1024}; // window width
-    QVector<float>     m_sigL;               // signal window
-    QVector<float>     m_sigR;
-    FFTSample*         m_dftL        { nullptr }; // real in, complex out
-    FFTSample*         m_dftR        { nullptr };
-    RDFTContext*       m_rdftContext { nullptr };
-    int                *m_red   {nullptr};
-    int                *m_green {nullptr};
-    int                *m_blue  {nullptr};
+    QSize          m_sgsize {1920, 1080}; // picture size
+    QSize          m_size;                // displayed dize
+    LogScale       m_scale;
+    int            m_fftlen {16 * 1024}; // window width
+    QVector<float> m_sigL;               // decaying signal window
+    QVector<float> m_sigR;
+    FFTSample*     m_dftL { nullptr }; // real in, complex out
+    FFTSample*     m_dftR { nullptr };
+    RDFTContext*   m_rdftContext { nullptr };
+    int            *m_red   {nullptr};
+    int            *m_green {nullptr};
+    int            *m_blue  {nullptr};
+    bool           m_binpeak { false }; // peak of bins, else mean
 };
 
 class Spectrum : public VisualBase

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -199,10 +199,11 @@ class LogScale
 
 class Spectrogram : public VisualBase
 {
-    static constexpr int kSGAudioSize { 4096 };
+    // 1152 is the most I can get = 38.28125 fps @ 44100
+    static constexpr int kSGAudioSize { 1152 };
 
   public:
-    Spectrogram();
+    Spectrogram(bool hist);
     ~Spectrogram() override;
 
     unsigned long getDesiredSamples(void) override;
@@ -217,19 +218,27 @@ class Spectrogram : public VisualBase
 
   protected:
     static inline double clamp(double cur, double max, double min);
+    QImage         *m_image;              // picture in use
     QSize          m_sgsize {1920, 1080}; // picture size
     QSize          m_size;                // displayed dize
-    LogScale       m_scale;		  // Y-axis
+    LogScale       m_scale;               // Y-axis
     int            m_fftlen {16 * 1024}; // window width
     QVector<float> m_sigL;               // decaying signal window
     QVector<float> m_sigR;
     FFTSample*     m_dftL { nullptr }; // real in, complex out
     FFTSample*     m_dftR { nullptr };
     RDFTContext*   m_rdftContext { nullptr };
-    int            *m_red   {nullptr};
+    int            *m_red   {nullptr}; // continuous color spectrum
     int            *m_green {nullptr};
     int            *m_blue  {nullptr};
-    bool           m_binpeak { false }; // peak of bins, else mean
+    bool           m_binpeak { true }; // peak of bins, else mean
+    bool           m_history { true }; // spectrogram? or spectrum
+};
+class SpectrumDetail : public Spectrogram
+{
+  public:
+    SpectrumDetail() = default;
+    ~SpectrumDetail() override = default;
 };
 
 class Spectrum : public VisualBase

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -180,6 +180,7 @@ class LogScale
 {
   public:
     explicit LogScale(int maxscale = 0, int maxrange = 0);
+    ~LogScale();
 
     int scale() const { return m_s; }
     int range() const { return m_r; }
@@ -190,9 +191,43 @@ class LogScale
 
 
   private:
-    std::vector<int> m_indices;
+    int *m_indices {nullptr};
     int  m_s       {0};
     int  m_r       {0};
+};
+
+// Spectrogram - by twitham@sbcglobal.net, 2023/05
+
+class Spectrogram : public VisualBase
+{
+  public:
+    Spectrogram();
+    ~Spectrogram() override;
+
+    unsigned long getDesiredSamples(void) override;
+    void resize(const QSize &size) override; // VisualBase
+    bool processUndisplayed(VisualNode *node) override;
+    bool process( VisualNode *node ) override;
+    bool draw(QPainter *p, const QColor &back = Qt::black) override;
+    void handleKeyPress(const QString &action) override
+        {(void) action;}
+    static QImage s_image;      // picture of spectrogram
+    static int    s_offset;     // position on screen
+
+  protected:
+    static inline double clamp(double cur, double max, double min);
+    QSize              m_sgsize {1920, 1080}; // picture size
+    QSize              m_size;                // displayed dize
+    LogScale           m_scale;
+    int                m_fftlen {16 * 1024}; // window width
+    QVector<float>     m_sigL;               // signal window
+    QVector<float>     m_sigR;
+    FFTSample*         m_dftL        { nullptr }; // real in, complex out
+    FFTSample*         m_dftR        { nullptr };
+    RDFTContext*       m_rdftContext { nullptr };
+    int                *m_red   {nullptr};
+    int                *m_green {nullptr};
+    int                *m_blue  {nullptr};
 };
 
 class Spectrum : public VisualBase

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -199,6 +199,8 @@ class LogScale
 
 class Spectrogram : public VisualBase
 {
+    static constexpr int kSGAudioSize { 4096 };
+
   public:
     Spectrogram();
     ~Spectrogram() override;

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -219,7 +219,7 @@ class Spectrogram : public VisualBase
     static inline double clamp(double cur, double max, double min);
     QSize          m_sgsize {1920, 1080}; // picture size
     QSize          m_size;                // displayed dize
-    LogScale       m_scale;
+    LogScale       m_scale;		  // Y-axis
     int            m_fftlen {16 * 1024}; // window width
     QVector<float> m_sigL;               // decaying signal window
     QVector<float> m_sigR;


### PR DESCRIPTION
I am pleased to offer a new Spectrogram visualization for Myth Music!

My custom FFT window is optimized for both frequency and time to show all frequencies quickly.  The Mel Scale distributes audible frequencies evenly across the display space in highest resolution.

I experimented with a colored graph but detail is harder to see in color.  Gray scale intensities more clearly show the sound details.  So now the color shows only the current spectrum as it draws the gray graph.  This makes it easy to see the high amplitudes drawing the brightest frequency dots.

**2023/06/13:** added a second visual SpectrumDetail which is simply the color spectrum turned sideways, like Spectrum, with no historical graphing.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

