### PR TITLE
Reorder structure changes to allow older MythTV databases to migrate cleanly.

### DIFF
--- a/mythtv/libs/libmythtv/dbcheck.cpp
+++ b/mythtv/libs/libmythtv/dbcheck.cpp
@@ -1959,7 +1959,50 @@ static bool doUpgradeTVDatabaseSchema(void)
 "           'smpte2022-1','smpte2022-2'),"
 "  bitrate INT(10) UNSIGNED NOT NULL,"
 "  PRIMARY KEY (iptvid)"
-") ENGINE=MyISAM DEFAULT CHARSET=utf8;"
+") ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+
+            "CREATE TABLE IF NOT EXISTS recgroups ("
+                "recgroupid  SMALLINT(4) NOT NULL AUTO_INCREMENT, "
+                "recgroup    VARCHAR(64) NOT NULL DEFAULT '', "
+                "displayname VARCHAR(64) NOT NULL DEFAULT '', "
+                "password    VARCHAR(40) NOT NULL DEFAULT '', "
+                "special     TINYINT(1) NOT NULL DEFAULT '0',"
+                "PRIMARY KEY (recgroupid), "
+                "UNIQUE KEY recgroup ( recgroup )"
+                ") ENGINE=MyISAM DEFAULT CHARSET=utf8;",
+            // Create the built-in, 'special', groups
+            "INSERT INTO recgroups ( recgroupid, recgroup, special ) VALUES ( 1, 'Default', '1' );",
+            "INSERT INTO recgroups ( recgroupid, recgroup, special ) VALUES ( 2, 'LiveTV', '1' );",
+            "INSERT INTO recgroups ( recgroupid, recgroup, special ) VALUES ( 3, 'Deleted', '1' );",
+            // Copy in the passwords for the built-in groups
+            "DELETE FROM recgrouppassword WHERE password = '';",
+            "UPDATE recgroups r, recgrouppassword p SET r.password = p.password WHERE r.recgroup = p.recgroup;",
+            // Copy over all existing recording groups, this information may be split over three tables!
+            "INSERT IGNORE INTO recgroups ( recgroup, displayname, password ) SELECT DISTINCT recgroup, recgroup, password FROM recgrouppassword;",
+            "INSERT IGNORE INTO recgroups ( recgroup, displayname ) SELECT DISTINCT recgroup, recgroup FROM record;",
+            "INSERT IGNORE INTO recgroups ( recgroup, displayname ) SELECT DISTINCT recgroup, recgroup FROM recorded;",
+            // Create recgroupid columns in record and recorded tables
+            "ALTER TABLE record ADD COLUMN recgroupid SMALLINT(4) NOT NULL DEFAULT '1', ADD INDEX ( recgroupid );",
+            "ALTER TABLE recorded ADD COLUMN recgroupid SMALLINT(4) NOT NULL DEFAULT '1', ADD INDEX ( recgroupid );",
+
+            "ALTER TABLE record ADD COLUMN autoextend TINYINT UNSIGNED DEFAULT 0;",
+
+            "ALTER TABLE record MODIFY COLUMN startdate DATE DEFAULT NULL",
+            "ALTER TABLE record MODIFY COLUMN enddate DATE DEFAULT NULL",
+            "ALTER TABLE record MODIFY COLUMN starttime TIME DEFAULT NULL",
+            "ALTER TABLE record MODIFY COLUMN endtime TIME DEFAULT NULL",
+
+            // All next_record, last_record and last_delete to be NULL.
+            "ALTER TABLE record MODIFY next_record DATETIME NULL",
+            // NOLINTNEXTLINE(bugprone-suspicious-missing-comma)
+            "UPDATE record SET next_record = NULL "
+            "    WHERE next_record = '0000-00-00 00:00:00'",
+            "ALTER TABLE record MODIFY last_record DATETIME NULL",
+            "UPDATE record SET last_record = NULL "
+            "    WHERE last_record = '0000-00-00 00:00:00'",
+            "ALTER TABLE record MODIFY last_delete DATETIME NULL",
+            "UPDATE record SET last_delete = NULL "
+            "    WHERE last_delete = '0000-00-00 00:00:00'",
 };
 
         if (!performActualUpdate("MythTV", "DBSchemaVer",
@@ -2501,29 +2544,6 @@ static bool doUpgradeTVDatabaseSchema(void)
     if (dbver == "1320")
     {
         DBUpdates updates {
-            "CREATE TABLE IF NOT EXISTS recgroups ("
-                "recgroupid  SMALLINT(4) NOT NULL AUTO_INCREMENT, "
-                "recgroup    VARCHAR(64) NOT NULL DEFAULT '', "
-                "displayname VARCHAR(64) NOT NULL DEFAULT '', "
-                "password    VARCHAR(40) NOT NULL DEFAULT '', "
-                "special     TINYINT(1) NOT NULL DEFAULT '0',"
-                "PRIMARY KEY (recgroupid), "
-                "UNIQUE KEY recgroup ( recgroup )"
-                ") ENGINE=MyISAM DEFAULT CHARSET=utf8;",
-            // Create the built-in, 'special', groups
-            "INSERT INTO recgroups ( recgroupid, recgroup, special ) VALUES ( 1, 'Default', '1' );",
-            "INSERT INTO recgroups ( recgroupid, recgroup, special ) VALUES ( 2, 'LiveTV', '1' );",
-            "INSERT INTO recgroups ( recgroupid, recgroup, special ) VALUES ( 3, 'Deleted', '1' );",
-            // Copy in the passwords for the built-in groups
-            "DELETE FROM recgrouppassword WHERE password = '';",
-            "UPDATE recgroups r, recgrouppassword p SET r.password = p.password WHERE r.recgroup = p.recgroup;",
-            // Copy over all existing recording groups, this information may be split over three tables!
-            "INSERT IGNORE INTO recgroups ( recgroup, displayname, password ) SELECT DISTINCT recgroup, recgroup, password FROM recgrouppassword;",
-            "INSERT IGNORE INTO recgroups ( recgroup, displayname ) SELECT DISTINCT recgroup, recgroup FROM record;",
-            "INSERT IGNORE INTO recgroups ( recgroup, displayname ) SELECT DISTINCT recgroup, recgroup FROM recorded;",
-            // Create recgroupid columns in record and recorded tables
-            "ALTER TABLE record ADD COLUMN recgroupid SMALLINT(4) NOT NULL DEFAULT '1', ADD INDEX ( recgroupid );",
-            "ALTER TABLE recorded ADD COLUMN recgroupid SMALLINT(4) NOT NULL DEFAULT '1', ADD INDEX ( recgroupid );",
             // Populate those columns with the corresponding recgroupid from the new recgroups table
             "UPDATE recorded, recgroups SET recorded.recgroupid = recgroups.recgroupid WHERE recorded.recgroup = recgroups.recgroup;",
             "UPDATE record, recgroups SET record.recgroupid = recgroups.recgroupid WHERE record.recgroup = recgroups.recgroup;"
@@ -2687,7 +2707,9 @@ static bool doUpgradeTVDatabaseSchema(void)
             "ADD COLUMN video_avg_bitrate MEDIUMINT UNSIGNED NOT NULL DEFAULT 0, " // Kbps
             "ADD COLUMN video_max_bitrate MEDIUMINT UNSIGNED NOT NULL DEFAULT 0, " // Kbps
             "ADD COLUMN audio_avg_bitrate MEDIUMINT UNSIGNED NOT NULL DEFAULT 0, " // Kbps
-            "ADD COLUMN audio_max_bitrate MEDIUMINT UNSIGNED NOT NULL DEFAULT 0 ;" // Kbps
+            "ADD COLUMN audio_max_bitrate MEDIUMINT UNSIGNED NOT NULL DEFAULT 0 ;", // Kbps
+
+            "ALTER TABLE recorded ADD COLUMN lastplay TINYINT UNSIGNED DEFAULT 0 AFTER bookmark;",
         };
         if (!performActualUpdate("MythTV", "DBSchemaVer",
                                  updates, "1330", dbver))
@@ -2989,21 +3011,7 @@ static bool doUpgradeTVDatabaseSchema(void)
 
     if (dbver == "1337")
     {
-        DBUpdates updates {
-            // All next_record, last_record and last_delete to be NULL.
-            "ALTER TABLE record MODIFY next_record DATETIME NULL",
-            // NOLINTNEXTLINE(bugprone-suspicious-missing-comma)
-            "UPDATE record SET next_record = NULL "
-            "    WHERE next_record = '0000-00-00 00:00:00'",
-            "ALTER TABLE record MODIFY last_record DATETIME NULL",
-            "UPDATE record SET last_record = NULL "
-            "    WHERE last_record = '0000-00-00 00:00:00'",
-            "ALTER TABLE record MODIFY last_delete DATETIME NULL",
-            "UPDATE record SET last_delete = NULL "
-            "    WHERE last_delete = '0000-00-00 00:00:00'"
-        };
-        if (!performActualUpdate("MythTV", "DBSchemaVer",
-                                 updates, "1338", dbver))
+        if (!UpdateDBVersionNumber("MythTV", "DBSchemaVer", "1338", dbver))
             return false;
     }
 
@@ -3294,14 +3302,7 @@ static bool doUpgradeTVDatabaseSchema(void)
 
     if (dbver == "1347")
     {
-        DBUpdates updates {
-            "ALTER TABLE record MODIFY COLUMN startdate DATE DEFAULT NULL",
-            "ALTER TABLE record MODIFY COLUMN enddate DATE DEFAULT NULL",
-            "ALTER TABLE record MODIFY COLUMN starttime TIME DEFAULT NULL",
-            "ALTER TABLE record MODIFY COLUMN endtime TIME DEFAULT NULL"
-        };
-        if (!performActualUpdate("MythTV", "DBSchemaVer",
-                                 updates, "1348", dbver))
+        if (!UpdateDBVersionNumber("MythTV", "DBSchemaVer", "1348", dbver))
             return false;
     }
 
@@ -3867,21 +3868,13 @@ static bool doUpgradeTVDatabaseSchema(void)
     {
         // Recording extender tables are now created later.
 
-        // If that worked, modify existing tables.
-        DBUpdates updates = getRecordingExtenderDbInfo(0);
-        if (!performActualUpdate("MythTV", "DBSchemaVer",
-                                 updates, "1372", dbver))
+        if (!UpdateDBVersionNumber("MythTV", "DBSchemaVer", "1372", dbver))
             return false;
     }
 
     if (dbver == "1372")
     {
-        DBUpdates updates {
-            "ALTER TABLE recorded ADD COLUMN lastplay "
-            "    TINYINT UNSIGNED DEFAULT 0 AFTER bookmark;",
-        };
-        if (!performActualUpdate("MythTV", "DBSchemaVer",
-                                 updates, "1373", dbver))
+        if (!UpdateDBVersionNumber("MythTV", "DBSchemaVer", "1373", dbver))
             return false;
     }
 
@@ -5289,12 +5282,6 @@ DBUpdates getRecordingExtenderDbInfo (int version)
             R"(DROP TABLE IF EXISTS sportscleanup;)",
             R"(DROP TABLE IF EXISTS sportslisting;)",
             R"(DROP TABLE IF EXISTS sportsapi;)",
-        };
-
-      case 0:
-        return {
-            R"(ALTER TABLE record ADD COLUMN autoextend
-                TINYINT UNSIGNED DEFAULT 0;)",
         };
 
       case 1:


### PR DESCRIPTION
After my last patch, .25 databases would migrate to .33 without aborting during the process.  However, there were a number SQL errors that still appeared during migration.  The major thing I noticed is that the "Default" recording template was not getting created.  That insert fails due to missing columns and columns that do not allow null values.

The code to add these missing columns and modify nullable attributes is already present, but it is executed after the changes are actually required.  Presumably, some later code changes broke some of the earlier migrations.

I added no new code.  I only moved various SQL structure changes to earlier version updates.  My .25 database now migrates cleanly and the Default recording rule is present after the migration.

Please update master and fixes/33 with these changes.  Thanks!

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

