### PR TITLE
MythMusic: Provide play time components to templates

### DIFF
--- a/mythplugins/mythmusic/mythmusic/musiccommon.h
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.h
@@ -120,7 +120,7 @@ class MPLUGIN_PUBLIC MusicCommon : public MythScreenType
     void updateShuffleMode(bool updateUIList = false);
 
     void changeVolume(bool up) const;
-    static void changeSpeed(bool up);
+    void changeSpeed(bool up);
     void toggleMute(void) const;
     static void toggleUpmix(void);
     static void showVolume(void);

--- a/mythplugins/mythmusic/theme/default-wide/music-base.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-base.xml
@@ -854,7 +854,7 @@
         </textarea>
 
         <textarea name="playlisttime" from="basetextarea">
-            <area>300,0,300,30</area>
+            <area>300,0,400,30</area>
             <font>basesmall</font>
             <align>left,top</align>
         </textarea>
@@ -913,7 +913,7 @@
         </textarea>
 
         <textarea name="time" from="basetextarea">
-            <area>1020,15,235,34</area>
+            <area>1020,15,245,34</area>
             <align>right</align>
             <font>basesmall</font>
         </textarea>

--- a/mythplugins/mythmusic/theme/default-wide/music-ui.xml
+++ b/mythplugins/mythmusic/theme/default-wide/music-ui.xml
@@ -1281,8 +1281,8 @@
         </textarea>
 
         <textarea name="time" from="basetextarea">
-            <area>385,125,185,25</area>
-            <align>right</align>
+            <area>375,125,285,25</area>
+            <align>left</align>
         </textarea>
 
         <imagetype name="coverart">

--- a/mythtv/themes/MythCenter-wide/music-ui.xml
+++ b/mythtv/themes/MythCenter-wide/music-ui.xml
@@ -1031,6 +1031,10 @@
     <window name="miniplayer">
         <area>-1,5,590,190</area>
 
+        <textarea name="channel"> <!--radio stream?-->
+            <area>0,0,0,0</area>          <!--hidden-->
+        </textarea>
+
         <imagetype name="track_info_background">
             <filename>miniplayer_background.png</filename>
             <area>10,10,569,170</area>
@@ -1063,8 +1067,8 @@
             <area>170,125,250,25</area>
         </textarea>
 
-        <textarea name="time" from="basetextarea">
-            <area>385,125,185,25</area>
+        <textarea name="time" from="basetextarea" depends="!channel">
+            <area>285,125,285,25</area>
             <align>right</align>
         </textarea>
 


### PR DESCRIPTION
Improve #786 by providing the three time components to XML theme templates.

Like the current "playlistplayedtime" and "playlisttotaltime" that are available to XML templates, this adds the components of "time":

* playedtime -- MM:SS or H:MM:SS
* totaltime -- MM:SS or H:MM:SS
* trackspeed -- empty for normal speed or 0.95, 1.05 and so on for abnormal playback speeds

This allows themers to format these separately if they wish.  Trackspeed is an empty string until modified by speed changes (W/X keys).  Documentation is updated at https://www.mythtv.org/wiki/Music-ui.xml#Generic_Attributes_Used_in_most_windows 