### PR TITLE
Reformat the --help slightly so it conforms to GNU standard.

### DIFF
--- a/mythtv/libs/libmythbase/mythcommandlineparser.cpp
+++ b/mythtv/libs/libmythbase/mythcommandlineparser.cpp
@@ -329,7 +329,7 @@ QString CommandLineArg::GetKeywordString(void) const
 {
     // this may cause problems if the terminal is too narrow, or if too
     // many keywords for the same argument are used
-    return m_keywords.join(" OR ");
+    return m_keywords.join(", ");
 }
 
 /** \brief Return length of full keyword string for use in determining indent
@@ -411,6 +411,7 @@ QString CommandLineArg::GetHelpString(int off, const QString& group, bool force)
     // print the first line with the available keywords
     QStringList hlist = m_help.split('\n');
     wrapList(hlist, termwidth-off);
+    msg << "  ";
     if (!m_parents.isEmpty())
         msg << "  ";
     msg << GetKeywordString().leftJustified(off, ' ')
@@ -1438,9 +1439,9 @@ QString MythCommandLineParser::GetHelpString(void) const
         for (const auto & group : qAsConst(groups))
         {
             if (group.isEmpty())
-                msg << "Misc. Options:" << QT_ENDL;
+                msg << "Misc. Options:" << QT_ENDL << QT_ENDL;
             else
-                msg << group.toLocal8Bit().constData() << " Options:" << QT_ENDL;
+                msg << group.toLocal8Bit().constData() << " Options:" << QT_ENDL << QT_ENDL;
 
             for (auto * cmdarg : qAsConst(m_namedArgs))
                 msg << cmdarg->GetHelpString(maxlen, group);


### PR DESCRIPTION
Just a small PR - I read the coding standards and nothing seems at odds with it.

**Desription of change:**
This reformats sligitly the output of --help in libmyth-base by adding a two space prefix for options, and adds new lines around the different help sections.

At least with ubuntu packages help2man is used to generate the man pages, and this changes the unformatted look to normal man pages.

##### Checklist

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

