### PR TITLE
MythMusic: Fix rewinds under 00:05 by stopping at 00:01

### DIFF
--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -1100,8 +1100,13 @@ void MusicCommon::seekforward()
 
 void MusicCommon::seekback()
 {
+    // I don't know why, but seeking before 00:05 fails.  Repeated
+    // rewind under 00:05 can hold time < 5s while the music plays.
+    // Time starts incrementing from zero but is now several seconds
+    // behind.  Finishing a track after this records a truncated
+    // length.  We can workaround this by limiting rewind to 1s.
     std::chrono::seconds nextTime = m_currentTime - 5s;
-    nextTime = std::clamp(nextTime, 0s, m_maxTime);
+    nextTime = std::clamp(nextTime, 1s, m_maxTime); // #787
     seek(nextTime);
 }
 


### PR DESCRIPTION
Fixes #787 by limiting rewind to 00:01.  We can't hear that first second again, but should be close enough.  You can always NEXTTRACK / PREVTRACK to hear that first second again.  I was unable to find a way to get a seek to 00:00.  If you do, then your fix could replace mine.

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

