### PR TITLE
MythMusic: fix handleKeyPress of visualizers

### DIFF
--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -1141,7 +1141,7 @@ bool Spectrogram::processUndisplayed(VisualNode *node)
             h = m_sgsize.height() / 2;
             painter.drawLine(s_offset,     h - i, s_offset     + mag, h - i);
             painter.drawLine(s_offset - w, h - i, s_offset - w + mag, h - i);
-            if (m_color & 0x01)
+            if (m_color & 0x01) // left in color?
             {
                 if (left > 255)
                     painter.setPen(Qt::white);
@@ -1166,7 +1166,7 @@ bool Spectrogram::processUndisplayed(VisualNode *node)
             h = m_sgsize.height();
             painter.drawLine(s_offset,     h - i, s_offset     + mag, h - i);
             painter.drawLine(s_offset - w, h - i, s_offset - w + mag, h - i);
-            if (m_color & 0x02)
+            if (m_color & 0x02) // right in color?
             {
                 if (left > 255)
                     painter.setPen(Qt::white);
@@ -1224,9 +1224,9 @@ void Spectrogram::handleKeyPress(const QString &action)
 {
     LOG(VB_PLAYBACK, LOG_DEBUG, QString("SG keypress = %1").arg(action));
 
-    if (action == "SELECT")
+    if (m_history && action == "SELECT")
     {
-        m_color = (m_color + 1) & 0x03;
+        m_color = (m_color + 1) & 0x03; // left and right color bits
         gCoreContext->SaveSetting("MusicSpectrogramColor",
                                   QString("%1").arg(m_color));
     }

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -1011,31 +1011,36 @@ bool Spectrogram::process(VisualNode */*node*/)
     // TODO: label certain frequencies instead: 50, 100, 200, 500,
     // 1000, 2000, 5000, 10000
 
-    // QPainter painter(m_image);
-    // painter.setPen(Qt::cyan);
-    // QFont font = QApplication::font();
-    // font.setPixelSize(14);
-    // painter.setFont(font);
-    // if (m_history)
-    // {
-    //     for (auto h = m_sgsize.height(); h > 0; h -= m_sgsize.height() / 2)
-    //     {
-    //         for (auto i = 0; i < m_sgsize.height() / 2; i += 20)
-    //         {
-    //             painter.drawText(0, h - i,
-    //                              QString("...%1.%2.%3...").arg(i).arg(m_scale[i])
-    //                              .arg(m_scale[i] * 22050 / 8192)); // hack!!!
-    //         }
-    //     }
-    // } else {
-    //     painter.rotate(90);
-    //     for (auto i = 0; i < m_sgsize.width(); i += 20)
-    //     {
-    //         painter.drawText(0, -1 * i,
-    //                          QString("...%1.%2.%3...").arg(i).arg(m_scale[i])
-    //                          .arg(m_scale[i] * 22050 / 8192)); // hack!!!
-    //     }
-    // }
+    if (!m_showtext)
+        return false;
+
+    QPainter painter(m_image);
+    painter.setPen(Qt::white);
+    QFont font = QApplication::font();
+    font.setPixelSize(14);
+    painter.setFont(font);
+    if (m_history)              // currently unused in v34...
+    {
+        for (auto h = m_sgsize.height(); h > 0; h -= m_sgsize.height() / 2)
+        {
+            for (auto i = 0; i < m_sgsize.height() / 2; i += 20)
+            {
+                painter.drawText(0, h - i,
+                                 QString("...%1.%2.%3...").arg(i).arg(m_scale[i])
+                                 .arg(m_scale[i] * 22050 / (m_fftlen/2))); // hack!!!
+            }
+        }
+    } else {
+        painter.rotate(90);
+        for (auto i = 0; i < m_sgsize.width(); i += 20)
+        {
+            painter.drawText(m_sgsize.height()/2, -1 * i,
+                             QString("...%1...")
+                             .arg(m_scale[i] * 22050 / (m_fftlen/2))); // hack!!!
+                             // QString("...%1.%2.%3...").arg(i).arg(m_scale[i])
+                             // .arg(m_scale[i] * 22050 / (m_fftlen/2))); // hack!!!
+        }
+    }
     return false;
 }
 
@@ -1224,11 +1229,15 @@ void Spectrogram::handleKeyPress(const QString &action)
 {
     LOG(VB_PLAYBACK, LOG_DEBUG, QString("SG keypress = %1").arg(action));
 
-    if (m_history && action == "SELECT")
-    {
-        m_color = (m_color + 1) & 0x03; // left and right color bits
-        gCoreContext->SaveSetting("MusicSpectrogramColor",
-                                  QString("%1").arg(m_color));
+    if (action == "SELECT") {
+        if (m_history)
+        {
+            m_color = (m_color + 1) & 0x03; // left and right color bits
+            gCoreContext->SaveSetting("MusicSpectrogramColor",
+                                      QString("%1").arg(m_color));
+        }
+        else
+            m_showtext = ! m_showtext;
     }
 }
 

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -1079,8 +1079,10 @@ bool Spectrogram::process(VisualNode */*node*/)
         int prev = -30;
         for (auto i = 0; i < 125; i++) // 125 notes fit in 22050 Hz
         {
+	    if (i < 72 && m_scale.note(i) == ".") // skip low sharps
+	      continue;
             int now = m_scale.pixel(i);
-            if (now >= prev + 20) { // all won't fit in bass
+            if (now >= prev + 20) { // skip until good spacing
                 painter.drawText(half + 20, -1 * now - 40,
                                  80, 80, Qt::AlignVCenter|Qt::AlignLeft,
                                  QString("%1").arg(m_scale.freq(i)));

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -1030,7 +1030,7 @@ bool Spectrogram::process(VisualNode */*node*/)
     QPainter painter(m_image);
     painter.setPen(Qt::white);
     QFont font = QApplication::font();
-    font.setPixelSize(14);
+    font.setPixelSize(16);
     painter.setFont(font);
     int half = m_sgsize.height() / 2;
 
@@ -1047,21 +1047,22 @@ bool Spectrogram::process(VisualNode */*node*/)
         }
     } else {
         for (auto i = 0; i < 125; i++) // 125 notes fit in 22050 Hz
-        {
-            painter.drawText(m_scale.pixel(i) - 2, half - (i % 12) * 15 - 20,
-                             m_notes[i % 12]);
+        {                  // let Qt center the note text on the pixel
+            painter.drawText(m_scale.pixel(i) - 20, half - (i % 12) * 15 - 40,
+                             40, 40, Qt::AlignCenter, m_notes[i % 12]);
             if (i % 12 == 5)    // octave numbers
-                painter.drawText(m_scale.pixel(i) - 2, half - 200,
+                painter.drawText(m_scale.pixel(i) - 20, half - 220,
+                                 40, 40, Qt::AlignCenter,
                                  QString("%1").arg(int(i / 12)));
         }
-        painter.rotate(90);
+        painter.rotate(90);     // frequency in Hz
         for (auto i = 0; i < m_sgsize.width(); i += 20)
         {
-            painter.drawText(half + 20, -1 * i,
-                             QString("...%1")
+            painter.drawText(half + 50, -1 * i - 30, 60, 60, Qt::AlignCenter,
+                             QString("%1")
                              .arg(m_scale[i] * 22050 / (m_fftlen/2))); // hack!!!
-                             // QString("...%1.%2.%3...").arg(i).arg(m_scale[i])
-                             // .arg(m_scale[i] * 22050 / (m_fftlen/2))); // hack!!!
+            // QString("%1 %2 %3").arg(i).arg(m_scale[i])
+            // .arg(m_scale[i] * 22050 / (m_fftlen/2))); // hack!!!
         }
     }
     return false;

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -160,7 +160,7 @@ public:
     unsigned long m_offset {0};          // node offset for draw
     short         *m_right {nullptr};
     QFont         m_font;       // optional text overlay
-    bool          m_showtext {true};
+    bool          m_showtext {false};
     MusicMetadata *m_currentMetadata {nullptr};
     unsigned long m_duration {60000}; // file length in milliseconds
     unsigned int  m_lastx    {1920};  // vert line tracker

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -78,7 +78,7 @@ class VisualBase
 
     virtual bool draw( QPainter *, const QColor & ) = 0;
     virtual void resize( const QSize &size ) = 0;
-    virtual void handleKeyPress(const QString &action) = 0;
+    virtual void handleKeyPress([[maybe_unused]] const QString &action) { };
     virtual int getDesiredFPS(void) { return m_fps; }
     // Override this if you need the potential of capturing more data than the default
     virtual unsigned long getDesiredSamples(void) { return SAMPLES_DEFAULT_SIZE; }
@@ -117,7 +117,6 @@ class StereoScope : public VisualBase
     void resize( const QSize &size ) override; // VisualBase
     bool process( VisualNode *node ) override; // VisualBase
     bool draw( QPainter *p, const QColor &back ) override; // VisualBase
-    void handleKeyPress([[maybe_unused]] const QString &action) override {}; // VisualBase
 
   protected:
     QColor         m_startColor  {Qt::yellow};
@@ -231,7 +230,7 @@ class Spectrogram : public VisualBase
     bool process( VisualNode *node ) override;
     bool draw(QPainter *p, const QColor &back = Qt::black) override;
     void handleKeyPress(const QString &action) override;
-    // {(void) action;}
+
     static QImage s_image;      // picture of spectrogram
     static int    s_offset;     // position on screen
 
@@ -269,7 +268,6 @@ class Spectrum : public VisualBase
     bool process(VisualNode *node) override; // VisualBase
     bool processUndisplayed(VisualNode *node) override; // VisualBase
     bool draw(QPainter *p, const QColor &back = Qt::black) override; // VisualBase
-    void handleKeyPress([[maybe_unused]] const QString &action) override {}; // VisualBase
 
   protected:
     static inline double clamp(double cur, double max, double min);
@@ -304,7 +302,6 @@ class Squares : public Spectrum
 
     void resize (const QSize &newsize) override; // Spectrum
     bool draw(QPainter *p, const QColor &back = Qt::black) override; // Spectrum
-    void handleKeyPress([[maybe_unused]] const QString &action) override {}; // Spectrum
 
   private:
     void drawRect(QPainter *p, QRect *rect, int i, int c, int w, int h);
@@ -356,7 +353,6 @@ struct piano_key_data {
     unsigned long getDesiredSamples(void) override; // VisualBase
 
     bool draw(QPainter *p, const QColor &back = Qt::black) override; // VisualBase
-    void handleKeyPress([[maybe_unused]] const QString &action) override {}; // VisualBase
 
   protected:
     static inline double clamp(double cur, double max, double min);
@@ -416,7 +412,6 @@ class Blank : public VisualBase
     void resize(const QSize &size) override; // VisualBase
     bool process(VisualNode *node = nullptr) override; // VisualBase
     bool draw(QPainter *p, const QColor &back = Qt::black) override; // VisualBase
-    void handleKeyPress([[maybe_unused]] const QString &action) override {}; // VisualBase
 
   private:
     QSize m_size;

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -205,9 +205,11 @@ class MelScale
     static double hz2mel(double hz) { return 1127 * log(1 + hz / 700); }
     static double mel2hz(double mel) { return 700 * (exp(mel / 1127) - 1); }
     int operator[](int index);
+    int pixel(int note);
 
   private:
-    std::vector<int> m_indices;
+    std::vector<int> m_indices;      // FFT bin of each pixel
+    std::array<int,144> m_notes {0}; // pixel of each note
     int  m_scale       {0};
     int  m_range       {0};
 };
@@ -238,8 +240,10 @@ class Spectrogram : public VisualBase
     static inline double clamp(double cur, double max, double min);
     QImage         *m_image;              // picture in use
     QSize          m_sgsize {1920, 1080}; // picture size
-    QSize          m_size;                // displayed dize
+    QSize          m_size;                // displayed size
     MelScale       m_scale;               // Y-axis
+    std::array<QString, 12> m_notes       // one octave
+    = {"C", ".", "D", ".", "E", "F", ".", "G", ".", "A", ".", "B"};
     int            m_fftlen {16 * 1024}; // window width
     int            m_color {0};          // color or grayscale
     QVector<float> m_sigL;               // decaying signal window

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -252,6 +252,7 @@ class Spectrogram : public VisualBase
     std::array<int,256*6> m_blue  {0};
     bool           m_binpeak { true }; // peak of bins, else mean
     bool           m_history { true }; // spectrogram? or spectrum
+    bool           m_showtext {false}; // freq overlay?
 };
 
 class Spectrum : public VisualBase

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -242,6 +242,7 @@ class Spectrogram : public VisualBase
     QSize          m_size;                // displayed dize
     MelScale       m_scale;               // Y-axis
     int            m_fftlen {16 * 1024}; // window width
+    int            m_color {0};          // color or grayscale
     QVector<float> m_sigL;               // decaying signal window
     QVector<float> m_sigR;
     FFTSample*     m_dftL { nullptr }; // real in, complex out

--- a/mythplugins/mythmusic/mythmusic/visualize.h
+++ b/mythplugins/mythmusic/mythmusic/visualize.h
@@ -205,11 +205,16 @@ class MelScale
     static double hz2mel(double hz) { return 1127 * log(1 + hz / 700); }
     static double mel2hz(double mel) { return 700 * (exp(mel / 1127) - 1); }
     int operator[](int index);
-    int pixel(int note);
+    QString note(int note);     // text of note, 0 - 125
+    int pixel(int note);        // position of note
+    int freq(int note);         // frequency of note
 
   private:
     std::vector<int> m_indices;      // FFT bin of each pixel
-    std::array<int,144> m_notes {0}; // pixel of each note
+    std::array<QString, 12> m_notes  // one octave of notes
+    = {"C", ".", "D", ".", "E", "F", ".", "G", ".", "A", ".", "B"};
+    std::array<int,126> m_pixels {0}; // pixel of each note
+    std::array<int,126> m_freqs {0};  // frequency of each note
     int  m_scale       {0};
     int  m_range       {0};
 };
@@ -242,8 +247,6 @@ class Spectrogram : public VisualBase
     QSize          m_sgsize {1920, 1080}; // picture size
     QSize          m_size;                // displayed size
     MelScale       m_scale;               // Y-axis
-    std::array<QString, 12> m_notes       // one octave
-    = {"C", ".", "D", ".", "E", "F", ".", "G", ".", "A", ".", "B"};
     int            m_fftlen {16 * 1024}; // window width
     int            m_color {0};          // color or grayscale
     QVector<float> m_sigL;               // decaying signal window

--- a/mythplugins/mythmusic/mythmusic/visualizerview.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualizerview.cpp
@@ -18,6 +18,7 @@
 #include <libmythui/mythdialogbox.h>
 
 // mythmusic
+#include "mainvisual.h"
 #include "musiccommon.h"
 #include "visualizerview.h"
 
@@ -74,6 +75,9 @@ bool VisualizerView::keyPressEvent(QKeyEvent *event)
     {
         QString action = actions[i];
         handled = true;
+
+        if (m_mainvisual && m_mainvisual->visual())
+            m_mainvisual->visual()->handleKeyPress(action);
 
         // unassgined arrow keys might as well be useful
         if (action == "UP")


### PR DESCRIPTION
Fix #766 by calling the visualizer's handleKeyPress from visualizerview's keyPressEvent.

SELECT key now takes action in 4 visualizers:

AlbumArt: cycles through available covers
WaveForm: toggles time and resolution text overlay
Spectrogram: cycles color graphs for either or both channels, saving this preference to the database
Spectrum: toggles note and frequency text overlay
