### PR TITLE
OSX: Fix FFMPEG Xcode15 linker issue

### DIFF
--- a/mythtv/external/FFmpeg/configure
+++ b/mythtv/external/FFmpeg/configure
@@ -5546,6 +5546,8 @@ case $target_os in
         if enabled clang; then
             clang_version=$($cc -dumpversion)
             test ${clang_version%%.*} -eq 11 && add_cflags -fno-stack-check
+            # Workaround code for Xcode >= 15
+            test ${clang_version%%.*} -ge 15 && add_ldflags -ld_classic
         fi
         ;;
     msys*)


### PR DESCRIPTION
With the introduction of Xcode 15, Apple has moved to a new linker and introduced the "-ld_classic" linker flag as a work around. Without this flag, FFMPEG fails to compile on systems with Xcode 15 (i.e. Sonoma).

This workaround may need to be removed at the next FFMPEG sync or when Apple deprecates the flag.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

Fixes [Issue 808](https://github.com/MythTV/mythtv/issues/808)
