### PR TITLE
Tweak structure changes to allow older MythTV databases to migrate cleanly.

### DIFF
--- a/mythtv/libs/libmythbase/dbutil.cpp
+++ b/mythtv/libs/libmythbase/dbutil.cpp
@@ -877,4 +877,52 @@ bool DBUtil::CheckTimeZoneSupport(void)
     return !query.value(0).isNull();
 }
 
+/** \fn DBUtil::CheckTableColumnExists(const QString &tableName, const QString &columnName)
+ *  \brief Checks for the presence of a column in a table in the current database
+ *
+ *   This function will check a table in the current database for the presence
+ *   of a named column.
+ *
+ *  \param tableName Name of table to check
+ *  \param columnName Name of column to look for
+ *  \return true if column exists in the table; false if it does not
+ *  \sa CheckTableColumnExists(const QString &tableName, const QString &columnName)
+ */
+bool DBUtil::CheckTableColumnExists(const QString &tableName, const QString &columnName)
+{
+    MSqlQuery query(MSqlQuery::InitCon());
+    if (!query.isConnected())
+        return false;
+
+    QString sql = QString("SELECT COUNT(*) FROM information_schema.columns "
+                          "WHERE table_schema = DATABASE() AND "
+                                "table_name = '%1' AND column_name = '%2';")
+                          .arg(tableName, columnName);
+    LOG(VB_GENERAL, LOG_DEBUG,
+            QString("DBUtil::CheckTableColumnExists() SQL: %1").arg(sql));
+
+    if (!query.exec(sql))
+    {
+        MythDB::DBError("DBUtil Check Table Column Exists", query);
+        return false;
+    }
+
+    bool result = false;
+    if (query.next())
+    {
+        result = (query.value(0).toInt() > 0);
+    }
+    else
+    {
+        LOG(VB_GENERAL, LOG_ERR,
+                            QString("DBUtil::CheckTableColumnExists() - Empty result set"));
+    }
+
+    LOG(VB_GENERAL, LOG_DEBUG,
+            QString("DBUtil::CheckTableColumnExists('%1', '%2') result: %3").arg(tableName,
+                    columnName, QVariant(result).toString()));
+
+    return result;
+}
+
 /* vim: set expandtab tabstop=4 shiftwidth=4: */

--- a/mythtv/libs/libmythbase/dbutil.h
+++ b/mythtv/libs/libmythbase/dbutil.h
@@ -53,6 +53,7 @@ class MBASE_PUBLIC DBUtil
     static void UnlockSchema(MSqlQuery &query);
 
     static bool CheckTimeZoneSupport(void);
+    static bool CheckTableColumnExists(const QString &tableName, const QString &columnName);
 
     static const int kUnknownVersionNumber;
 

--- a/mythtv/libs/libmythtv/dbcheck.cpp
+++ b/mythtv/libs/libmythtv/dbcheck.cpp
@@ -2760,6 +2760,9 @@ static bool doUpgradeTVDatabaseSchema(void)
 
     if (dbver == "1330")
     {
+        // Adding field lastplay because it is now required in the upgrade to database schema 1331
+        // but only when the are recordings present in the database.
+        // Field lastplay is initially introduced in the upgrade to database schema 1373.
         if (!DBUtil::CheckTableColumnExists(QString("recorded"), QString("lastplay")))
         {
             DBUpdates updates {


### PR DESCRIPTION
Take two on this.  I added a method to DBUtil to check for a column's presence.

.25 databases would migrate to .33 without aborting during the process. However, there were a number SQL errors that still appeared during migration. The major thing I noticed is that the "Default" recording template was not getting created. That insert fails due to missing columns and columns that do not allow null values.

The code to add these missing columns and modify nullable attributes is already present, but it is executed after the changes are actually required. Presumably, some later code changes broke some of the earlier migrations.

This time I removed none of the existing SQL changes. I only copied various SQL structure changes/data updates to earlier db version updates.  I then modified the later ones to not cause an error should they get run a second time.

My .25 database now migrates cleanly and the Default recording rule is present after the migration.

Please update fixes/33 (and master as you see fit) with these changes. Thanks!

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

