### PR TITLE
MythMusic: WaveForm: Fix divide by zero crash on zero track length

### DIFF
--- a/mythplugins/mythmusic/mythmusic/streamview.cpp
+++ b/mythplugins/mythmusic/mythmusic/streamview.cpp
@@ -77,6 +77,7 @@ bool StreamView::Create(void)
 void StreamView::ShowMenu(void)
 {
     auto *menu = new MythMenu(tr("Stream Actions"), this, "mainmenu");
+    menu->AddItemV(MusicCommon::tr("Fullscreen Visualizer"), QVariant::fromValue((int)MV_VISUALIZER));
     menu->AddItem(tr("Add Stream"));
 
     if (m_streamList->GetItemCurrent())
@@ -85,7 +86,6 @@ void StreamView::ShowMenu(void)
         menu->AddItem(tr("Remove Stream"));
     }
 
-    menu->AddItemV(MusicCommon::tr("Fullscreen Visualizer"), QVariant::fromValue((int)MV_VISUALIZER));
     menu->AddItemV(MusicCommon::tr("Lyrics"), QVariant::fromValue((int)MV_LYRICS));
 
     menu->AddItem(tr("More Options"), nullptr, createSubMenu());

--- a/mythplugins/mythmusic/mythmusic/visualize.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualize.cpp
@@ -652,6 +652,15 @@ void WaveForm::saveload(MusicMetadata *meta)
         // but this is now compensated for by drawing wider "pixels"
         m_duration = m_stream ? 60000 : meta->Length().count(); // millisecs
     }
+
+    // A track length of zero milliseconds is most likely wrong but
+    // can accidentally happen.  Rather than crash on divide by zero
+    // later, let's pretend it is 1 minute long.  If the file plays
+    // successfully, then it should record the correct track length
+    // and be more correct next time.
+    if (m_duration <= 0)
+        m_duration = 60000;
+
     if (s_image.isNull())
     {
         s_image = QImage(m_wfsize.width(), m_wfsize.height(), QImage::Format_RGB32);


### PR DESCRIPTION
A track length of zero milliseconds is most likely wrong but can accidentally happen.  Rather than crash on divide by zero
later, let's pretend it is 1 minute long.  If the file plays successfully, then it should record the correct track length
and be more correct next time.

Also push fullscreen vis to the top of the stream menu since it is used more than add/edit/remove
