### PR TITLE
hardwareprofile: drop ancient python2 compatibility libraries: "future" and "simplejson"

### DIFF
--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -48,7 +48,7 @@ jobs:
         sudo apt install ccache qt5-qmake qtscript5-dev nasm libsystemd-dev libfreetype6-dev libmp3lame-dev libx264-dev libx265-dev libxrandr-dev libxml2-dev
         sudo apt install libavahi-compat-libdnssd-dev libasound2-dev liblzo2-dev libhdhomerun-dev libsamplerate0-dev libva-dev libdrm-dev libvdpau-dev
         sudo apt install libass-dev libpulse-dev libcec-dev libssl-dev libtag1-dev libbluray-dev libbluray-bdj libgnutls28-dev libqt5webkit5-dev
-        sudo apt install libvpx-dev python3-mysqldb python3-lxml python3-simplejson python3-future python3-setuptools libdbi-perl libdbd-mysql-perl libnet-upnp-perl
+        sudo apt install libvpx-dev python3-mysqldb python3-lxml python3-future python3-setuptools libdbi-perl libdbd-mysql-perl libnet-upnp-perl
         sudo apt install libio-socket-inet6-perl libxml-simple-perl libqt5sql5-mysql libwayland-dev qtbase5-private-dev libzip-dev libsoundtouch-dev
       if: runner.os == 'Linux'
 

--- a/mythtv/configure
+++ b/mythtv/configure
@@ -6563,7 +6563,6 @@ if enabled bindings_python; then
     check_py_lib MySQLdb       || disable_bindings_python "MySQLdb"
     check_py_lib lxml          || disable_bindings_python "lxml"
     check_py_lib requests      || disable_bindings_python "requests"
-    check_py_lib future        || disable_bindings_python "future"
     check_python "(3,11,1)" && check_py_lib wheel && check_py_lib_version pip "(23,0,1)" && USE_PYTHON_PIP="yes"
 fi
 

--- a/mythtv/configure
+++ b/mythtv/configure
@@ -5535,7 +5535,7 @@ if enabled bdjava; then
         java_code_version=1.4
 
         javac_version=`"${JAVAC}" -version 2>&1 | head -n 1`
-        
+
         echo "${javac_version}" | grep -E -q '^javac (9|1[0-1])' && java_code_version=1.6
         echo "${javac_version}" | grep -E -q '^javac (1[2-9])' && java_code_version=1.7
         echo "${javac_version}" | grep -E -q '^javac (2.*)' && java_code_version=1.7
@@ -6563,7 +6563,6 @@ if enabled bindings_python; then
     check_py_lib MySQLdb       || disable_bindings_python "MySQLdb"
     check_py_lib lxml          || disable_bindings_python "lxml"
     check_py_lib requests      || disable_bindings_python "requests"
-    check_py_lib simplejson    || disable_bindings_python "simplejson"
     check_py_lib future        || disable_bindings_python "future"
     check_python "(3,11,1)" && check_py_lib wheel && check_py_lib_version pip "(23,0,1)" && USE_PYTHON_PIP="yes"
 fi

--- a/mythtv/programs/scripts/hardwareprofile/MultipartPostHandler.py
+++ b/mythtv/programs/scripts/hardwareprofile/MultipartPostHandler.py
@@ -41,8 +41,6 @@ Further Example:
 """
 from __future__ import print_function
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 from email.generator import _make_boundary
 import mimetypes

--- a/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/request.py
+++ b/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/request.py
@@ -21,8 +21,6 @@
 # providing the base url, user agent, and proxy information.
 # The object returned is slightly modified, with a shortcut to urlopen.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import urllib.request, urllib.error, urllib.parse
 import urllib.parse

--- a/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/uuiddb.py
+++ b/mythtv/programs/scripts/hardwareprofile/distros/mythtv_data/uuiddb.py
@@ -16,8 +16,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import map
 from builtins import str
 from builtins import object

--- a/mythtv/programs/scripts/hardwareprofile/hwdata.py
+++ b/mythtv/programs/scripts/hardwareprofile/hwdata.py
@@ -25,8 +25,6 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import int
 from builtins import open
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 from smolt_config import get_config_attr
 
@@ -71,9 +69,9 @@ class DeviceMap(object):
                     pass
         else:
             raise Exception('Hardware data file not found.  Please set the location HWDATA_DIR in config.py')
-         
-            
-            
+
+
+
         vendors = {}
         curvendor = None
         curdevice = None

--- a/mythtv/programs/scripts/hardwareprofile/os_detect.py
+++ b/mythtv/programs/scripts/hardwareprofile/os_detect.py
@@ -26,7 +26,6 @@
 from __future__ import print_function
 from builtins import object
 import os
-from future.utils import with_metaclass
 
 class OrderedType( type ):
     # provide global sequencing for OS class and subclasses to ensure
@@ -37,7 +36,7 @@ class OrderedType( type ):
         mcs.nextorder += 1
         return type.__new__(mcs, name, bases, attrs)
 
-class OS( with_metaclass(OrderedType, object) ):
+class OS(metaclass=OrderedType):
     _requires_func = True
     def __init__(self, ostype=-1, func=None, inst=None):
         if callable(ostype):
@@ -189,7 +188,7 @@ class OSInfoType( type ):
             # fall through to Unknown
             return 'Unknown'
 
-class get_os_info( with_metaclass(OSInfoType, object) ):
+class get_os_info(metaclass=OSInfoType):
     @OS('nt')
     def windows(self):
         win_version = {

--- a/mythtv/programs/scripts/hardwareprofile/request.py
+++ b/mythtv/programs/scripts/hardwareprofile/request.py
@@ -21,8 +21,6 @@
 # providing the base url, user agent, and proxy information.
 # The object returned is slightly modified, with a shortcut to urlopen.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 
 try:

--- a/mythtv/programs/scripts/hardwareprofile/scan.py
+++ b/mythtv/programs/scripts/hardwareprofile/scan.py
@@ -18,8 +18,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 import smolt
 import json
 

--- a/mythtv/programs/scripts/hardwareprofile/smolt.py
+++ b/mythtv/programs/scripts/hardwareprofile/smolt.py
@@ -50,7 +50,6 @@ except ImportError:
     from urlparse import urlparse
 import json
 from json import JSONEncoder
-from simplejson import errors as sje
 import datetime
 import logging
 
@@ -790,8 +789,8 @@ class _HardwareProfile:
                 sys.exit(1)
 
             try:
-                admin_obj = admin_token.json()
-            except sje.JSONDecodeError:
+                admin_obj = json.loads(admin_token.content)
+            except json.JSONDecodeError:
                 self.session.close()
                 error(_('Incorrect server response. Expected a JSON string'))
                 return (1, None, None)

--- a/mythtv/programs/scripts/hardwareprofile/uuiddb.py
+++ b/mythtv/programs/scripts/hardwareprofile/uuiddb.py
@@ -16,8 +16,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import configparser
 import logging


### PR DESCRIPTION
Two commits:
- hardwareprofile: remove external dependency on simplejson

This uses the requests module and converts requests responses to json using requests' own `.json()` method on responses. For incomprehensible reasons, requests has spent about a decade using either simplejson or the standard library's json module more or less at will, and returning either one or the other exception types. They don't know why they use simplejson, we don't know why they use simplejson. In requests 3 (which will be released in the Year Of The Linux Desktop or when pigs fly, whichever one comes later) simplejson is dropped entirely.

There are innumerable issues discussing the problem on the requests bugtracker, with the general consensus being that it's better to randomly return either one of two different libraries and two different library return types in errors -- because it was historically done that way and people might be depending on it. ??????


Bugs:
https://github.com/psf/requests/pull/710
https://github.com/psf/requests/pull/2516
https://github.com/psf/requests/issues/3052
https://github.com/psf/requests/issues/4169
https://github.com/psf/requests/issues/4842
https://github.com/psf/requests/issues/5794
https://github.com/psf/requests/issues/6084

The awkward workaround is to guarantee that requests' silent behavior of using simplejson *if it is installed* is forcibly triggered by forcibly depending on simplejson, and then catching the simplejson exception.

The better solution here is pretty simple: do not rely on the requests module's automatic json conversion, this is as simple as using the already-imported json module and calling json.loads() on the retrieved content.

Fixes: 1df343e9ab7defa284a73390210a65cf2112f17e
Reimplements: bb154a843b737cc3ad8c1a45fa04a1a3609aff05

- hardwareprofile: remove ancient "future" compatibility library for python2

Ironically, for a package that was intended to provide portability between python2 and python3, it is broken with python 3.12. A better library to use in all cases is "six".

However, mythtv requires python 3.8 for a while now. Using "future.standard_library" is a no-op other than costing a pointless import and being troublesome to actually install.

The hacky copy of six.with_metaclass included in "future" is rewritten to use the pure python3 form of a metaclass.

Part of #824