### PR TITLE
Disable the libva GLX backend if EGL is enabled

### DIFF
--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -538,7 +538,7 @@ using_frontend {
         DEFINES += USING_VAAPI
         HEADERS += decoders/mythvaapicontext.h
         SOURCES += decoders/mythvaapicontext.cpp
-        LIBS    += -lva -lva-x11 -lva-glx -lva-drm
+        LIBS    += -lva -lva-drm
     }
 
     using_nvdec {
@@ -605,10 +605,9 @@ using_frontend {
         SOURCES += opengl/mythopengltonemap.cpp
         SOURCES += visualisations/videovisualcircles.cpp
 
-
         using_vaapi {
-            HEADERS += opengl/mythvaapiinterop.h   opengl/mythvaapiglxinterop.h
-            SOURCES += opengl/mythvaapiinterop.cpp opengl/mythvaapiglxinterop.cpp
+            HEADERS += opengl/mythvaapiinterop.h
+            SOURCES += opengl/mythvaapiinterop.cpp
         }
 
         using_vdpau:using_x11 {
@@ -648,6 +647,12 @@ using_frontend {
             using_vaapi {
                 HEADERS += opengl/mythvaapidrminterop.h
                 SOURCES += opengl/mythvaapidrminterop.cpp
+            }
+        } else {
+            using_vaapi {
+                HEADERS += opengl/mythvaapiglxinterop.h
+                SOURCES += opengl/mythvaapiglxinterop.cpp
+                LIBS    += -lva-x11 -lva-glx
             }
         }
 

--- a/mythtv/libs/libmythtv/opengl/mythvaapiinterop.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythvaapiinterop.cpp
@@ -8,8 +8,12 @@
 #include "mythvideocolourspace.h"
 #include "fourcc.h"
 #include "mythvaapiinterop.h"
+
+#ifdef USING_EGL
 #include "mythvaapidrminterop.h"
+#else
 #include "mythvaapiglxinterop.h"
+#endif
 
 extern "C" {
 #include "libavfilter/buffersrc.h"
@@ -57,14 +61,14 @@ void MythVAAPIInterop::GetVAAPITypes(MythRenderOpenGL* Context, MythInteropGPU::
     // zero copy
     if (egl && MythVAAPIInteropDRM::IsSupported(Context))
         vaapitypes.emplace_back(GL_VAAPIEGLDRM);
-#endif
+#else
     // 1x copy
     if (!egl && !wayland && MythVAAPIInteropGLXPixmap::IsSupported(Context))
         vaapitypes.emplace_back(GL_VAAPIGLXPIX);
     // 2x copy
     if (!egl && !opengles && !wayland)
         vaapitypes.emplace_back(GL_VAAPIGLXCOPY);
-
+#endif
     if (!vaapitypes.empty())
         Types[FMT_VAAPI] = vaapitypes;
 }
@@ -82,11 +86,12 @@ MythVAAPIInterop* MythVAAPIInterop::CreateVAAPI(MythPlayerUI *Player, MythRender
 #ifdef USING_EGL
             if ((type == GL_VAAPIEGLDRM) || (type == DRM_DRMPRIME))
                 return new MythVAAPIInteropDRM(Player, Context, type);
-#endif
+#else
             if (type == GL_VAAPIGLXPIX)
                 return new MythVAAPIInteropGLXPixmap(Player, Context);
             if (type == GL_VAAPIGLXCOPY)
                 return new MythVAAPIInteropGLXCopy(Player, Context);
+#endif
         }
     }
     return nullptr;

--- a/mythtv/libs/libmythtv/opengl/mythvaapiinterop.h
+++ b/mythtv/libs/libmythtv/opengl/mythvaapiinterop.h
@@ -25,9 +25,12 @@ struct AVFilterContext;
 #undef None            // X11/X.h defines this. Causes compile failure in Qt6.
 #undef Cursor
 #undef pointer
-#include "va/va_glx.h"
+#ifdef USING_EGL
 #include "va/va_drm.h"
 #include "va/va_drmcommon.h"
+#else
+#include "va/va_glx.h"
+#endif
 #undef Bool            // Interferes with cmake moc file compilation
 
 #ifndef VA_FOURCC_I420


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

I've left the last two items unchecked on purpose as I think this might not be the solution that will be accepted. But we will see how you guys feel.

Currently mythtv always seem to pull in the `drm` and `glx` backend for libva.
On Gentoo we have removed the glx backend for libva to simplify some packaging.
This shouldn't regress the user experience as it seems all packages using libva in Gentoo (including mythtv) also supports the EGL backend and usually prefers to use the EGL backend as well.

However there is currently no way to compile mythtv without also requiring the libva glx backend, even if it will never be used. So to fix this I created the "lazy" solution of making the GLX backend only available if EGL support is not turned on.

I'm unsure if this is an acceptable solution or not. But at least it should provide a good basis for starting a discussion.

One could instead for example add a `USING_GLX` flag to allow both backends to be available as before.
However most other projects that depend on libva in the Gentoo package manager seem to have opted to drop the GLX backend and always use the drm backend. (However this of course means that you won't be able to use it on older linux dists where EGL is not available)