### PR TITLE
MythMusic: let music controls work during trackinfo popup

### DIFF
--- a/mythplugins/mythmusic/mythmusic/visualizerview.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualizerview.cpp
@@ -198,12 +198,12 @@ bool TrackInfoPopup::keyPressEvent(QKeyEvent *event)
     for (int i = 0; i < actions.size() && !handled; i++)
     {
         QString action = actions[i];
+	handled = true;
 
-        if (action == "INFO")
-        {
-            showTrackInfo(gPlayer->getCurrentMetadata());
-            handled = true;
-        }
+	if (action == "ESCAPE")
+	    Close();
+        else if (action == "INFO")
+	    showTrackInfo(gPlayer->getCurrentMetadata());
         else
             handled = false;
     }

--- a/mythplugins/mythmusic/mythmusic/visualizerview.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualizerview.cpp
@@ -198,12 +198,12 @@ bool TrackInfoPopup::keyPressEvent(QKeyEvent *event)
     for (int i = 0; i < actions.size() && !handled; i++)
     {
         QString action = actions[i];
-	handled = true;
+        handled = true;
 
-	if (action == "ESCAPE")
-	    Close();
+        if (action == "ESCAPE")
+            Close();
         else if (action == "INFO")
-	    showTrackInfo(gPlayer->getCurrentMetadata());
+            showTrackInfo(gPlayer->getCurrentMetadata());
         else
             handled = false;
     }

--- a/mythplugins/mythmusic/mythmusic/visualizerview.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualizerview.cpp
@@ -42,11 +42,13 @@ bool VisualizerView::Create(void)
 
     if (err)
     {
-        LOG(VB_GENERAL, LOG_ERR, "Cannot load screen 'lyricsview'");
+        LOG(VB_GENERAL, LOG_ERR, "Cannot load screen 'visualizerview'");
         return false;
     }
 
     BuildFocusList();
+
+    m_currentView = MV_VISUALIZER;
 
     return true;
 }
@@ -111,7 +113,7 @@ void VisualizerView::showTrackInfoPopup(void)
 {
     MythScreenStack *popupStack = GetMythMainWindow()->GetStack("popup stack");
 
-    auto *popup = new TrackInfoPopup(popupStack, gPlayer->getCurrentMetadata());
+    auto *popup = new TrackInfoPopup(popupStack);
 
     if (!popup->Create())
     {
@@ -144,9 +146,20 @@ bool TrackInfoPopup::Create(void)
     if (!err)
         return false;
 
+    // find common widgets available on any view
+    m_currentView = MV_VISUALIZER; // reverted to zero ?!
+    err = CreateCommon();
+
+    if (err)
+    {
+        LOG(VB_GENERAL, LOG_ERR, "Cannot load screen 'trackinfo_popup'");
+        return false;
+    }
+
     // get map for current track
+    MusicMetadata *metadata = gPlayer->getCurrentMetadata();
     InfoMap metadataMap;
-    m_metadata->toMap(metadataMap); 
+    metadata->toMap(metadataMap);
 
     // add the map from the next track
     MusicMetadata *nextMetadata = gPlayer->getNextMetadata();
@@ -157,14 +170,14 @@ bool TrackInfoPopup::Create(void)
 
     MythUIStateType *ratingState = dynamic_cast<MythUIStateType *>(GetChild("ratingstate"));
     if (ratingState)
-        ratingState->DisplayState(QString("%1").arg(m_metadata->Rating()));
+        ratingState->DisplayState(QString("%1").arg(metadata->Rating()));
 
     MythUIImage *albumImage = dynamic_cast<MythUIImage *>(GetChild("coverart"));
     if (albumImage)
     {
-        if (!m_metadata->getAlbumArtFile().isEmpty())
+        if (!metadata->getAlbumArtFile().isEmpty())
         {
-            albumImage->SetFilename(m_metadata->getAlbumArtFile());
+            albumImage->SetFilename(metadata->getAlbumArtFile());
             albumImage->Load();
         }
     }
@@ -185,15 +198,17 @@ bool TrackInfoPopup::keyPressEvent(QKeyEvent *event)
     for (int i = 0; i < actions.size() && !handled; i++)
     {
         QString action = actions[i];
-        handled = true;
 
         if (action == "INFO")
-            Close();
+        {
+            showTrackInfo(gPlayer->getCurrentMetadata());
+            handled = true;
+        }
         else
             handled = false;
     }
 
-    if (!handled && MythScreenType::keyPressEvent(event))
+    if (!handled && MusicCommon::keyPressEvent(event))
         handled = true;
 
     return handled;

--- a/mythplugins/mythmusic/mythmusic/visualizerview.h
+++ b/mythplugins/mythmusic/mythmusic/visualizerview.h
@@ -33,16 +33,16 @@ class VisualizerView : public MusicCommon
     static void showTrackInfoPopup(void);
 };
 
-class MPLUGIN_PUBLIC TrackInfoPopup : public MusicCommon
+class MPLUGIN_PUBLIC TrackInfoPopup : public VisualizerView
 {
   Q_OBJECT
   public:
-    explicit TrackInfoPopup(MythScreenStack *parent)
-	: MusicCommon(parent, nullptr, "trackinfopopup") {}
+    TrackInfoPopup(MythScreenStack *parent)
+        : VisualizerView(parent, nullptr) {}
     ~TrackInfoPopup(void) override;
 
-    bool Create(void) override; // MythScreenType
-    bool keyPressEvent(QKeyEvent *event) override; // MusicCommon
+    bool Create(void) override; // VisualizerView
+    bool keyPressEvent(QKeyEvent *event) override; // VisualizerView
 
   protected:
     QTimer        *m_displayTimer {nullptr};

--- a/mythplugins/mythmusic/mythmusic/visualizerview.h
+++ b/mythplugins/mythmusic/mythmusic/visualizerview.h
@@ -33,20 +33,18 @@ class VisualizerView : public MusicCommon
     static void showTrackInfoPopup(void);
 };
 
-class MPLUGIN_PUBLIC TrackInfoPopup : public MythScreenType
+class MPLUGIN_PUBLIC TrackInfoPopup : public MusicCommon
 {
   Q_OBJECT
   public:
-    TrackInfoPopup(MythScreenStack *parent, MusicMetadata *mdata)
-        : MythScreenType(parent, "trackinfopopup", false),
-        m_metadata(mdata) {}
+    explicit TrackInfoPopup(MythScreenStack *parent)
+	: MusicCommon(parent, nullptr, "trackinfopopup") {}
     ~TrackInfoPopup(void) override;
 
     bool Create(void) override; // MythScreenType
-    bool keyPressEvent(QKeyEvent *event) override; // MythScreenType
+    bool keyPressEvent(QKeyEvent *event) override; // MusicCommon
 
   protected:
-    MusicMetadata *m_metadata     {nullptr};
     QTimer        *m_displayTimer {nullptr};
 };
 

--- a/mythplugins/mythmusic/theme/default-wide/music-base.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-base.xml
@@ -724,7 +724,7 @@
         </progressbar>
 
         <textarea name="time" from="basetextarea">
-            <area>230,205,185,35</area>
+            <area>230,205,300,35</area>
             <font>basesmall</font>
         </textarea>
 
@@ -854,9 +854,9 @@
         </textarea>
 
         <textarea name="playlisttime" from="basetextarea">
-            <area>210,0,230,30</area>
+            <area>300,0,300,30</area>
             <font>basesmall</font>
-            <align>right,top</align>
+            <align>left,top</align>
         </textarea>
 
         <progressbar name="playlistprogress" from="baseplaylistprogress">
@@ -905,7 +905,7 @@
         </statetype>
 
         <textarea name="title" from="basetextarea">
-            <area>120,10,930,34</area>
+            <area>120,10,900,34</area>
             <font>basemedium</font>
             <cutdown>false</cutdown>
             <scroll direction="left" rate="15" returnrate="35" startdelay="4" returndelay="4" />
@@ -913,7 +913,7 @@
         </textarea>
 
         <textarea name="time" from="basetextarea">
-            <area>1070,15,185,34</area>
+            <area>1020,15,235,34</area>
             <align>right</align>
             <font>basesmall</font>
         </textarea>

--- a/mythplugins/mythmusic/theme/default-wide/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-ui.xml
@@ -579,18 +579,38 @@
             <font>basemedium</font>
         </textarea>
 
+        <textarea name="channel"> <!--radio stream?-->
+            <area>0,0,0,0</area>          <!--hidden-->
+        </textarea>
+        <textarea name="year" from="basetextarea">
+            <area>590,50,390,35</area>
+            <font>basesmall</font>
+            <align>right,top</align>
+        </textarea>
+        <textarea name="tracknum" from="year" depends="!channel">
+            <position>590,80</position>
+        </textarea>
+        <textarea name="time" from="year" depends="!channel">
+            <position>590,115</position>
+        </textarea>
+        <textarea name="length" from="year" depends="!time">
+            <position>590,115</position>
+        </textarea>
+
         <statetype name="ratingstate" from="baseratingstate">
             <position>180,115</position>
         </statetype>
 
-<!--
-        <textarea name="length" from="basetextarea">
-            <area>170,125,185,25</area>
-        </textarea>
--->
+        <progressbar name="progress" from="basetrackprogress">
+            <position>400,115</position>
+        </progressbar>
+
         <textarea name="nexttitle" from="basetextarea">
             <area>180,145,800,25</area>
             <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
+        </textarea>
+        <textarea name="url" from="basetextarea" depends="channel">
+            <area>180,145,800,25</area>
         </textarea>
 
         <imagetype name="coverart">

--- a/mythplugins/mythmusic/theme/default-wide/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-ui.xml
@@ -597,7 +597,7 @@
             <position>590,115</position>
         </textarea>
 
-        <statetype name="ratingstate" from="baseratingstate">
+        <statetype name="ratingstate" from="baseratingstate" depends="!channel">
             <position>180,115</position>
         </statetype>
 

--- a/mythplugins/mythmusic/theme/default-wide/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-ui.xml
@@ -591,7 +591,8 @@
             <position>590,80</position>
         </textarea>
         <textarea name="time" from="year" depends="!channel">
-            <position>590,115</position>
+            <position>810,115</position>
+            <align>left</align>
         </textarea>
         <textarea name="length" from="year" depends="!time">
             <position>590,115</position>

--- a/mythplugins/mythmusic/theme/default/music-base.xml
+++ b/mythplugins/mythmusic/theme/default/music-base.xml
@@ -415,7 +415,7 @@
         </progressbar>
 
         <textarea name="time" from="basetextarea">
-            <area>185,155,185,35</area>
+            <area>185,155,300,35</area>
             <font>basesmall</font>
         </textarea>
 
@@ -598,7 +598,7 @@
         <textarea name="playlisttime" from="basetextarea">
             <area>200,0,230,30</area>
             <font>basesmall</font>
-            <align>right,top</align>
+            <align>left,top</align>
         </textarea>
 
         <progressbar name="playlistprogress" from="baseplaylistprogress">
@@ -643,14 +643,14 @@
         </statetype>
 
         <textarea name="title" from="basetextarea">
-            <area>100,10,520,34</area>
+            <area>100,10,500,34</area>
             <font>basesmall</font>
             <align>left,vcenter</align>
             <template>%TITLE% by %ARTIST% on %ALBUM%</template>
         </textarea>
 
         <textarea name="time" from="basetextarea">
-            <area>620,10,155,34</area>
+            <area>600,10,175,34</area>
             <align>right,vcenter</align>
             <font>basesmall</font>
         </textarea>

--- a/mythplugins/mythmusic/theme/default/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default/music-ui.xml
@@ -449,10 +449,10 @@
 
     <!-- used in the visualiser screen to show some track details after a track change -->
     <window name="trackinfo_popup">
-        <area>-1,380,750,190</area>
+        <area>-1,380,750,200</area>
 
         <shape name="background" from="basebackground">
-            <area>0,0,750,190</area>
+            <area>0,0,750,200</area>
             <type>roundbox</type>
             <fill color="#303030" alpha="100" />
             <line color="#FFFFFF" alpha="50" width="2" />
@@ -479,18 +479,38 @@
             <font>basemedium</font>
         </textarea>
 
+        <textarea name="channel"> <!--radio stream?-->
+            <area>0,0,0,0</area>          <!--hidden-->
+        </textarea>
+        <textarea name="year" from="basetextarea">
+            <area>340,50,390,35</area>
+            <font>basesmall</font>
+            <align>right,top</align>
+        </textarea>
+        <textarea name="tracknum" from="year" depends="!channel">
+            <position>340,80</position>
+        </textarea>
+        <textarea name="time" from="year" depends="!channel">
+            <position>340,170</position>
+        </textarea>
+        <textarea name="length" from="year" depends="!time">
+            <position>340,170</position>
+        </textarea>
+
         <statetype name="ratingstate" from="baseratingstate">
             <position>180,115</position>
         </statetype>
 
-<!--
-        <textarea name="length" from="basetextarea">
-            <area>170,125,185,25</area>
-        </textarea>
--->
+        <progressbar name="progress" from="basetrackprogress">
+            <position>22,170</position>
+        </progressbar>
+
         <textarea name="nexttitle" from="basetextarea">
             <area>180,145,550,25</area>
             <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
+        </textarea>
+        <textarea name="url" from="basetextarea" depends="channel">
+            <area>180,145,550,25</area>
         </textarea>
 
         <imagetype name="coverart">

--- a/mythplugins/mythmusic/theme/default/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default/music-ui.xml
@@ -497,7 +497,7 @@
             <position>340,170</position>
         </textarea>
 
-        <statetype name="ratingstate" from="baseratingstate">
+        <statetype name="ratingstate" from="baseratingstate" depends="!channel">
             <position>180,115</position>
         </statetype>
 

--- a/mythtv/themes/MythCenter-wide/music-base.xml
+++ b/mythtv/themes/MythCenter-wide/music-base.xml
@@ -722,7 +722,7 @@
         </progressbar>
 
         <textarea name="time" from="basetextarea">
-            <area>230,205,185,35</area>
+            <area>230,205,300,35</area>
             <font>basesmall</font>
         </textarea>
 
@@ -773,9 +773,9 @@
         </textarea>
 
         <textarea name="playlisttime" from="basetextarea">
-            <area>200,0,240,30</area>
+            <area>300,0,300,30</area>
             <font>basesmall</font>
-            <align>right,top</align>
+            <align>left,top</align>
         </textarea>
 
         <progressbar name="playlistprogress" from="baseplaylistprogress">
@@ -825,7 +825,7 @@
         </statetype>
 
         <textarea name="title" from="basetextarea">
-            <area>120,10,930,34</area>
+            <area>120,10,900,34</area>
             <font>basemedium</font>
             <cutdown>false</cutdown>
             <scroll direction="left" rate="50" returnrate="35" startdelay="4" returndelay="4" />
@@ -833,7 +833,7 @@
         </textarea>
 
         <textarea name="time" from="basetextarea">
-            <area>1070,15,185,34</area>
+            <area>1020,15,235,34</area>
             <align>right</align>
             <font>basesmall</font>
         </textarea>

--- a/mythtv/themes/MythCenter-wide/music-base.xml
+++ b/mythtv/themes/MythCenter-wide/music-base.xml
@@ -773,7 +773,7 @@
         </textarea>
 
         <textarea name="playlisttime" from="basetextarea">
-            <area>210,0,230,30</area>
+            <area>200,0,240,30</area>
             <font>basesmall</font>
             <align>right,top</align>
         </textarea>

--- a/mythtv/themes/MythCenter-wide/music-ui.xml
+++ b/mythtv/themes/MythCenter-wide/music-ui.xml
@@ -367,13 +367,14 @@
         <textarea name="year" from="basetextarea">
             <area>590,50,390,35</area>
             <font>basesmall</font>
-            <align>right,vcenter</align>
+            <align>right,top</align>
         </textarea>
         <textarea name="tracknum" from="year" depends="!channel">
             <position>590,80</position>
         </textarea>
         <textarea name="time" from="year" depends="!channel">
-            <position>590,115</position>
+            <position>810,115</position>
+            <align>left</align>
         </textarea>
         <textarea name="length" from="year" depends="!time">
             <position>590,115</position>

--- a/mythtv/themes/MythCenter-wide/music-ui.xml
+++ b/mythtv/themes/MythCenter-wide/music-ui.xml
@@ -361,18 +361,38 @@
             <font>basemedium</font>
         </textarea>
 
+        <textarea name="channel"> <!--radio stream?-->
+            <area>0,0,0,0</area>          <!--hidden-->
+        </textarea>
+        <textarea name="year" from="basetextarea">
+            <area>590,50,390,35</area>
+            <font>basesmall</font>
+            <align>right,vcenter</align>
+        </textarea>
+        <textarea name="tracknum" from="year" depends="!channel">
+            <position>590,80</position>
+        </textarea>
+        <textarea name="time" from="year" depends="!channel">
+            <position>590,115</position>
+        </textarea>
+        <textarea name="length" from="year" depends="!time">
+            <position>590,115</position>
+        </textarea>
+
         <statetype name="ratingstate" from="baseratingstate">
             <position>180,115</position>
         </statetype>
 
-<!--
-        <textarea name="length" from="basetextarea">
-            <area>170,125,185,25</area>
-        </textarea>
--->
+        <progressbar name="progress" from="basetrackprogress">
+            <position>400,115</position>
+        </progressbar>
+
         <textarea name="nexttitle" from="basetextarea">
             <area>180,145,800,25</area>
             <template>Next: %NEXTTITLE% by %NEXTARTIST%</template>
+        </textarea>
+        <textarea name="url" from="basetextarea" depends="channel">
+            <area>180,145,800,25</area>
         </textarea>
 
         <imagetype name="coverart">

--- a/mythtv/themes/MythCenter-wide/music-ui.xml
+++ b/mythtv/themes/MythCenter-wide/music-ui.xml
@@ -379,7 +379,7 @@
             <position>590,115</position>
         </textarea>
 
-        <statetype name="ratingstate" from="baseratingstate">
+        <statetype name="ratingstate" from="baseratingstate" depends="!channel">
             <position>180,115</position>
         </statetype>
 


### PR DESCRIPTION
and let another i key press show track details and let common widgets work so theme can show for example progress bar and time.

Fixes #780, fixes #781, enhances #785, #786.

Highly recommend custom trackinfo_popup of themes add progressbar and time to assist seeking since FFWD/REW work as expected in #785.  This is provided here in the shipped defaults and MythCenter-wide.  We also add year and track number which is nice to know when skipping to next or previous track.

The XML tweaks to time and playlisttime are for #786, done here in one place to avoid conflicts.  Ideally both should be merged near the same time.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)
- [x] (for this PR): adjust shipped themes to include progressbar and time in trackinfo_popup
