### PR TITLE
MythMusic: DELETE key clears WaveForm, 2 key toggles text on Spectrogram

### DIFF
--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -165,7 +165,10 @@ void MusicCommon::init(bool startPlayback)
     {
         if (!gPlayer->isPlaying())
         {
-            if (m_currentView == MV_RADIO)
+            if (m_currentView == MV_VISUALIZER ||
+                m_currentView == MV_VISUALIZERINFO) // keep playmode
+                gPlayer->setPlayMode(gPlayer->getPlayMode());
+            else if (m_currentView == MV_RADIO)
                 gPlayer->setPlayMode(MusicPlayer::PLAYMODE_RADIO);
             else if (m_currentView == MV_PLAYLISTEDITORGALLERY || m_currentView == MV_PLAYLISTEDITORTREE)
                 gPlayer->setPlayMode(MusicPlayer::PLAYMODE_TRACKSEDITOR);

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -655,7 +655,7 @@ void WaveForm::saveload(MusicMetadata *meta)
     if (s_image.isNull())
     {
         s_image = QImage(m_wfsize.width(), m_wfsize.height(), QImage::Format_RGB32);
-        s_image.fill(qRgb(0, 0, 0));
+        s_image.fill(Qt::black);
     }
     m_minl = 0;                 // drop last pixel, prepare for first
     m_maxl = 0;
@@ -847,9 +847,13 @@ void WaveForm::handleKeyPress(const QString &action)
 {
     LOG(VB_PLAYBACK, LOG_DEBUG, QString("WF keypress = %1").arg(action));
 
-    if (action == "SELECT")
+    if (action == "SELECT" || action == "2")
     {
         m_showtext = ! m_showtext;
+    }
+    else if (action == "DELETE" && !s_image.isNull())
+    {
+        s_image.fill(Qt::black);
     }
 }
 

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -1054,7 +1054,9 @@ bool Spectrogram::process(VisualNode */*node*/)
         {
             for (auto i = 0; i < half; i += 20)
             {
-                painter.drawText(s_offset, h - i - 20, 255, 40,
+                painter.drawText(s_offset > m_sgsize.width() - 255
+                                 ? s_offset - m_sgsize.width() : s_offset,
+                                 h - i - 20, 255, 40,
                                  Qt::AlignRight|Qt::AlignVCenter,
                                  // QString("%1 %2").arg(m_scale[i])
                                  QString("%1")

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -666,8 +666,7 @@ void WaveForm::saveload(MusicMetadata *meta)
     m_position = 0;
     m_lastx = m_wfsize.width();
     m_font = QApplication::font();
-    // m_font.setPointSize(14);
-    m_font.setPixelSize(m_size.height() / 60); // small to be mostly unnoticed
+    m_font.setPixelSize(18);    // small to be mostly unnoticed
 }
 
 unsigned long WaveForm::getDesiredSamples(void)
@@ -1049,15 +1048,17 @@ bool Spectrogram::process(VisualNode */*node*/)
     painter.setFont(font);
     int half = m_sgsize.height() / 2;
 
-    if (m_history)              // currently unused in v34...
+    if (m_history)
     {
         for (auto h = m_sgsize.height(); h > 0; h -= half)
         {
             for (auto i = 0; i < half; i += 20)
             {
-                painter.drawText(0, h - i,
-                                 QString("...%1.%2.%3...").arg(i).arg(m_scale[i])
-                                 .arg(m_scale[i] * 22050 / (m_fftlen/2))); // hack!!!
+                painter.drawText(s_offset, h - i - 20, 255, 40,
+                                 Qt::AlignRight|Qt::AlignVCenter,
+                                 // QString("%1 %2").arg(m_scale[i])
+                                 QString("%1")
+                                 .arg(m_scale[i] * 22050 / (m_fftlen/2)));
             }
         }
     } else {
@@ -1081,8 +1082,8 @@ bool Spectrogram::process(VisualNode */*node*/)
         int prev = -30;
         for (auto i = 0; i < 125; i++) // 125 notes fit in 22050 Hz
         {
-	    if (i < 72 && m_scale.note(i) == ".") // skip low sharps
-	      continue;
+            if (i < 72 && m_scale.note(i) == ".") // skip low sharps
+              continue;
             int now = m_scale.pixel(i);
             if (now >= prev + 20) { // skip until good spacing
                 painter.drawText(half + 20, -1 * now - 40,
@@ -1287,7 +1288,8 @@ void Spectrogram::handleKeyPress(const QString &action)
 {
     LOG(VB_PLAYBACK, LOG_DEBUG, QString("SG keypress = %1").arg(action));
 
-    if (action == "SELECT") {
+    if (action == "SELECT")
+    {
         if (m_history)
         {
             m_color = (m_color + 1) & 0x03; // left and right color bits
@@ -1296,6 +1298,10 @@ void Spectrogram::handleKeyPress(const QString &action)
         }
         else
             m_showtext = ! m_showtext;
+    }
+    if (action == "2")          // 1/3 is slower/faster, 2 should be unused
+    {
+        m_showtext = ! m_showtext;
     }
 }
 


### PR DESCRIPTION
Continuing #801,

* 2 key now toggles text frequency overlay in Spectrogram
* 2 key also toggles text overlay in Spectrum and WaveForm, along with SELECT
* DELETE key clears WaveForm, in case you want to see it drawn again
* fixed bug that starting a stopped radio stream from full screen visual started music instead

I'll add this and more details to the manual soon.
