### PR TITLE
Update upnphelpers.cpp fix profile Sweden MPEG_TS_SD_EU_ISO

### DIFF
--- a/mythtv/libs/libmythupnp/upnphelpers.cpp
+++ b/mythtv/libs/libmythupnp/upnphelpers.cpp
@@ -108,9 +108,11 @@ QString DLNAProfileName(const QString &mimeType, const QSize resolution,
     // HACK This is just temporary until we start storing more video
     // information in the database for each file and can determine this
     // stuff 'properly'
-    QString sCountryCode = gCoreContext->GetLocale()->GetCountryCode();
+    QString sCountryCode = gCoreContext->GetLocale()->GetCountryCode().toLower();
     bool isNorthAmerica = (sCountryCode == "us" || sCountryCode == "ca" ||
                             sCountryCode == "mx"); // North America (NTSC/ATSC)
+
+    bool isSweden = (sCountryCode == "se"); //Sweden dvb svt1/2 use MPEG_TS_SD_EU_ISO also for HD
 
     if (container == "MPEG2-PS")
     {
@@ -143,7 +145,7 @@ QString DLNAProfileName(const QString &mimeType, const QSize resolution,
         }
         else // Europe standard (DVB)
         {
-            if (vidCodec == "H264" || isHD) // All HD is AVC with DVB
+            if ((vidCodec == "H264" || isHD) && !isSweden ) // All HD is AVC with DVB except for Sweden
                 sProfileName = "AVC_TS_EU_ISO";
             else // if (videoCodec == "MPEG2VIDEO")
                 sProfileName = "MPEG_TS_SD_EU_ISO";


### PR DESCRIPTION
When swedish DVBT broadcaster SVT changed format from SD to HD in fall of 2022, they are using h.264 in TS.
To make my Sony BRAVIA Tv's play these recorings they need to be served MPEG_TS_SD_EU_ISO. 

This is a fix to do that based on country code. This makes them work again. 
I have not tested on other brands since I only have Sony kit.
/Mats

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

