### PR TITLE
Support playing Audio CD from optical disc menu

### DIFF
--- a/mythplugins/mythmusic/mythmusic/mythmusic.cpp
+++ b/mythplugins/mythmusic/mythmusic/mythmusic.cpp
@@ -485,7 +485,7 @@ static QStringList BuildFileList(const QString &dir, const QStringList &filters)
     return ret;
 }
 
-static void handleMedia(MythMediaDevice *cd)
+static void handleMedia(MythMediaDevice *cd, bool forcePlayback)
 {
     static QString s_mountPath;
 
@@ -526,7 +526,7 @@ static void handleMedia(MythMediaDevice *cd)
     s_mountPath.clear();
 
     // don't show the music screen if AutoPlayCD is off
-    if (!gCoreContext->GetBoolSetting("AutoPlayCD", false))
+    if (!forcePlayback && !gCoreContext->GetBoolSetting("AutoPlayCD", false))
         return;
 
     if (!gMusicData->m_initialized)
@@ -631,7 +631,7 @@ static void handleMedia(MythMediaDevice *cd)
 }
 
 #ifdef HAVE_CDIO
-static void handleCDMedia(MythMediaDevice *cd)
+static void handleCDMedia(MythMediaDevice *cd, bool forcePlayback)
 {
 
     if (!cd)
@@ -743,7 +743,7 @@ static void handleCDMedia(MythMediaDevice *cd)
 
     // if the AutoPlayCD setting is set we remove all the existing tracks
     // from the playlist and replace them with the new CD tracks found
-    if (gCoreContext->GetBoolSetting("AutoPlayCD", false))
+    if (forcePlayback || gCoreContext->GetBoolSetting("AutoPlayCD", false))
     {
         gMusicData->m_all_playlists->getActive()->removeAllTracks();
 
@@ -780,7 +780,7 @@ static void handleCDMedia(MythMediaDevice *cd)
     }
 }
 #else
-static void handleCDMedia([[maybe_unused]] MythMediaDevice *cd)
+static void handleCDMedia([[maybe_unused]] MythMediaDevice *cd, [[maybe_unused]] bool forcePlayback)
 {
     LOG(VB_GENERAL, LOG_NOTICE, "MythMusic got a media changed event"
                                 "but cdio support is not compiled in");

--- a/mythtv/libs/libmythui/mediamonitor.cpp
+++ b/mythtv/libs/libmythui/mediamonitor.cpp
@@ -631,14 +631,13 @@ QList<MythMediaDevice*> MediaMonitor::GetMedias(unsigned mediatypes)
  *  \param description Unused.
  *  \param callback    The function to call when an event occurs.
  *  \param mediaType   The type of media supported by this callback. The
- *                     value must be an enum of type MythMediaType.
+ *                     value must be a bitmask of enums of type MythMediaType.
  *  \param extensions A list of file name extensions supported by this
  *  callback.
  */
 void MediaMonitor::RegisterMediaHandler(const QString  &destination,
                                         const QString  &description,
-                                        void          (*callback)
-                                              (MythMediaDevice*),
+                                        MediaCallback  callback,
                                         int             mediaType,
                                         const QString  &extensions)
 {
@@ -673,7 +672,7 @@ void MediaMonitor::RegisterMediaHandler(const QString  &destination,
  * to allow the user to select which one to use,
  * but for now, we're going to just use the first one.
  */
-void MediaMonitor::JumpToMediaHandler(MythMediaDevice* pMedia)
+void MediaMonitor::JumpToMediaHandler(MythMediaDevice* pMedia, bool forcePlayback)
 {
     QVector<MHData>                  handlers;
     QMap<QString, MHData>::Iterator  itr = m_handlerMap.begin();
@@ -701,7 +700,7 @@ void MediaMonitor::JumpToMediaHandler(MythMediaDevice* pMedia)
     // if user didn't cancel, selected = handlers.at(choice);
     int selected = 0;
 
-    handlers.at(selected).callback(pMedia);
+    handlers.at(selected).callback(pMedia, forcePlayback);
 }
 
 /**
@@ -817,7 +816,7 @@ bool MediaMonitor::eventFilter(QObject *obj, QEvent *event)
             {
                 if ((*itr).MythMediaType & (int)pDev->getMediaType() ||
                     pDev->getStatus() == MEDIASTAT_OPEN)
-                    (*itr).callback(pDev);
+                    (*itr).callback(pDev, false);
                 itr++;
             }
         }

--- a/mythtv/libs/libmythui/mediamonitor.h
+++ b/mythtv/libs/libmythui/mediamonitor.h
@@ -12,6 +12,8 @@
 #include "libmythbase/mythmedia.h"
 #include "libmythui/mythuiexp.h"
 
+typedef void (*MediaCallback)(MythMediaDevice *mediadevice, bool forcePlayback);
+
 /// Stores details of media handlers
 
 // Adding member initializers caused compilation to fail with an error
@@ -19,7 +21,7 @@
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct MHData
 {
-    void   (*callback)(MythMediaDevice *mediadevice);
+    MediaCallback callback;
     int      MythMediaType;
     QString  destination;
     QString  description;
@@ -74,10 +76,10 @@ class MUI_PUBLIC MediaMonitor : public QObject
 
     void RegisterMediaHandler(const QString  &destination,
                               const QString  &description,
-                              void          (*callback) (MythMediaDevice*),
+                              MediaCallback  callback,
                               int             mediaType,
                               const QString  &extensions);
-    void JumpToMediaHandler(MythMediaDevice*  pMedia);
+    void JumpToMediaHandler(MythMediaDevice*  pMedia, bool forcePlayback = false);
 
     // Plugins should use these if they need to access optical disks:
     static QString defaultCDdevice();
@@ -137,7 +139,7 @@ class MUI_PUBLIC MediaMonitor : public QObject
 static inline void
 REG_MEDIA_HANDLER (const QString&  destination,
                    const QString&  description,
-                   void          (*callback)(MythMediaDevice*),
+                   MediaCallback   callback,
                    int             mediaType,
                    const QString&  extensions)
 {

--- a/mythtv/libs/libmythui/mediamonitor.h
+++ b/mythtv/libs/libmythui/mediamonitor.h
@@ -12,7 +12,7 @@
 #include "libmythbase/mythmedia.h"
 #include "libmythui/mythuiexp.h"
 
-typedef void (*MediaCallback)(MythMediaDevice *mediadevice, bool forcePlayback);
+using MediaCallback = void (*)(MythMediaDevice *, bool);
 
 /// Stores details of media handlers
 

--- a/mythtv/programs/mythfrontend/mythfrontend.cpp
+++ b/mythtv/programs/mythfrontend/mythfrontend.cpp
@@ -789,7 +789,7 @@ static void playDisc()
 {
     // Check for Bluray
     LOG(VB_MEDIA, LOG_DEBUG, "Checking for BluRay medium");
-    QString bluray_mountpoint =
+    const QString bluray_mountpoint =
             gCoreContext->GetSetting("BluRayMountpoint", "/media/cdrom");
     QDir bdtest(bluray_mountpoint + "/BDMV");
     const bool isBD = (bdtest.exists() || MythCDROM::inspectImage(bluray_mountpoint) == MythCDROM::kBluray);
@@ -815,7 +815,10 @@ static void playDisc()
 
     // Check for DVD
     LOG(VB_MEDIA, LOG_DEBUG, "Checking for DVD medium");
-    if (!mediaMonitor->GetMedias(MEDIATYPE_DVD).isEmpty())
+    const bool isDVD = mediaMonitor->IsActive()
+                     ? !mediaMonitor->GetMedias(MEDIATYPE_DVD).isEmpty() 
+                     : MythCDROM::inspectImage(MediaMonitor::defaultDVDdevice()) == MythCDROM::kDVD;
+    if (isDVD)
     {
         QString dvd_device = MediaMonitor::defaultDVDdevice();
 
@@ -871,19 +874,21 @@ static void playDisc()
 
     // Check for Audio CD
     LOG(VB_MEDIA, LOG_DEBUG, "Checking for audio CD medium");
-    auto audioMedia = mediaMonitor->GetMedias(MEDIATYPE_AUDIO | MEDIATYPE_MIXED);
-    if (!audioMedia.isEmpty())
+    if (mediaMonitor->IsActive())
     {
-        for (auto *medium : qAsConst(audioMedia))
+        auto audioMedia = mediaMonitor->GetMedias(MEDIATYPE_AUDIO | MEDIATYPE_MIXED);
+        if (!audioMedia.isEmpty())
         {
-            if (medium->isUsable()) {
-                LOG(VB_MEDIA, LOG_DEBUG, QString("Found usable audio/mixed device %1").arg(medium->getDevicePath()));
-                mediaMonitor->JumpToMediaHandler(medium, true);
-                return;
+            for (auto *medium : qAsConst(audioMedia))
+            {
+                if (medium->isUsable()) {
+                    LOG(VB_MEDIA, LOG_DEBUG, QString("Found usable audio/mixed device %1").arg(medium->getDevicePath()));
+                    mediaMonitor->JumpToMediaHandler(medium, true);
+                    return;
+                }
             }
         }
     }
-
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Add support to play an audio CD from the 'Play Optical Disc' menu. The media monitor callback function was extended by a 'forcePlayback' parameter which will override the auto play option for some of the media handlers when started explicitly by the user via the menu.

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

