### PR TITLE
MythMusic: show playback speed only when altered

### DIFF
--- a/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
+++ b/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
@@ -458,6 +458,9 @@ void avfDecoder::run()
                 LOG(VB_GENERAL, LOG_ERR, "Error seeking");
 
             m_seekTime = -1.0;
+            // Play all pending and restart buffering, else REW/FFWD
+            // takes 1 second per keypress at the "buffered" wait below.
+            output()->Drain();  // (see issue #784)
         }
 
         while (!m_finish && !m_userStop && m_seekTime <= 0.0)

--- a/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
+++ b/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
@@ -458,9 +458,6 @@ void avfDecoder::run()
                 LOG(VB_GENERAL, LOG_ERR, "Error seeking");
 
             m_seekTime = -1.0;
-            // Play all pending and restart buffering, else REW/FFWD
-            // takes 1 second per keypress at the "buffered" wait below.
-            output()->Drain();  // (see issue #784)
         }
 
         while (!m_finish && !m_userStop && m_seekTime <= 0.0)

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -2136,10 +2136,15 @@ QString MusicCommon::getTimeString(std::chrono::seconds exTime, std::chrono::sec
 {
     if (maxTime <= 0ms)
         return MythDate::formatTime(exTime,
-                              (exTime >= 1h) ? "H:mm:ss" : "mm:ss");
+                                    (exTime >= 1h) ? "H:mm:ss" : "mm:ss");
 
     QString fmt = (maxTime >= 1h) ? "H:mm:ss" : "mm:ss";
-    return MythDate::formatTime(exTime, fmt) + " / " + MythDate::formatTime(maxTime, fmt);
+    QString out = MythDate::formatTime(exTime, fmt)
+        + " / " + MythDate::formatTime(maxTime, fmt);
+    float speed = gPlayer->getSpeed();
+    if (int(speed * 100.0F + 0.5F) != 100) // v34 - show altered speed
+        out += QString(", %1").arg(speed);
+    return out;
 }
 
 void MusicCommon::searchButtonList(void)


### PR DESCRIPTION
Playback speed can be changed faster/slower (by default W and X keys) but this is not displayed anywhere.  So this makes it hard to know the speed factor.  This simply appends the speed to time and playlisttime only when speed is changed.  A speedup of 25% looks like:

    01:36 / 03:53, 1.25

Some themes might need to tweak text area width wider or adjust align to be perfect, but it already works well with the XML in #779 and should be close in all themes.  There is no display change when playback speed is normal.

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

I'll update the wiki only if this is merged.
