### PR TITLE
Improve forced subtitle handling

### DIFF
--- a/mythtv/libs/libmythtv/captions/subtitlereader.cpp
+++ b/mythtv/libs/libmythtv/captions/subtitlereader.cpp
@@ -57,11 +57,19 @@ void SubtitleReader::SeekFrame(int64_t ts, int flags)
 
 bool SubtitleReader::AddAVSubtitle(AVSubtitle &subtitle,
                                    bool fix_position,
+                                   bool is_selected_forced_track,
                                    bool allow_forced,
-                                   bool  isExternal)
+                                   bool isExternal)
 {
     bool enableforced = false;
     bool forced = false;
+
+    if (m_avSubtitlesEnabled && is_selected_forced_track)
+    {
+        FreeAVSubtitle(subtitle);
+        return enableforced;
+    }
+
     for (unsigned i = 0; i < subtitle.num_rects; i++)
     {
         forced = forced || static_cast<bool>(subtitle.rects[i]->flags & AV_SUBTITLE_FLAG_FORCED);

--- a/mythtv/libs/libmythtv/captions/subtitlereader.h
+++ b/mythtv/libs/libmythtv/captions/subtitlereader.h
@@ -56,7 +56,8 @@ class SubtitleReader : public QObject
 
     AVSubtitles* GetAVSubtitles(void) { return &m_avSubtitles; }
     bool AddAVSubtitle(AVSubtitle& subtitle, bool fix_position,
-                       bool allow_forced, bool isExternal);
+                       bool is_selected_forced_track, bool allow_forced,
+                       bool isExternal);
     void ClearAVSubtitles(void);
     static void FreeAVSubtitle(AVSubtitle &sub);
 

--- a/mythtv/libs/libmythtv/captions/textsubtitleparser.cpp
+++ b/mythtv/libs/libmythtv/captions/textsubtitleparser.cpp
@@ -255,7 +255,7 @@ int TextSubtitleParser::ReadNextSubtitle(void)
     sub.start_display_time = av_q2d(m_stream->time_base) * m_pkt->dts * 1000;
     sub.end_display_time = av_q2d(m_stream->time_base) * (m_pkt->dts + m_pkt->duration) * 1000;
 
-    m_parent->AddAVSubtitle(sub, m_decCtx->codec_id == AV_CODEC_ID_XSUB, false, true);
+    m_parent->AddAVSubtitle(sub, m_decCtx->codec_id == AV_CODEC_ID_XSUB, false, false, true);
     return ret;
 }
 

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -3916,7 +3916,8 @@ bool AvFormatDecoder::ProcessSubtitlePacket(AVStream *curstream, AVPacket *pkt)
 
     m_trackLock.lock();
     int subIdx = m_selectedTrack[kTrackTypeSubtitle].m_av_stream_index;
-    bool isForcedTrack = m_selectedTrack[kTrackTypeSubtitle].m_forced;
+    int forcedSubIdx = m_selectedForcedTrack[kTrackTypeSubtitle].m_av_stream_index;
+    bool isForcedTrack = false;
     m_trackLock.unlock();
 
     int gotSubtitles = 0;
@@ -3941,7 +3942,8 @@ bool AvFormatDecoder::ProcessSubtitlePacket(AVStream *curstream, AVPacket *pkt)
             }
         }
     }
-    else if (m_decodeAllSubtitles || pkt->stream_index == subIdx)
+    else if (m_decodeAllSubtitles || pkt->stream_index == subIdx
+                                  || pkt->stream_index == forcedSubIdx)
     {
         m_avCodecLock.lock();
         AVCodecContext *ctx = m_codecMap.GetCodecContext(curstream);
@@ -3950,6 +3952,9 @@ bool AvFormatDecoder::ProcessSubtitlePacket(AVStream *curstream, AVPacket *pkt)
 
         subtitle.start_display_time += pts;
         subtitle.end_display_time += pts;
+
+        if (pkt->stream_index != subIdx)
+            isForcedTrack = true;
     }
 
     if (gotSubtitles)

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -3974,6 +3974,7 @@ bool AvFormatDecoder::ProcessSubtitlePacket(AVStream *curstream, AVPacket *pkt)
 
         bool forcedon = m_parent->GetSubReader(pkt->stream_index)->AddAVSubtitle(
                 subtitle, curstream->codecpar->codec_id == AV_CODEC_ID_XSUB,
+                isForcedTrack,
                 m_parent->GetAllowForcedSubtitles(), false);
          m_parent->EnableForcedSubtitles(forcedon || isForcedTrack);
     }

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -3917,6 +3917,7 @@ bool AvFormatDecoder::ProcessSubtitlePacket(AVStream *curstream, AVPacket *pkt)
     m_trackLock.lock();
     int subIdx = m_selectedTrack[kTrackTypeSubtitle].m_av_stream_index;
     int forcedSubIdx = m_selectedForcedTrack[kTrackTypeSubtitle].m_av_stream_index;
+    bool mainTrackIsForced = m_selectedTrack[kTrackTypeSubtitle].m_forced;
     bool isForcedTrack = false;
     m_trackLock.unlock();
 
@@ -3975,7 +3976,7 @@ bool AvFormatDecoder::ProcessSubtitlePacket(AVStream *curstream, AVPacket *pkt)
         bool forcedon = m_parent->GetSubReader(pkt->stream_index)->AddAVSubtitle(
                 subtitle, curstream->codecpar->codec_id == AV_CODEC_ID_XSUB,
                 isForcedTrack,
-                m_parent->GetAllowForcedSubtitles(), false);
+                (m_parent->GetAllowForcedSubtitles() && !mainTrackIsForced), false);
          m_parent->EnableForcedSubtitles(forcedon || isForcedTrack);
     }
 

--- a/mythtv/libs/libmythtv/decoders/decoderbase.cpp
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.cpp
@@ -1144,6 +1144,24 @@ int DecoderBase::AutoSelectTrack(uint Type)
     {
         // Find best track favoring forced.
         selTrack = BestTrack(Type, true);
+
+        if (Type == kTrackTypeSubtitle)
+        {
+            if (m_tracks[Type][selTrack].m_forced)
+            {
+                // A forced AV Subtitle tracks is handled without the user
+                // explicitly enabling subtitles. Try to find a good non-forced
+                // track that can be swapped to in the case the user does
+                // explicitly enable subtitles.
+                int nonForcedTrack = BestTrack(Type, false);
+
+                if (!m_tracks[Type][nonForcedTrack].m_forced)
+                {
+                    m_selectedForcedTrack[Type] = m_tracks[Type][selTrack];
+                    selTrack = nonForcedTrack;
+                }
+            }
+        }
     }
 
     int oldTrack = m_currentTrack[Type];

--- a/mythtv/libs/libmythtv/decoders/decoderbase.cpp
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.cpp
@@ -1065,8 +1065,7 @@ int DecoderBase::BestTrack(uint Type, bool forcedPreferred)
     for (uint i = 0; i < numStreams; i++)
     {
         bool forced = (Type == kTrackTypeSubtitle &&
-                        m_tracks[Type][i].m_forced &&
-                        m_parent->ForcedSubtitlesFavored());
+                        m_tracks[Type][i].m_forced);
         int position = static_cast<int>(numStreams) - static_cast<int>(i);
         int language = 0;
         for (uint j = 0; (language == 0) && (j < m_languagePreference.size()); ++j)

--- a/mythtv/libs/libmythtv/decoders/decoderbase.h
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.h
@@ -361,6 +361,7 @@ class DecoderBase
     std::array<sinfo_vec_t,kTrackTypeCount> m_tracks;
     std::array<StreamInfo, kTrackTypeCount> m_wantedTrack;
     std::array<StreamInfo, kTrackTypeCount> m_selectedTrack;
+    std::array<StreamInfo, kTrackTypeCount> m_selectedForcedTrack;
 
     /// language preferences for auto-selection of streams
     std::vector<int>     m_languagePreference;

--- a/mythtv/libs/libmythtv/decoders/decoderbase.h
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.h
@@ -264,6 +264,7 @@ class DecoderBase
     static AVPixelFormat GetBestVideoFormat(AVPixelFormat* Formats, const VideoFrameTypes* RenderFormats);
 
   protected:
+    int          BestTrack(uint Type, bool forcedPreferred);
     virtual int  AutoSelectTrack(uint Type);
     void         AutoSelectTracks(void);
     void         ResetTracks(void);

--- a/mythtv/libs/libmythtv/decoders/decoderbase.h
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.h
@@ -264,7 +264,7 @@ class DecoderBase
     static AVPixelFormat GetBestVideoFormat(AVPixelFormat* Formats, const VideoFrameTypes* RenderFormats);
 
   protected:
-    int          BestTrack(uint Type, bool forcedPreferred);
+    int          BestTrack(uint Type, bool forcedPreferred, int preferredLanguage = 0);
     virtual int  AutoSelectTrack(uint Type);
     void         AutoSelectTracks(void);
     void         ResetTracks(void);

--- a/mythtv/libs/libmythtv/mythplayer.h
+++ b/mythtv/libs/libmythtv/mythplayer.h
@@ -201,9 +201,6 @@ class MTV_PUBLIC MythPlayer : public QObject
 
     // Public Audio/Subtitle/EIA-608/EIA-708 stream selection - thread safe
     void EnableForcedSubtitles(bool enable);
-    bool ForcedSubtitlesFavored(void) const {
-        return m_allowForcedSubtitles && !m_captionsEnabledbyDefault;
-    }
     // How to handle forced Subtitles (i.e. when in a movie someone speaks
     // in a different language than the rest of the movie, subtitles are
     // forced on even if the user doesn't have them turned on.)


### PR DESCRIPTION
Change mythfrontend's auotmatic handling of forced subtitles so as to avoid making selection of non-forced subtitles less convenient.

This fixes Issue #820.

The previous implementation handled forced subtitle tracks by making a forced track the user's default selection. Because of that, the user was not able to toggle on a suitable non-forced track simply by using the T key. Also, should the user select a non-forced track then the handling of the forced track became inhibited.

This new implemenation stores the forced track without making it the user's default selection, so that the T key will toggle between the non-forced and forced track, rather than between on and off.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

