### PR TITLE
Force Full Screen option for GUI and playback

### DIFF
--- a/mythtv/libs/libmythui/mythdisplay.cpp
+++ b/mythtv/libs/libmythui/mythdisplay.cpp
@@ -647,7 +647,8 @@ void MythDisplay::InitScreenBounds()
         return;
     }
 
-    if (GetMythDB()->GetBoolSetting("RunFrontendInWindow", false))
+    if (!GetMythDB()->GetBoolSetting("ForceFullScreen", false) &&
+        GetMythDB()->GetBoolSetting("RunFrontendInWindow", false))
     {
         LOG(VB_GUI, LOG_INFO, LOC + "Running in a window");
         // This doesn't include the area occupied by the

--- a/mythtv/libs/libmythui/mythuiscreenbounds.cpp
+++ b/mythtv/libs/libmythui/mythuiscreenbounds.cpp
@@ -129,11 +129,13 @@ MythUIScreenBounds::MythUIScreenBounds()
 
 void MythUIScreenBounds::InitScreenBounds()
 {
-    m_wantFullScreen = (gCoreContext->GetNumSetting("GuiOffsetX") == 0 &&
+    m_forceFullScreen = gCoreContext->GetBoolSetting("ForceFullScreen", false);
+    m_wantFullScreen = m_forceFullScreen ||
+                       (gCoreContext->GetNumSetting("GuiOffsetX") == 0 &&
                         gCoreContext->GetNumSetting("GuiWidth")   == 0 &&
                         gCoreContext->GetNumSetting("GuiOffsetY") == 0 &&
                         gCoreContext->GetNumSetting("GuiHeight")  == 0);
-    m_wantWindow   = gCoreContext->GetBoolSetting("RunFrontendInWindow", false);
+    m_wantWindow   = gCoreContext->GetBoolSetting("RunFrontendInWindow", false) && !m_forceFullScreen;
     m_qtFullScreen = WindowIsAlwaysFullscreen();
     m_alwaysOnTop  = gCoreContext->GetBoolSetting("AlwaysOnTop", false);
     m_themeSize    = GetMythUI()->GetBaseSize();
@@ -162,7 +164,7 @@ void MythUIScreenBounds::UpdateScreenSettings(MythDisplay *mDisplay)
     QRect screenbounds = mDisplay->GetScreenBounds();
 
     // As per MythMainWindow::Init, fullscreen is indicated by all zero's in settings
-    if (x == 0 && y == 0 && width == 0 && height == 0)
+    if (m_forceFullScreen || (x == 0 && y == 0 && width == 0 && height == 0))
         m_screenRect = screenbounds;
     else
         m_screenRect = QRect(x, y, width, height);

--- a/mythtv/libs/libmythui/mythuiscreenbounds.h
+++ b/mythtv/libs/libmythui/mythuiscreenbounds.h
@@ -49,6 +49,7 @@ class MUI_PUBLIC MythUIScreenBounds : public QWidget
     bool  m_qtFullScreen     { false };
     bool  m_alwaysOnTop      { false };
     int   m_fontStretch      { 100   };
+    bool  m_forceFullScreen  { false };
 
   private:
     static int s_XOverride;

--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -2277,6 +2277,21 @@ static HostCheckBoxSetting *GuiSizeForTV()
     return gc;
 }
 
+static HostCheckBoxSetting *ForceFullScreen()
+{
+    auto *gc = new HostCheckBoxSetting("ForceFullScreen");
+
+    gc->setLabel(AppearanceSettings::tr("Force Full Screen for GUI and TV playback"));
+
+    gc->setValue(false);
+
+    gc->setHelpText(AppearanceSettings::tr(
+        "Use Full Screen for GUI and TV playback independent of the settings for "
+        "the GUI dimensions. This does not change the values of the GUI dimensions "
+        "so it is easy to switch from window mode to full screen and back."));
+    return gc;
+}
+
 static HostCheckBoxSetting *UseVideoModes()
 {
     HostCheckBoxSetting *gc = new VideoModeSettings("UseVideoModes");
@@ -4684,6 +4699,7 @@ AppearanceSettings::AppearanceSettings()
     PopulateScreens(MythDisplay::GetScreenCount());
     connect(m_display, &MythDisplay::ScreenCountChanged, this, &AppearanceSettings::PopulateScreens);
 
+    screen->addChild(ForceFullScreen());
     screen->addChild(new GuiDimension());
 
     screen->addChild(GuiSizeForTV());


### PR DESCRIPTION
Add a "Force Full Screen" checkbox option in Setup / Appearance/ Theme/Screen settings.

This makes it possible to go from windowed mode to full screen mode and vice versa The current method to go to full screen mode is to make all four numbers that comprise the GUI dimensions (X-offset, Y-offset, X-size and Y-size) zero; to go back to window mode these four numbers have to be entered again. The new "Force Full Screen" setting overrides the existing "GUI dimension" and "Use window border" settings but it does not change these settings. This makes it possible to go from windowed mode to full screen mode and vice versa using only a single checkbox.
