### PR TITLE
DB Schema Update:  Change lambda capture from 'by value' to 'by reference'.

### DIFF
--- a/mythtv/libs/libmythtv/dbcheck.cpp
+++ b/mythtv/libs/libmythtv/dbcheck.cpp
@@ -474,13 +474,13 @@ static bool doUpgradeTVDatabaseSchema(void)
 
     auto ss2ba = [](const auto & ss){ return QByteArray::fromStdString(ss); };
     auto qs2ba = [](const auto & item){ return item.constData(); };
-    auto add_start_end = [order](const auto & field){
+    auto add_start_end = [&order](const auto & field){
         return QString("UPDATE %1 "
                        "SET starttime = CONVERT_TZ(starttime, 'SYSTEM', 'Etc/UTC'), "
                        "    endtime   = CONVERT_TZ(endtime, 'SYSTEM', 'Etc/UTC') "
                        "ORDER BY %2")
             .arg(QString::fromStdString(field)).arg(order).toLocal8Bit(); };
-    auto add_start = [order](const auto & field){
+    auto add_start = [&order](const auto & field){
         return QString("UPDATE %1 "
                        "SET starttime = CONVERT_TZ(starttime, 'SYSTEM', 'Etc/UTC') "
                        "ORDER BY %2")


### PR DESCRIPTION
This fix corrects a program abort when updating from db version 1302 to 1303.  The problem is that the 'ORDER BY' column name is not specified, causing a fatal SQL error.  The column name should be either 'starttime' or '-starttime' depending on your time zone.

This occurs because the lambda capture is 'by value' and takes on the value at the time it was created (which is empty).  Further updates to the local variable are not available to the lambda expression.

Switching the lambda capture to 'by reference' resolves this issue.

Please apply this change to both the master and fixes/33 branches.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

