### PR TITLE
Github workflow: Remove external dependency on python-future

### DIFF
--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -48,7 +48,7 @@ jobs:
         sudo apt install ccache qt5-qmake qtscript5-dev nasm libsystemd-dev libfreetype6-dev libmp3lame-dev libx264-dev libx265-dev libxrandr-dev libxml2-dev
         sudo apt install libavahi-compat-libdnssd-dev libasound2-dev liblzo2-dev libhdhomerun-dev libsamplerate0-dev libva-dev libdrm-dev libvdpau-dev
         sudo apt install libass-dev libpulse-dev libcec-dev libssl-dev libtag1-dev libbluray-dev libbluray-bdj libgnutls28-dev libqt5webkit5-dev
-        sudo apt install libvpx-dev python3-mysqldb python3-lxml python3-future python3-setuptools libdbi-perl libdbd-mysql-perl libnet-upnp-perl
+        sudo apt install libvpx-dev python3-mysqldb python3-lxml python3-setuptools libdbi-perl libdbd-mysql-perl libnet-upnp-perl
         sudo apt install libio-socket-inet6-perl libxml-simple-perl libqt5sql5-mysql libwayland-dev qtbase5-private-dev libzip-dev libsoundtouch-dev
       if: runner.os == 'Linux'
 


### PR DESCRIPTION
Python 3.12 removes the imp module but python-future v0.18.3 uses it,
see PythonCharmers/python-future#625
Since 4b5eac8, python-future is not needed anymore.

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

