### PR TITLE
MythMusic: fix bug that switching from Gallery to Tree broke repaints

### DIFF
--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -478,10 +478,7 @@ void MusicCommon::switchView(MusicView view)
                 delete pleview;
 
             if (oldView)
-            {
-                disconnect(this, &MythScreenType::Exiting, nullptr, nullptr);
                 Close();
-            }
 
             break;
         }
@@ -508,10 +505,7 @@ void MusicCommon::switchView(MusicView view)
                 delete pleview;
 
             if (oldView)
-            {
-                disconnect(this, &MythScreenType::Exiting, nullptr, nullptr);
                 Close();
-            }
 
             break;
         }


### PR DESCRIPTION
upon escape back to the playlist.  I don't know what these disconnects were for, but removing them restores updates to the parent window.

Fixes #794.
