### PR TITLE
MythMusic: "Play Now" any tracks from the music browsers

### DIFF
--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -1350,9 +1350,9 @@ void MusicCommon::customEvent(QEvent *event)
             if (resulttext == tr("Fullscreen Visualizer"))
                 switchView(MV_VISUALIZER);
             else if (resulttext == tr("Playlist Editor") ||
-                     resulttext == tr("Play Now..."))
+                     resulttext == tr("Play Now"))
             {
-                gPlayer->inPlayNow(resulttext == tr("Play Now..."));
+                gPlayer->inPlayNow(resulttext == tr("Play Now"));
                 if (gCoreContext->GetSetting("MusicPlaylistEditorView", "tree") ==  "tree")
                     switchView(MV_PLAYLISTEDITORTREE);
                 else
@@ -2196,7 +2196,7 @@ MythMenu* MusicCommon::createMainMenu(void)
     }
     else if (m_currentView == MV_PLAYLIST)
     {
-        menu->AddItem(MusicCommon::tr("Play Now..."));
+        menu->AddItem(MusicCommon::tr("Play Now"));
         menu->AddItem(MusicCommon::tr("Playlist Editor"));
     }
 

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -2406,8 +2406,16 @@ MythMenu* MusicCommon::createPlaylistOptionsMenu(void)
 
     auto *menu = new MythMenu(label, this, "playlistoptionsmenu");
 
-    menu->AddItem(tr("Play Now"));
-    menu->AddItem(tr("Add Tracks"));
+    if (gPlayer->getInPlayNow())
+    {
+	menu->AddItem(tr("Play Now"));
+	menu->AddItem(tr("Add Tracks"));
+    }
+    else
+    {
+	menu->AddItem(tr("Add Tracks"));
+	menu->AddItem(tr("Play Now"));
+    }
     menu->AddItem(tr("Replace Tracks"));
 
     return menu;

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -478,10 +478,7 @@ void MusicCommon::switchView(MusicView view)
                 delete pleview;
 
             if (oldView)
-            {
-                disconnect(this, &MythScreenType::Exiting, nullptr, nullptr);
                 Close();
-            }
 
             break;
         }
@@ -508,10 +505,7 @@ void MusicCommon::switchView(MusicView view)
                 delete pleview;
 
             if (oldView)
-            {
-                disconnect(this, &MythScreenType::Exiting, nullptr, nullptr);
                 Close();
-            }
 
             break;
         }

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -1530,8 +1530,9 @@ void MusicCommon::customEvent(QEvent *event)
             else if (resulttext == tr("Play Now"))
             {               // cancel shuffles and repeats to play now
                 gPlayer->setShuffleMode(MusicPlayer::SHUFFLE_OFF);
+                updateShuffleMode();
                 gPlayer->setRepeatMode(MusicPlayer::REPEAT_OFF);
-                updateShuffleMode(true);
+                updateRepeatMode();
                 m_playlistOptions.insertPLOption = PL_INSERTATEND;
                 m_playlistOptions.playPLOption = PL_FIRSTNEW;
                 doUpdatePlaylist();
@@ -2540,11 +2541,8 @@ void MusicCommon::showPlaylistOptionsMenu(bool addMainMenu)
 void MusicCommon::doUpdatePlaylist(void)
 {
     int curTrackID = -1;
-    int trackCount = 0;
+    int added = 0;
     int curPos = gPlayer->getCurrentTrackPos();
-
-    if (gPlayer->getCurrentPlaylist())
-        trackCount = gPlayer->getCurrentPlaylist()->getTrackCount();
 
     // store id of current track
     if (gPlayer->getCurrentMetadata())
@@ -2553,16 +2551,16 @@ void MusicCommon::doUpdatePlaylist(void)
     if (!m_whereClause.isEmpty())
     {
         // update playlist from quick playlist
-        gMusicData->m_all_playlists->getActive()->fillSonglistFromQuery(
-            m_whereClause, false, // play now must be able to repeat songs
+        added = gMusicData->m_all_playlists->getActive()->fillSonglistFromQuery(
+            m_whereClause, true,
             m_playlistOptions.insertPLOption, curTrackID);
         m_whereClause.clear();
     }
     else if (!m_songList.isEmpty())
     {
         // update playlist from song list (from the playlist editor)
-        gMusicData->m_all_playlists->getActive()->fillSonglistFromList(
-            m_songList, false, // play now must be able to repeat songs
+        added = gMusicData->m_all_playlists->getActive()->fillSonglistFromList(
+            m_songList, true,
             m_playlistOptions.insertPLOption, curTrackID);
 
         m_songList.clear();
@@ -2601,7 +2599,7 @@ void MusicCommon::doUpdatePlaylist(void)
                     case PL_INSERTATEND:
                     {
                         pause();
-                        if (!gPlayer->setCurrentTrackPos(trackCount))
+                        if (!gPlayer->setCurrentTrackPos(gPlayer->getCurrentPlaylist()->getTrackCount() - added))
                             playFirstTrack();
                         break;
                     }

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -1366,12 +1366,6 @@ void MusicCommon::customEvent(QEvent *event)
                 switchView(MV_PLAYLISTEDITORTREE);
             else if (resulttext == tr("Lyrics"))
                 switchView(MV_LYRICS);
-            else if (resulttext == tr("Play Now"))
-            {
-                m_playlistOptions.insertPLOption = PL_INSERTATEND;
-                m_playlistOptions.playPLOption = PL_FIRSTNEW;
-                doUpdatePlaylist();
-            }
         }
         else if (resultid == "submenu")
         {
@@ -1534,7 +1528,10 @@ void MusicCommon::customEvent(QEvent *event)
                 doUpdatePlaylist();
             }
             else if (resulttext == tr("Play Now"))
-            {
+            {               // cancel shuffles and repeats to play now
+                gPlayer->setShuffleMode(MusicPlayer::SHUFFLE_OFF);
+                gPlayer->setRepeatMode(MusicPlayer::REPEAT_OFF);
+                updateShuffleMode(true);
                 m_playlistOptions.insertPLOption = PL_INSERTATEND;
                 m_playlistOptions.playPLOption = PL_FIRSTNEW;
                 doUpdatePlaylist();
@@ -2408,13 +2405,13 @@ MythMenu* MusicCommon::createPlaylistOptionsMenu(void)
 
     if (gPlayer->getInPlayNow())
     {
-	menu->AddItem(tr("Play Now"));
-	menu->AddItem(tr("Add Tracks"));
+        menu->AddItem(tr("Play Now"));
+        menu->AddItem(tr("Add Tracks"));
     }
     else
     {
-	menu->AddItem(tr("Add Tracks"));
-	menu->AddItem(tr("Play Now"));
+        menu->AddItem(tr("Add Tracks"));
+        menu->AddItem(tr("Play Now"));
     }
     menu->AddItem(tr("Replace Tracks"));
 

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -2194,9 +2194,9 @@ MythMenu* MusicCommon::createMainMenu(void)
     }
     else if (m_currentView == MV_PLAYLIST)
     {
-        menu->AddItem(tr("Playlist Editor"));
+        // menu->AddItem(tr("Playlist Editor")); // v33-
         // this might be easier for new users to find / understand:
-        // menu->AddItem(tr("Browse Music Library"));
+        menu->AddItem(tr("Browse Music Library")); // v34+
     }
 
     QStringList screenList;

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -1350,9 +1350,8 @@ void MusicCommon::customEvent(QEvent *event)
             if (resulttext == tr("Fullscreen Visualizer"))
                 switchView(MV_VISUALIZER);
             else if (resulttext == tr("Playlist Editor") ||
-                     resulttext == tr("Play Now"))
+                     resulttext == tr("Browse Music Library"))
             {
-                gPlayer->inPlayNow(resulttext == tr("Play Now"));
                 if (gCoreContext->GetSetting("MusicPlaylistEditorView", "tree") ==  "tree")
                     switchView(MV_PLAYLISTEDITORTREE);
                 else
@@ -1528,7 +1527,7 @@ void MusicCommon::customEvent(QEvent *event)
                 doUpdatePlaylist();
             }
             else if (resulttext == tr("Play Now"))
-            {               // cancel shuffles and repeats to play now
+            {     // cancel shuffles and repeats to play only this now
                 gPlayer->setShuffleMode(MusicPlayer::SHUFFLE_OFF);
                 updateShuffleMode();
                 gPlayer->setRepeatMode(MusicPlayer::REPEAT_OFF);
@@ -1537,6 +1536,10 @@ void MusicCommon::customEvent(QEvent *event)
                 m_playlistOptions.playPLOption = PL_FIRSTNEW;
                 doUpdatePlaylist();
             }
+            else if (resulttext == tr("Prefer Play Now"))
+		gPlayer->setPlayNow(true);
+            else if (resulttext == tr("Prefer Add Tracks"))
+                gPlayer->setPlayNow(false);
         }
         else if (resultid == "visualizermenu")
         {
@@ -2197,8 +2200,9 @@ MythMenu* MusicCommon::createMainMenu(void)
     }
     else if (m_currentView == MV_PLAYLIST)
     {
-        menu->AddItem(MusicCommon::tr("Play Now"));
-        menu->AddItem(MusicCommon::tr("Playlist Editor"));
+        menu->AddItem(tr("Playlist Editor"));
+	// this might be easier for new users to understand:
+        // menu->AddItem(tr("Browse Music Library"));
     }
 
     QStringList screenList;
@@ -2404,17 +2408,20 @@ MythMenu* MusicCommon::createPlaylistOptionsMenu(void)
 
     auto *menu = new MythMenu(label, this, "playlistoptionsmenu");
 
-    if (gPlayer->getInPlayNow())
+    if (gPlayer->getPlayNow())
     {
         menu->AddItem(tr("Play Now"));
         menu->AddItem(tr("Add Tracks"));
+        menu->AddItem(tr("Replace Tracks"));
+        menu->AddItem(tr("Prefer Add Tracks"));
     }
     else
     {
         menu->AddItem(tr("Add Tracks"));
         menu->AddItem(tr("Play Now"));
+        menu->AddItem(tr("Replace Tracks"));
+        menu->AddItem(tr("Prefer Play Now"));
     }
-    menu->AddItem(tr("Replace Tracks"));
 
     return menu;
 }

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -1537,7 +1537,7 @@ void MusicCommon::customEvent(QEvent *event)
                 doUpdatePlaylist();
             }
             else if (resulttext == tr("Prefer Play Now"))
-		gPlayer->setPlayNow(true);
+                gPlayer->setPlayNow(true);
             else if (resulttext == tr("Prefer Add Tracks"))
                 gPlayer->setPlayNow(false);
         }
@@ -2201,7 +2201,7 @@ MythMenu* MusicCommon::createMainMenu(void)
     else if (m_currentView == MV_PLAYLIST)
     {
         menu->AddItem(tr("Playlist Editor"));
-	// this might be easier for new users to understand:
+        // this might be easier for new users to find / understand:
         // menu->AddItem(tr("Browse Music Library"));
     }
 

--- a/mythplugins/mythmusic/mythmusic/musicplayer.cpp
+++ b/mythplugins/mythmusic/mythmusic/musicplayer.cpp
@@ -219,6 +219,16 @@ void MusicPlayer::loadSettings(void)
 
     m_lastplayDelay = gCoreContext->GetDurSetting<std::chrono::seconds>("MusicLastPlayDelay", LASTPLAY_DELAY);
     m_autoShowPlayer = (gCoreContext->GetNumSetting("MusicAutoShowPlayer", 1) > 0);
+
+}
+
+void MusicPlayer::setPlayNow(bool PlayNow)
+{
+    gCoreContext->SaveBoolSetting("MusicPreferPlayNow", PlayNow);
+}
+bool MusicPlayer::getPlayNow(void)
+{
+    return gCoreContext->GetBoolSetting("MusicPreferPlayNow", false);
 }
 
 // this stops playing the playlist and plays the file pointed to by mdata

--- a/mythplugins/mythmusic/mythmusic/musicplayer.h
+++ b/mythplugins/mythmusic/mythmusic/musicplayer.h
@@ -119,9 +119,9 @@ class MusicPlayer : public QObject, public MythObservable
     void canShowPlayer(bool canShow) { m_canShowPlayer = canShow; }
     bool getCanShowPlayer(void) const { return m_canShowPlayer; }
 
-    /// whether we entered the Play Now browser
-    void inPlayNow(bool inPlayNow) { m_inPlayNow = inPlayNow; }
-    bool getInPlayNow(void) const { return m_inPlayNow; }
+    /// whether we prefer Play Now over Add Tracks
+    void setPlayNow(bool PlayNow);
+    bool getPlayNow(void);
 
     Decoder        *getDecoder(void) { return m_decoderHandler ? m_decoderHandler->getDecoder() : nullptr; }
     DecoderHandler *getDecoderHandler(void) { return m_decoderHandler; }
@@ -234,7 +234,6 @@ class MusicPlayer : public QObject, public MythObservable
     bool         m_isPlaying          {false};
     bool         m_isAutoplay         {false};
     bool         m_canShowPlayer      {true};
-    bool         m_inPlayNow          {false};
     bool         m_autoShowPlayer     {true};
     bool         m_wasPlaying         {false};
     bool         m_updatedLastplay    {false};

--- a/mythplugins/mythmusic/mythmusic/musicplayer.h
+++ b/mythplugins/mythmusic/mythmusic/musicplayer.h
@@ -119,6 +119,10 @@ class MusicPlayer : public QObject, public MythObservable
     void canShowPlayer(bool canShow) { m_canShowPlayer = canShow; }
     bool getCanShowPlayer(void) const { return m_canShowPlayer; }
 
+    /// whether we entered the Play Now browser
+    void inPlayNow(bool inPlayNow) { m_inPlayNow = inPlayNow; }
+    bool getInPlayNow(void) const { return m_inPlayNow; }
+
     Decoder        *getDecoder(void) { return m_decoderHandler ? m_decoderHandler->getDecoder() : nullptr; }
     DecoderHandler *getDecoderHandler(void) { return m_decoderHandler; }
     AudioOutput    *getOutput(void) { return m_output; }
@@ -230,6 +234,7 @@ class MusicPlayer : public QObject, public MythObservable
     bool         m_isPlaying          {false};
     bool         m_isAutoplay         {false};
     bool         m_canShowPlayer      {true};
+    bool         m_inPlayNow          {false};
     bool         m_autoShowPlayer     {true};
     bool         m_wasPlaying         {false};
     bool         m_updatedLastplay    {false};

--- a/mythplugins/mythmusic/mythmusic/playlist.h
+++ b/mythplugins/mythmusic/mythmusic/playlist.h
@@ -62,18 +62,18 @@ class Playlist : public QObject
     void describeYourself(void) const; //  debugging
 
     void fillSongsFromSonglist(const QString& songList);
-    void fillSonglistFromQuery(const QString& whereClause, 
-                               bool removeDuplicates = false,
-                               InsertPLOption insertOption = PL_REPLACE,
-                               int currentTrackID = 0);
-    void fillSonglistFromSmartPlaylist(const QString& category, const QString& name,
-                                       bool removeDuplicates = false,
-                                       InsertPLOption insertOption = PL_REPLACE,
-                                       int currentTrackID = 0);
-    void fillSonglistFromList(const QList<int> &songList,
-                              bool removeDuplicates,
-                              InsertPLOption insertOption,
-                              int currentTrackID);
+    int fillSonglistFromQuery(const QString& whereClause,
+                              bool removeDuplicates = false,
+                              InsertPLOption insertOption = PL_REPLACE,
+                              int currentTrackID = 0);
+    int fillSonglistFromSmartPlaylist(const QString& category, const QString& name,
+                                      bool removeDuplicates = false,
+                                      InsertPLOption insertOption = PL_REPLACE,
+                                      int currentTrackID = 0);
+    int fillSonglistFromList(const QList<int> &songList,
+                             bool removeDuplicates,
+                             InsertPLOption insertOption,
+                             int currentTrackID);
     QString toRawSonglist(bool shuffled = false, bool tracksOnly = false);
 
 

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -159,6 +159,11 @@ bool PlaylistEditorView::Create(void)
         QStringList route = gCoreContext->GetSetting("MusicTreeLastActive", "").split("\n");
         restoreTreePosition(route);
     }
+    else	 // default to Albums, rather than All Tracks, 2023/07
+    {
+        QStringList route = (QString("Root Music Node.Albums").split("."));
+        restoreTreePosition(route);
+    }
 
     connect(m_playlistTree, &MythUIButtonTree::itemClicked,
             this, &PlaylistEditorView::treeItemClicked);

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -817,18 +817,18 @@ void PlaylistEditorView::treeItemClicked(MythUIButtonListItem *item)
 
     if (mnode->getAction() == "trackid")
     {
-        if (gPlayer->getInPlayNow())
+        if (gPlayer->getCurrentPlaylist()->checkTrack(mnode->getInt()))
+        {
+            // remove track from the current playlist
+            gPlayer->removeTrack(mnode->getInt());
+            mnode->setCheck(MythUIButtonListItem::NotChecked);
+        }
+        else if (gPlayer->getInPlayNow())
         {
             gPlayer->addTrack(mnode->getInt(), false);
             gPlayer->setCurrentTrackPos(gPlayer->getCurrentPlaylist()->getTrackCount() - 1);
             updateUIPlaylist();
             mnode->setCheck(MythUIButtonListItem::FullChecked);
-        }
-        else if (gPlayer->getCurrentPlaylist()->checkTrack(mnode->getInt()))
-        {
-            // remove track from the current playlist
-            gPlayer->removeTrack(mnode->getInt());
-            mnode->setCheck(MythUIButtonListItem::NotChecked);
         }
         else
         {

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -159,7 +159,7 @@ bool PlaylistEditorView::Create(void)
         QStringList route = gCoreContext->GetSetting("MusicTreeLastActive", "").split("\n");
         restoreTreePosition(route);
     }
-    else	 // default to Albums, rather than All Tracks, 2023/07
+    else         // default to Albums, rather than All Tracks, 2023/07
     {
         QStringList route = (QString("Root Music Node.Albums").split("."));
         restoreTreePosition(route);
@@ -302,14 +302,21 @@ void PlaylistEditorView::customEvent(QEvent *event)
             }
             else if (resulttext == tr("Replace Tracks"))
             {
-                m_playlistOptions.playPLOption = PL_CURRENT;
                 m_playlistOptions.insertPLOption = PL_REPLACE;
                 doUpdatePlaylist();
             }
             else if (resulttext == tr("Add Tracks"))
             {
-                m_playlistOptions.playPLOption = PL_CURRENT;
                 m_playlistOptions.insertPLOption = PL_INSERTATEND;
+                doUpdatePlaylist();
+            }
+            else if (resulttext == tr("Play Now"))
+            {               // cancel shuffles and repeats to play now
+                gPlayer->setShuffleMode(MusicPlayer::SHUFFLE_OFF);
+                gPlayer->setRepeatMode(MusicPlayer::REPEAT_OFF);
+                updateShuffleMode(true);
+                m_playlistOptions.insertPLOption = PL_INSERTATEND;
+                m_playlistOptions.playPLOption = PL_FIRSTNEW;
                 doUpdatePlaylist();
             }
         }
@@ -336,13 +343,21 @@ void PlaylistEditorView::customEvent(QEvent *event)
             }
             else if (resulttext == tr("Replace Tracks"))
             {
-                m_playlistOptions.playPLOption = PL_CURRENT;
                 m_playlistOptions.insertPLOption = PL_REPLACE;
                 doUpdatePlaylist();
             }
             else if (resulttext == tr("Add Tracks"))
             {
                 m_playlistOptions.insertPLOption = PL_INSERTATEND;
+                doUpdatePlaylist();
+            }
+            else if (resulttext == tr("Play Now"))
+            {               // cancel shuffles and repeats to play now
+                gPlayer->setShuffleMode(MusicPlayer::SHUFFLE_OFF);
+                gPlayer->setRepeatMode(MusicPlayer::REPEAT_OFF);
+                updateShuffleMode(true);
+                m_playlistOptions.insertPLOption = PL_INSERTATEND;
+                m_playlistOptions.playPLOption = PL_FIRSTNEW;
                 doUpdatePlaylist();
             }
         }
@@ -692,8 +707,17 @@ MythMenu* PlaylistEditorView::createPlaylistMenu(void)
         if (mnode->getAction() == "playlist")
         {
             menu = new MythMenu(tr("Playlist Actions"), this, "treeplaylistmenu");
+            if (gPlayer->getInPlayNow())
+            {
+                menu->AddItem(tr("Play Now"));
+                menu->AddItem(tr("Add Tracks"));
+            }
+            else
+            {
+                menu->AddItem(tr("Add Tracks"));
+                menu->AddItem(tr("Play Now"));
+            }
             menu->AddItem(tr("Replace Tracks"));
-            menu->AddItem(tr("Add Tracks"));
             menu->AddItem(tr("Remove Playlist"));
         }
     }
@@ -724,8 +748,17 @@ MythMenu* PlaylistEditorView::createSmartPlaylistMenu(void)
         {
             menu = new MythMenu(tr("Smart Playlist Actions"), this, "smartplaylistmenu");
 
+            if (gPlayer->getInPlayNow())
+            {
+                menu->AddItem(tr("Play Now"));
+                menu->AddItem(tr("Add Tracks"));
+            }
+            else
+            {
+                menu->AddItem(tr("Add Tracks"));
+                menu->AddItem(tr("Play Now"));
+            }
             menu->AddItem(tr("Replace Tracks"));
-            menu->AddItem(tr("Add Tracks"));
 
             menu->AddItem(tr("Edit Smart Playlist"));
             menu->AddItem(tr("New Smart Playlist"));

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -154,7 +154,7 @@ bool PlaylistEditorView::Create(void)
 
     m_playlistTree->AssignTree(m_rootNode);
 
-    if (m_restorePosition)
+    if (true) // v34 - continue where we left off (was m_restorePosition)
     {
         QStringList route = gCoreContext->GetSetting("MusicTreeLastActive", "").split("\n");
         restoreTreePosition(route);

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -812,7 +812,14 @@ void PlaylistEditorView::treeItemClicked(MythUIButtonListItem *item)
 
     if (mnode->getAction() == "trackid")
     {
-        if (gPlayer->getCurrentPlaylist()->checkTrack(mnode->getInt()))
+        if (gPlayer->getInPlayNow())
+        {
+            gPlayer->addTrack(mnode->getInt(), false);
+            gPlayer->setCurrentTrackPos(gPlayer->getCurrentPlaylist()->getTrackCount() - 1);
+            updateUIPlaylist();
+            mnode->setCheck(MythUIButtonListItem::FullChecked);
+        }
+        else if (gPlayer->getCurrentPlaylist()->checkTrack(mnode->getInt()))
         {
             // remove track from the current playlist
             gPlayer->removeTrack(mnode->getInt());

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -661,7 +661,7 @@ void PlaylistEditorView::ShowMenu(void)
             {
                 menu = createPlaylistMenu();
             }
-            else if ((mnode->getAction() == "trackid") ||
+            else if ( // (mnode->getAction() == "trackid") ||
                      (mnode->getAction() == "error"))
             {
             }
@@ -707,7 +707,7 @@ MythMenu* PlaylistEditorView::createPlaylistMenu(void)
         if (mnode->getAction() == "playlist")
         {
             menu = new MythMenu(tr("Playlist Actions"), this, "treeplaylistmenu");
-            if (gPlayer->getInPlayNow())
+            if (gPlayer->getPlayNow())
             {
                 menu->AddItem(tr("Play Now"));
                 menu->AddItem(tr("Add Tracks"));
@@ -748,7 +748,7 @@ MythMenu* PlaylistEditorView::createSmartPlaylistMenu(void)
         {
             menu = new MythMenu(tr("Smart Playlist Actions"), this, "smartplaylistmenu");
 
-            if (gPlayer->getInPlayNow())
+            if (gPlayer->getPlayNow())
             {
                 menu->AddItem(tr("Play Now"));
                 menu->AddItem(tr("Add Tracks"));
@@ -856,7 +856,7 @@ void PlaylistEditorView::treeItemClicked(MythUIButtonListItem *item)
             gPlayer->removeTrack(mnode->getInt());
             mnode->setCheck(MythUIButtonListItem::NotChecked);
         }
-        else if (gPlayer->getInPlayNow())
+        else if (gPlayer->getPlayNow())
         {
             gPlayer->addTrack(mnode->getInt(), false);
             gPlayer->setCurrentTrackPos(gPlayer->getCurrentPlaylist()->getTrackCount() - 1);

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -154,12 +154,13 @@ bool PlaylistEditorView::Create(void)
 
     m_playlistTree->AssignTree(m_rootNode);
 
-    if (true) // v34 - continue where we left off (was m_restorePosition)
+    // if (m_restorePosition) // v33- only when switching gallery/tree
+    if (true)              // v34+ always enter where we exited
     {
         QStringList route = gCoreContext->GetSetting("MusicTreeLastActive", "").split("\n");
         restoreTreePosition(route);
     }
-    else         // default to Albums, rather than All Tracks, 2023/07
+    else               // not used, could enter at any point like this
     {
         QStringList route = (QString("Root Music Node.Albums").split("."));
         restoreTreePosition(route);

--- a/mythplugins/mythmusic/mythmusic/searchview.cpp
+++ b/mythplugins/mythmusic/mythmusic/searchview.cpp
@@ -178,7 +178,7 @@ void SearchView::customEvent(QEvent *event)
                     }
                 }
             }
-            else if (resulttext == tr("Add To Playlist And Play"))
+            else if (resulttext == tr("Play Now"))
             {
                 if (GetFocusWidget() == m_tracksList)
                 {
@@ -273,8 +273,8 @@ void SearchView::ShowMenu(void)
                     menu->AddItem(tr("Remove From Playlist"));
                 else
                 {
+                    menu->AddItem(tr("Play Now"));
                     menu->AddItem(tr("Add To Playlist"));
-                    menu->AddItem(tr("Add To Playlist And Play"));
                 }
             }
         }

--- a/mythplugins/mythmusic/mythmusic/searchview.cpp
+++ b/mythplugins/mythmusic/mythmusic/searchview.cpp
@@ -109,10 +109,8 @@ void SearchView::customEvent(QEvent *event)
         MusicCommon::customEvent(event);
         handled = true;
 
-        if (m_playTrack)
+        if (m_playTrack == 1 || (m_playTrack == -1 && gPlayer->getPlayNow()))
         {
-            m_playTrack = false;
-
             if (event->type() == MusicPlayerEvent::kTrackAddedEvent)
             {
                 // make the added track current and play it
@@ -120,6 +118,7 @@ void SearchView::customEvent(QEvent *event)
                 playlistItemClicked(m_currentPlaylist->GetItemCurrent());
             }
         }
+        m_playTrack = -1;     // use PlayNow preference or menu option
     }
     else if (event->type() == MusicPlayerEvent::kAllTracksRemovedEvent)
     {
@@ -173,7 +172,7 @@ void SearchView::customEvent(QEvent *event)
                     MythUIButtonListItem *item = m_tracksList->GetItemCurrent();
                     if (item)
                     {
-                        m_playTrack = false;
+                        m_playTrack = 0;
                         trackClicked(item);
                     }
                 }
@@ -185,11 +184,15 @@ void SearchView::customEvent(QEvent *event)
                     MythUIButtonListItem *item = m_tracksList->GetItemCurrent();
                     if (item)
                     {
-                        m_playTrack = true;
+                        m_playTrack = 1;
                         trackClicked(item);
                     }
                 }
             }
+            else if (resulttext == tr("Prefer Play Now"))
+                gPlayer->setPlayNow(true);
+            else if (resulttext == tr("Prefer Add Tracks"))
+                gPlayer->setPlayNow(false);
             else if (resulttext == tr("Search List..."))
                 searchButtonList();
         }
@@ -238,7 +241,7 @@ bool SearchView::keyPressEvent(QKeyEvent *event)
                 MythUIButtonListItem *item = m_tracksList->GetItemCurrent();
                 if (item)
                 {
-                    m_playTrack = true;
+                    m_playTrack = 1;
                     trackClicked(item);
                 }
             }
@@ -273,8 +276,18 @@ void SearchView::ShowMenu(void)
                     menu->AddItem(tr("Remove From Playlist"));
                 else
                 {
-                    menu->AddItem(tr("Play Now"));
-                    menu->AddItem(tr("Add To Playlist"));
+                    if (gPlayer->getPlayNow())
+                    {
+                        menu->AddItem(tr("Play Now"));
+                        menu->AddItem(tr("Add To Playlist"));
+                        menu->AddItem(tr("Prefer Add To Playlist"));
+                    }
+                    else
+                    {
+                        menu->AddItem(tr("Add To Playlist"));
+                        menu->AddItem(tr("Play Now"));
+                        menu->AddItem(tr("Prefer Play Now"));
+                    }
                 }
             }
         }

--- a/mythplugins/mythmusic/mythmusic/searchview.h
+++ b/mythplugins/mythmusic/mythmusic/searchview.h
@@ -39,7 +39,7 @@ class SearchView : public MusicCommon
     static void trackVisible(MythUIButtonListItem *item);
 
   private:
-    bool                 m_playTrack    {false};
+    int                  m_playTrack    {-1};
     MythUIButtonList    *m_fieldList    {nullptr};
     MythUITextEdit      *m_criteriaEdit {nullptr};
     MythUIText          *m_matchesText  {nullptr};

--- a/mythplugins/mythmusic/theme/default-wide/music-base.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-base.xml
@@ -929,7 +929,7 @@
             <area>40,25,1200,190</area>
             <multiline>yes</multiline>
             <align>allcenter</align>
-            <value>You haven't selected any tracks to play</value>
+            <value>Press M (Menu) to add and play tracks</value>
         </textarea>
 
         <buttonlist name="currentplaylist" from="basebuttonlist2">

--- a/mythplugins/mythmusic/theme/default-wide/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-ui.xml
@@ -117,7 +117,7 @@
             <area>35,20,1210,340</area>
             <multiline>yes</multiline>
             <align>allcenter</align>
-            <value>You haven't selected any tracks to play</value>
+            <value>Press M (Menu) to add and play tracks</value>
         </textarea>
 
         <buttonlist name="currentplaylist" from="basecurrentplaylist">

--- a/mythplugins/mythmusic/theme/default/music-base.xml
+++ b/mythplugins/mythmusic/theme/default/music-base.xml
@@ -666,7 +666,7 @@
             <area>35,25,730,190</area>
             <multiline>yes</multiline>
             <align>allcenter</align>
-            <value>You haven't selected any tracks to play</value>
+            <value>Press M (Menu) to add and play tracks</value>
         </textarea>
 
         <buttonlist name="currentplaylist" from="basecurrentplaylist">

--- a/mythplugins/mythmusic/theme/default/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default/music-ui.xml
@@ -14,7 +14,7 @@
             <area>15,15,770,210</area>
             <multiline>yes</multiline>
             <align>allcenter</align>
-            <value>You haven't selected any tracks to play</value>
+            <value>Press M (Menu) to add and play tracks</value>
         </textarea>
 
         <buttonlist name="currentplaylist" from="basecurrentplaylist">

--- a/mythtv/themes/MythCenter-wide/music-base.xml
+++ b/mythtv/themes/MythCenter-wide/music-base.xml
@@ -849,7 +849,7 @@
             <area>40,25,1200,190</area>
             <multiline>yes</multiline>
             <align>allcenter</align>
-            <value>You haven't selected any tracks to play</value>
+            <value>Press M (Menu) to add and play tracks</value>
         </textarea>
 
         <buttonlist name="currentplaylist" from="basebuttonlist2">

--- a/mythtv/themes/MythCenter-wide/music-ui.xml
+++ b/mythtv/themes/MythCenter-wide/music-ui.xml
@@ -117,7 +117,7 @@
             <area>35,20,1210,340</area>
             <multiline>yes</multiline>
             <align>allcenter</align>
-            <value>You haven't selected any tracks to play</value>
+            <value>Press M (Menu) to add and play tracks</value>
         </textarea>
 
         <buttonlist name="currentplaylist" from="basecurrentplaylist">


### PR DESCRIPTION
ref: https://forum.mythtv.org/viewtopic.php?p=25164#p25164

Spontaneous listeners want to just play an album or song now and care less about any playlist.  This adds a simple "Play Now" to the menus which is identical to "Add Tracks" except that it immediately starts playing the additions.  When "Play Now" is preferred (a new toggle), selecting a single track adds it and plays it now, rather than just adding it.

This required moving previously added tracks to the end so that adding an album gets all tracks even if you played some of them earlier.

Possible documentation is now at the top of https://www.mythtv.org/wiki/Talk:MythMusic to be cut-n-pasted to the manual when this gets to production.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

