### PR TITLE
Github Workflow - Add macos-14 for both arm64 and x86_64

### DIFF
--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -1,10 +1,11 @@
+---
 name: master
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -33,126 +34,152 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Checkout master
-      uses: actions/checkout@v3
+      - name: Checkout master
+        uses: actions/checkout@v3
 
-    - name: Setup build environment
-      run: |
-        echo "MYTHTV_CONFIG=--prefix=${{ github.workspace }}/build/install --cc=${{ matrix.cc }} --cxx=${{ matrix.cxx }}" >> $GITHUB_ENV
-        echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
-        # As some OSes can cross-compile, establish defaule configrue/make commands which can be overided as appropriate
-        echo "CONFIGURE_CMD=./configure" >> $GITHUB_ENV
-        echo "MAKE_CMD=make" >> $GITHUB_ENV
+      - name: Setup build environment
+        run: |
+          echo "MYTHTV_CONFIG=--prefix=${{ github.workspace }}/build/install --cc=${{ matrix.cc }} --cxx=${{ matrix.cxx }}" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+          # As some OSes can cross-compile, establish defaule configrue/make
+          # commands which can be overided as appropriate
+          echo "CONFIGURE_CMD=./configure" >> $GITHUB_ENV
+          echo "MAKE_CMD=make" >> $GITHUB_ENV
 
-    # GitHub caches are immutable, so to update a cache, use a unique key with a
-    # prefixed restore-key.  GitHub will rotate the caches within their 10 GB
-    # storage limit.  See https://github.com/actions/cache/blob/471fb0c87e5d7210f339d8ea2e01505ddafd793d/workarounds.md#update-a-cache
-    - name: Check ccache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: ${{ matrix.os }}-${{ matrix.cc }}-ccache-${{ github.sha }}
-        restore-keys: ${{ matrix.os }}-${{ matrix.cc }}-ccache
+      # GitHub caches are immutable, so to update a cache, use a unique key with
+      # a prefixed restore-key. GitHub will rotate the caches within their 10 GB
+      # storage limit.
+      # See https://github.com/actions/cache/blob/471fb0c87e5d7210f339d8ea2e01505ddafd793d/workarounds.md#update-a-cache
+      - name: Check ccache
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: ${{ matrix.os }}-${{ matrix.cc }}-ccache-${{ github.sha }}
+          restore-keys: ${{ matrix.os }}-${{ matrix.cc }}-ccache
 
-    # macOS based github runners starting with macos-14 only run on the arm64 architecture.  To generate x86_64 based executable, the
-    # arch -x86_64 command is needed before any brew commands, make, and install to run as x86_64 via Rosetta2.
-    - name: Check cross-compile environment (macOS)
-      env:
-        ARCH: ${{ matrix.arch }}
-      run: |
-        SYSARCH=$(/usr/bin/uname -m)
-        PKGMGR_CMD='brew'
-        if [ "$SYSARCH" = "$ARCH" ]; then
-          # this is a cross-compile
-          PKGMGR_CMD="arch -${ARCH} $PKGMGR_CMD"
-          echo "CONFIGURE_CMD=arch -${ARCH}  $CONFIGURE_CMD" >> $GITHUB_ENV
-          echo "MAKE_CMD=arch -${ARCH} $MAKE_CMD" >> $GITHUB_ENV
-        fi
-        echo "PKGMGR_CMD=$PKGMGR_CMD" >> $GITHUB_ENV
-      if: runner.os == 'macOS'
+      # macOS based github runners starting with macos-14 only run on the arm64
+      # architecture.  To generate x86_64 based executable, the arch -x86_64
+      # command is needed before any brew commands, make, and install to run
+      # as x86_64 via Rosetta2.
+      - name: Check cross-compile environment (macOS)
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          SYSARCH=$(/usr/bin/uname -m)
+          PKGMGR_CMD='brew'
+          if [ "$SYSARCH" = "$ARCH" ]; then
+            # this is a cross-compile
+            PKGMGR_CMD="arch -${ARCH} $PKGMGR_CMD"
+            echo "CONFIGURE_CMD=arch -${ARCH}  $CONFIGURE_CMD" >> $GITHUB_ENV
+            echo "MAKE_CMD=arch -${ARCH} $MAKE_CMD" >> $GITHUB_ENV
+          fi
+          echo "PKGMGR_CMD=$PKGMGR_CMD" >> $GITHUB_ENV
+        if: runner.os == 'macOS'
 
-    # N.B. These dependencies are for the master branch. Unlike the ansible playlists they do not include old dependencies that may
-    # be required for older versions. The list is intended to provide as much code coverage as possible (i.e. enable as many options as possible)
-    - name: Install core dependencies (linux)
-      run: |
-        sudo apt update
-        sudo apt install ccache qt5-qmake qtscript5-dev nasm libsystemd-dev libfreetype6-dev libmp3lame-dev libx264-dev libx265-dev libxrandr-dev libxml2-dev
-        sudo apt install libavahi-compat-libdnssd-dev libasound2-dev liblzo2-dev libhdhomerun-dev libsamplerate0-dev libva-dev libdrm-dev libvdpau-dev
-        sudo apt install libass-dev libpulse-dev libcec-dev libssl-dev libtag1-dev libbluray-dev libbluray-bdj libgnutls28-dev libqt5webkit5-dev
-        sudo apt install libvpx-dev python3-mysqldb python3-lxml python3-setuptools libdbi-perl libdbd-mysql-perl libnet-upnp-perl
-        sudo apt install libio-socket-inet6-perl libxml-simple-perl libqt5sql5-mysql libwayland-dev qtbase5-private-dev libzip-dev libsoundtouch-dev
-      if: runner.os == 'Linux'
+      # N.B. These dependencies are for the master branch. Unlike the ansible
+      # playlists they do not include old dependencies that may be required for
+      # older versions. The list is intended to provide as much code coverage as
+      # possible (i.e. enable as many options as possible)
+      - name: Install core dependencies (linux)
+        run: |
+          sudo apt update
+          sudo apt install ccache qt5-qmake qtscript5-dev nasm libsystemd-dev \
+            libfreetype6-dev libmp3lame-dev libx264-dev libx265-dev \
+            libxrandr-dev libxml2-dev libavahi-compat-libdnssd-dev \
+            libasound2-dev liblzo2-dev libhdhomerun-dev libsamplerate0-dev \
+            libva-dev libdrm-dev libvdpau-dev libass-dev libpulse-dev \
+            libcec-dev libssl-dev libtag1-dev libbluray-dev libbluray-bdj \
+            libgnutls28-dev libqt5webkit5-dev libvpx-dev python3-mysqldb \
+            python3-lxml python3-setuptools libdbi-perl libdbd-mysql-perl \
+            libnet-upnp-perl libio-socket-inet6-perl libxml-simple-perl \
+            libqt5sql5-mysql libwayland-dev qtbase5-private-dev libzip-dev \
+            libsoundtouch-dev
+        if: runner.os == 'Linux'
 
-    - name: Install core dependencies (macOS)
-      env:
-        OS_VERS: ${{ matrix.os }}
-      run: |
-        ${PKGMGR_CMD} install pkg-config ccache qt5 nasm libsamplerate taglib lzo libcec libbluray libass libhdhomerun dav1d x264 x265 libvpx openssl sound-touch lame
-        ${PKGMGR_CMD} install freetype libass libiconv libxml2 libzip XviD zlib
-        ${PKGMGR_CMD} install pyenv-virtualenv python-lxml  python-requests python-setuptools
-        ${PKGMGR_CMD} link qt5 --force
-        # macos-14 updated the linker and needs to be run in "classic" mode
-        case $OS_VERS in
-          macos-14)
-            LDFLAGS="-Wl,-ld_classic" 
-          ;;
-        esac
-        # homebrew uses different prefixes on x86_64 and arm64, find the correct one and setup the correct build variables
-        HB_PREFIX=$(${PKGMGR_CMD} --prefix)
-        echo "C_INCLUDE_PATH=$HB_PREFIX/include:$C_INCLUDE_PATH" >> $GITHUB_ENV
-        echo "CPLUS_INCLUDE_PATH=$HB_PREFIX/include:$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
-        echo "LDFLAGS=-L$HB_PREFIX/lib $LDFLAGS" >> $GITHUB_ENV
-        echo "LIBRARY_PATH=$HB_PREFIX/lib:$LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=$HB_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-      if: runner.os == 'macOS'
+      - name: Install core dependencies (macOS)
+        env:
+          OS_VERS: ${{ matrix.os }}
+        run: |
+          brew update
+          ${PKGMGR_CMD} install pkg-config ccache qt5 nasm libsamplerate taglib\
+            lzo libcec libbluray libass libhdhomerun dav1d x264 x265 libvpx \
+            openssl sound-touch lame freetype libass libiconv libxml2 libzip \
+            XviD zlib pyenv-virtualenv python-lxml  python-requests \
+            python-setuptools
+          ${PKGMGR_CMD} link qt5 --force
+          # macos-14 updated the linker and needs to be run in "classic" mode
+          case $OS_VERS in
+            macos-14)
+              LDFLAGS="-Wl,-ld_classic"
+            ;;
+          esac
+          # homebrew uses different prefixes on x86_64 and arm64, find the
+          #  correct one and setup the correct build variables
+          HB_PREFIX=$(${PKGMGR_CMD} --prefix)
+          C_INCLUDE_PATH=$HB_PREFIX/include:$C_INCLUDE_PATH
+          echo "C_INCLUDE_PATH=$C_INCLUDE_PATH" >> $GITHUB_ENV
+          CPLUS_INCLUDE_PATH=$HB_PREFIX/include:$CPLUS_INCLUDE_PATH
+          echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
+          LDFLAGS="-L$HB_PREFIX/lib $LDFLAGS"
+          echo "LDFLAGS=$LDFLAGS" >> $GITHUB_ENV
+          LIBRARY_PATH=$HB_PREFIX/lib:$LIBRARY_PATH
+          echo "LIBRARY_PATH=$LIBRARY_PATH" >> $GITHUB_ENV
+          PKG_CONFIG_PATH=$HB_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH
+          echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        if: runner.os == 'macOS'
 
-    - name: ccache statistics [pre]
-      run: |
-        ccache -sV
+      - name: ccache statistics [pre]
+        run: |
+          ccache -sV
 
-    - name: Configure core
-      working-directory: ./mythtv
-      run: ${CONFIGURE_CMD} $MYTHTV_CONFIG --enable-libmp3lame --enable-libvpx --enable-libx264 --enable-libx265 --enable-bdjava --enable-vulkan
+      - name: Configure core
+        working-directory: ./mythtv
+        run: ${CONFIGURE_CMD} $MYTHTV_CONFIG --enable-libmp3lame --enable-libvpx
+             --enable-libx264 --enable-libx265 --enable-bdjava --enable-vulkan
 
-    - name: Make core
-      working-directory: ./mythtv
-      run: ${MAKE_CMD} all_no_test -j4
+      - name: Make core
+        working-directory: ./mythtv
+        run: ${MAKE_CMD} all_no_test -j4
 
-    - name: Install core
-      working-directory: ./mythtv
-      run: ${MAKE_CMD} install
+      - name: Install core
+        working-directory: ./mythtv
+        run: ${MAKE_CMD} install
 
-    # QTest requires a QT SQL plugin - but there are currently none available via brew on macOS
-    - name: Unit test core
-      working-directory: ./mythtv
-      run: ${MAKE_CMD} test
-      if: runner.os == 'Linux'
+      # QTest requires a QT SQL plugin - but there are currently none available
+      # via brew on macOS
+      - name: Unit test core
+        working-directory: ./mythtv
+        run: ${MAKE_CMD} test
+        if: runner.os == 'Linux'
 
-    - name: Install plugin dependencies (linux)
-      run: sudo apt install libvorbis-dev libflac++-dev libminizip-dev libcdio-dev libcdio-paranoia-dev python3-pycurl
-           libxml-xpath-perl libdate-manip-perl libdatetime-format-iso8601-perl libsoap-lite-perl libjson-perl libimage-size-perl
-      if: runner.os == 'Linux'
+      - name: Install plugin dependencies (linux)
+        run: sudo apt install libvorbis-dev libflac++-dev libminizip-dev
+             libcdio-dev libcdio-paranoia-dev python3-pycurl libxml-xpath-perl
+             libdate-manip-perl libdatetime-format-iso8601-perl
+             libsoap-lite-perl libjson-perl libimage-size-perl
+        if: runner.os == 'Linux'
 
-    - name: Install plugin dependencies (ubuntu-20.04)
-      run: sudo apt install python3-oauth
-      if: matrix.os == 'ubuntu-20.04'
+      - name: Install plugin dependencies (ubuntu-20.04)
+        run: sudo apt install python3-oauth
+        if: matrix.os == 'ubuntu-20.04'
 
-    - name: Install plugin dependencies (ubuntu-22.04)
-      run: sudo apt install python3-oauthlib
-      if: matrix.os == 'ubuntu-22.04'
+      - name: Install plugin dependencies (ubuntu-22.04)
+        run: sudo apt install python3-oauthlib
+        if: matrix.os == 'ubuntu-22.04'
 
-    - name: Install plugin dependencies (macOS)
-      run: ${PKGMGR_CMD} install minizip flac libvorbis libcdio python-pycurl python-oauthlib
-      if: runner.os == 'macOS'
+      - name: Install plugin dependencies (macOS)
+        run: ${PKGMGR_CMD} install minizip flac libvorbis libcdio python-pycurl
+             python-oauthlib
+        if: runner.os == 'macOS'
 
-    - name: Configure plugins
-      working-directory: ./mythplugins
-      run: ${CONFIGURE_CMD} $MYTHTV_CONFIG
+      - name: Configure plugins
+        working-directory: ./mythplugins
+        run: ${CONFIGURE_CMD} $MYTHTV_CONFIG
 
-    - name: Make plugins
-      working-directory: ./mythplugins
-      run: ${MAKE_CMD} -j4
+      - name: Make plugins
+        working-directory: ./mythplugins
+        run: ${MAKE_CMD} -j4
 
-    - name: ccache statistics [post]
-      run: |
-        ccache -sV
+      - name: ccache statistics [post]
+        run: |
+          ccache -sV

--- a/.github/workflows/buildmaster.yml
+++ b/.github/workflows/buildmaster.yml
@@ -11,13 +11,23 @@ jobs:
     name: build
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-12', 'macos-13']
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-12', 'macos-13', 'macos-14']
+        arch: ['x86_64', 'arm64']
         cc: ['gcc', 'clang']
         include:
           - cc: 'gcc'
             cxx: 'g++'
           - cc: 'clang'
             cxx: 'clang++'
+        exclude:
+          - os: 'ubuntu-20.04'
+            arch: 'arm64'
+          - os: 'ubuntu-22.04'
+            arch: 'arm64'
+          - os: 'macos-12'
+            arch: 'arm64'
+          - os: 'macos-13'
+            arch: 'arm64'
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -29,6 +39,9 @@ jobs:
       run: |
         echo "MYTHTV_CONFIG=--prefix=${{ github.workspace }}/build/install --cc=${{ matrix.cc }} --cxx=${{ matrix.cxx }}" >> $GITHUB_ENV
         echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+        # As some OSes can cross-compile, establish defaule configrue/make commands which can be overided as appropriate
+        echo "CONFIGURE_CMD=./configure" >> $GITHUB_ENV
+        echo "MAKE_CMD=make" >> $GITHUB_ENV
 
     # GitHub caches are immutable, so to update a cache, use a unique key with a
     # prefixed restore-key.  GitHub will rotate the caches within their 10 GB
@@ -39,6 +52,23 @@ jobs:
         path: ~/.ccache
         key: ${{ matrix.os }}-${{ matrix.cc }}-ccache-${{ github.sha }}
         restore-keys: ${{ matrix.os }}-${{ matrix.cc }}-ccache
+
+    # macOS based github runners starting with macos-14 only run on the arm64 architecture.  To generate x86_64 based executable, the
+    # arch -x86_64 command is needed before any brew commands, make, and install to run as x86_64 via Rosetta2.
+    - name: Check cross-compile environment (macOS)
+      env:
+        ARCH: ${{ matrix.arch }}
+      run: |
+        SYSARCH=$(/usr/bin/uname -m)
+        PKGMGR_CMD='brew'
+        if [ "$SYSARCH" = "$ARCH" ]; then
+          # this is a cross-compile
+          PKGMGR_CMD="arch -${ARCH} $PKGMGR_CMD"
+          echo "CONFIGURE_CMD=arch -${ARCH}  $CONFIGURE_CMD" >> $GITHUB_ENV
+          echo "MAKE_CMD=arch -${ARCH} $MAKE_CMD" >> $GITHUB_ENV
+        fi
+        echo "PKGMGR_CMD=$PKGMGR_CMD" >> $GITHUB_ENV
+      if: runner.os == 'macOS'
 
     # N.B. These dependencies are for the master branch. Unlike the ansible playlists they do not include old dependencies that may
     # be required for older versions. The list is intended to provide as much code coverage as possible (i.e. enable as many options as possible)
@@ -53,10 +83,26 @@ jobs:
       if: runner.os == 'Linux'
 
     - name: Install core dependencies (macOS)
+      env:
+        OS_VERS: ${{ matrix.os }}
       run: |
-        brew install pkg-config ccache qt5 nasm libsamplerate taglib lzo libcec libbluray libass libhdhomerun dav1d x264 x265 libvpx openssl sound-touch lame
-        brew link qt5 --force
-        echo "MYTHTV_CONFIG=$MYTHTV_CONFIG --extra-cxxflags=-I/usr/local/include --extra-ldflags=-L/usr/local/lib" >> $GITHUB_ENV
+        ${PKGMGR_CMD} install pkg-config ccache qt5 nasm libsamplerate taglib lzo libcec libbluray libass libhdhomerun dav1d x264 x265 libvpx openssl sound-touch lame
+        ${PKGMGR_CMD} install freetype libass libiconv libxml2 libzip XviD zlib
+        ${PKGMGR_CMD} install pyenv-virtualenv python-lxml  python-requests python-setuptools
+        ${PKGMGR_CMD} link qt5 --force
+        # macos-14 updated the linker and needs to be run in "classic" mode
+        case $OS_VERS in
+          macos-14)
+            LDFLAGS="-Wl,-ld_classic" 
+          ;;
+        esac
+        # homebrew uses different prefixes on x86_64 and arm64, find the correct one and setup the correct build variables
+        HB_PREFIX=$(${PKGMGR_CMD} --prefix)
+        echo "C_INCLUDE_PATH=$HB_PREFIX/include:$C_INCLUDE_PATH" >> $GITHUB_ENV
+        echo "CPLUS_INCLUDE_PATH=$HB_PREFIX/include:$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
+        echo "LDFLAGS=-L$HB_PREFIX/lib $LDFLAGS" >> $GITHUB_ENV
+        echo "LIBRARY_PATH=$HB_PREFIX/lib:$LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$HB_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
       if: runner.os == 'macOS'
 
     - name: ccache statistics [pre]
@@ -65,20 +111,20 @@ jobs:
 
     - name: Configure core
       working-directory: ./mythtv
-      run: ./configure $MYTHTV_CONFIG --enable-libmp3lame --enable-libvpx --enable-libx264 --enable-libx265 --enable-bdjava --enable-vulkan
+      run: ${CONFIGURE_CMD} $MYTHTV_CONFIG --enable-libmp3lame --enable-libvpx --enable-libx264 --enable-libx265 --enable-bdjava --enable-vulkan
 
     - name: Make core
       working-directory: ./mythtv
-      run: make all_no_test -j4
+      run: ${MAKE_CMD} all_no_test -j4
 
     - name: Install core
       working-directory: ./mythtv
-      run: make install
+      run: ${MAKE_CMD} install
 
     # QTest requires a QT SQL plugin - but there are currently none available via brew on macOS
     - name: Unit test core
       working-directory: ./mythtv
-      run: make test
+      run: ${MAKE_CMD} test
       if: runner.os == 'Linux'
 
     - name: Install plugin dependencies (linux)
@@ -95,16 +141,16 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
 
     - name: Install plugin dependencies (macOS)
-      run: brew install minizip flac libvorbis libcdio
+      run: ${PKGMGR_CMD} install minizip flac libvorbis libcdio python-pycurl python-oauthlib
       if: runner.os == 'macOS'
 
     - name: Configure plugins
       working-directory: ./mythplugins
-      run: ./configure $MYTHTV_CONFIG
+      run: ${CONFIGURE_CMD} $MYTHTV_CONFIG
 
     - name: Make plugins
       working-directory: ./mythplugins
-      run: make -j4
+      run: ${MAKE_CMD} -j4
 
     - name: ccache statistics [post]
       run: |


### PR DESCRIPTION
Updates include:
 - Updates for macos-14 runer which is arm64, but allows compilation on x86_64 via Rosetta 2
 - The addition of a manual workflow trigger (allows a developer to run the CI on a branch other than master)
 - lint clean up based on yamllint


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

