### PR TITLE
Python: Remove deprecated `distutils` package.

### DIFF
--- a/mythplugins/configure
+++ b/mythplugins/configure
@@ -471,13 +471,23 @@ check_py_lib(){
     log check_py_lib "$@"
     lib=${1}
     check_cmd $python <<EOF
-from distutils.sysconfig import get_python_lib
 import sys
-for mythroot in '${mythroot}'.split(':'):
-    sys.path.append(get_python_lib(prefix=mythroot +'${prefix}'))
-    sys.path.append(get_python_lib(prefix=mythroot +'${prefix}/local'))
-sys.path.append(get_python_lib(prefix='${sysroot}${prefix}'))
-sys.path.append(get_python_lib(prefix='${sysroot}${prefix}/local'))
+try:
+    from distutils.sysconfig import get_python_lib
+    for mythroot in '${mythroot}'.split(':'):
+        sys.path.append(get_python_lib(prefix=mythroot +'${prefix}'))
+        sys.path.append(get_python_lib(prefix=mythroot +'${prefix}/local'))
+    sys.path.append(get_python_lib(prefix='${sysroot}${prefix}'))
+    sys.path.append(get_python_lib(prefix='${sysroot}${prefix}/local'))
+except:
+    # python 3.12+
+    from sysconfig import get_path
+    for mroot in '${mythroot}'.split(':'):
+        sys.path.append(mroot + get_path('purelib'))
+    vars = {'base': '${sysroot}${prefix}', 'prefix': '${prefix}'}
+    sys.path.append(get_path('purelib', vars=vars, expand=True))
+    vars = {'base': '${sysroot}${prefix}', 'prefix': '${prefix}/local'}
+    sys.path.append(get_path('purelib', vars=vars, expand=True))
 try:
     import $lib
 except:


### PR DESCRIPTION
If the plugin MythNetVision is built together with MythTV, configure tries to determine the preliminary path of the Python Bindings.

Python3.10 deprecates the 'distutils' package, and python3.12 will remove this package, hence we need another solution to provide the correct paths to the MythTV Python libs.

Fixes MythTV#437


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

