### PR TITLE
MythMusic: handle streams that repeat same metadata in changing strings

### DIFF
--- a/mythplugins/mythmusic/mythmusic/avfdecoder.h
+++ b/mythplugins/mythmusic/mythmusic/avfdecoder.h
@@ -60,6 +60,7 @@ class avfDecoder : public QObject, public Decoder
 
     QTimer *m_mdataTimer                  {nullptr};
     QString m_lastMetadata;
+    QString m_lastMetadataParsed;
 
     int m_errCode                         {0};
 };

--- a/mythplugins/mythmusic/mythmusic/musicplayer.cpp
+++ b/mythplugins/mythmusic/mythmusic/musicplayer.cpp
@@ -891,7 +891,7 @@ void MusicPlayer::customEvent(QEvent *event)
         // update the current tracks time in the last played list
         if (m_playMode == PLAYMODE_RADIO)
         {
-            if (!m_playedList.isEmpty())
+            if (!m_playedList.isEmpty() && m_currentTime > 0s)
             {
                 m_playedList.last()->setLength(m_currentTime);
                 // this will update any track lengths displayed on screen


### PR DESCRIPTION
Fixes #790 by parsing the changed metadata string and accepting it only if title/artist/album changed.

The LOG of raw data string and its parse is moved to DEBUG level so that stations repeating the same StreamTitle in a changing string don't spam an INFO log.  Actual changes to StreamTitle are still logged to INFO as before only at first detection of the change.

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)
