### PR TITLE
metadata/Music: remove unused external dependency on simplejson

### DIFF
--- a/mythtv/programs/scripts/metadata/Music/lyrics/genius.py
+++ b/mythtv/programs/scripts/metadata/Music/lyrics/genius.py
@@ -20,7 +20,7 @@ import difflib
 from optparse import OptionParser
 from common import utilities
 
-import json as simplejson
+import json
 
 __author__      = "Paul Harrison and ronie'"
 __title__       = "Genius"
@@ -50,7 +50,7 @@ class LyricsFetcher:
             return False
 
         req.close()
-        data = simplejson.loads(response)
+        data = json.loads(response)
 
         try:
             name = data['response']['hits'][0]['result']['primary_artist']['name']
@@ -198,4 +198,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/mythtv/programs/scripts/metadata/Music/lyrics/lyricswiki.py
+++ b/mythtv/programs/scripts/metadata/Music/lyrics/lyricswiki.py
@@ -1,6 +1,6 @@
 #-*- coding: UTF-8 -*-
 
-import sys, re, socket
+import json, sys, re, socket
 
 try:
     from urllib2 import quote, urlopen, HTTPError
@@ -14,11 +14,6 @@ except ImportError:
     from html import parser as html_parser
 
 from optparse import OptionParser
-
-if sys.version_info < (2, 7):
-    import simplejson
-else:
-    import json as simplejson
 
 from common import *
 
@@ -49,7 +44,7 @@ class LyricsFetcher:
         except:
             return False
         req.close()
-        data = simplejson.loads(response)
+        data = json.loads(response)
         try:
             self.page = data['url']
         except:


### PR DESCRIPTION
The simplejson module was added to the python standard library in 2.6; here, it is inconsistently imported for python 2.6 (where it already exists) and lower (where it does not) instead of using `json`.

But, mythtv only supports python 3.8 for a while now. So this conditional is merely dead code. The import name is still aliased using `as simplejson`, though, which is bad for visibility and analysis.


Part of #824