### PR TITLE
Support system distro version of exiv2 0.28 with includes C++17 support

### DIFF
--- a/cmake/externallibs/FindOrBuildExiv2.cmake
+++ b/cmake/externallibs/FindOrBuildExiv2.cmake
@@ -13,13 +13,16 @@
 #
 # A comment from 2023-01-18 in a github Exiv issue #2406 discussing releases:
 #
-# Dear folks, Exiv2 v0.27.6 has been released!  I'll start working on the v1.0.0
-# major release based on 9ca161d.
+#   Dear folks, Exiv2 v0.27.6 has been released!  I'll start working on the v1.0.0
+#   major release based on 9ca161d.
+#
+# However, Exiv2 v0.28 was released with C++17 support included, so we can use
+# that version if the distro includes it.
 #
 function(find_or_build_exiv2)
-  pkg_check_modules(EXIV2 "exiv2>=1.0" QUIET IMPORTED_TARGET)
+  pkg_check_modules(EXIV2 "exiv2>=0.28" QUIET IMPORTED_TARGET)
   if(NOT EXIV2_FOUND)
-    pkg_check_modules(EXIV2 "mythexiv2>=0.99" QUIET IMPORTED_TARGET)
+    pkg_check_modules(EXIV2 "mythexiv2>=0.28" QUIET IMPORTED_TARGET)
   endif()
   if(TARGET PkgConfig::EXIV2)
     message(STATUS "Found Exiv2 ${EXIV2_VERSION} ${EXIV2_LINK_LIBRARIES}")

--- a/mythtv/cmake/MythFindPackages.cmake
+++ b/mythtv/cmake/MythFindPackages.cmake
@@ -60,7 +60,7 @@ pkg_check_modules(LIBUDFREAD "libudfread>=1.1.1" REQUIRED IMPORTED_TARGET)
 #
 pkg_check_modules(EXIV2 "exiv2>=0.28" QUIET IMPORTED_TARGET)
 if(NOT EXIV2_FOUND)
-  pkg_check_modules(EXIV2 "mythexiv2>=0.28" QUIET IMPORTED_TARGET)
+  pkg_check_modules(EXIV2 "mythexiv2>=0.28" REQUIRED IMPORTED_TARGET)
 endif()
 
 #

--- a/mythtv/cmake/MythFindPackages.cmake
+++ b/mythtv/cmake/MythFindPackages.cmake
@@ -55,10 +55,13 @@ endif()
 pkg_check_modules(LIBUDFREAD "libudfread>=1.1.1" REQUIRED IMPORTED_TARGET)
 
 #
-# Find an exiv2 that has c++17 support.  The current version number is 0.28 and
-# the c++17 based version is supposed to be 1.0.
+# Find an exiv2 that has c++17 support.  The current version number is 0.27 and
+# the c++17 based version is supposed to be 1.0 but is included in 0.28
 #
-pkg_check_modules(EXIV2 "mythexiv2>=0.99" REQUIRED IMPORTED_TARGET)
+pkg_check_modules(EXIV2 "exiv2>=0.28" QUIET IMPORTED_TARGET)
+if(NOT EXIV2_FOUND)
+  pkg_check_modules(EXIV2 "mythexiv2>=0.28" QUIET IMPORTED_TARGET)
+endif()
 
 #
 # If not provided by the system, this is currently built as part of mythtv (not

--- a/mythtv/configure
+++ b/mythtv/configure
@@ -5435,7 +5435,7 @@ enabled libudev && check_lib udev libudev.h udev_new -ludev || disable libudev
 
 # libexiv2
 if enabled system_libexiv2 ; then
-    if $(pkg-config --atleast-version="0.99" exiv2); then
+    if $(pkg-config --atleast-version="0.28" exiv2); then
         use_pkg_config exiv2 exiv2 exiv2/exiv2.hpp versionNumber
     elif [ $target_os != "android" ] ; then
         disable system_libexiv2

--- a/mythtv/external/external.pro
+++ b/mythtv/external/external.pro
@@ -6,7 +6,7 @@ win32-msvc* {
 
 # Libraries without dependencies
 
-!using_system_exiv2: SUBDIRS += libexiv2
+!using_system_libexiv2: SUBDIRS += libexiv2
 !using_system_libbluray: SUBDIRS += libmythbluray
 SUBDIRS += libmythdvdnav
 !using_system_libudfread: SUBDIRS += libudfread

--- a/mythtv/libs/libmythmetadata/test/test_lyrics/test_lyrics.pro
+++ b/mythtv/libs/libmythmetadata/test/test_lyrics/test_lyrics.pro
@@ -29,7 +29,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_system_exiv2 {
+using_system_libexiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_metadatagrabber/test_metadatagrabber.pro
+++ b/mythtv/libs/libmythmetadata/test/test_metadatagrabber/test_metadatagrabber.pro
@@ -27,7 +27,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_system_exiv2 {
+using_system_libexiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_musicmetadata/test_musicmetadata.pro
+++ b/mythtv/libs/libmythmetadata/test/test_musicmetadata/test_musicmetadata.pro
@@ -27,7 +27,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_system_exiv2 {
+using_system_libexiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_musicutils/test_musicutils.pro
+++ b/mythtv/libs/libmythmetadata/test/test_musicutils/test_musicutils.pro
@@ -27,7 +27,7 @@ LIBS += -L../../../../external/FFmpeg/libpostproc -lmythpostproc
 LIBS += -L../.. -lmythmetadata-$$LIBVERSION
 
 
-using_system_exiv2 {
+using_system_libexiv2 {
 LIBS += -lexiv2
 } else {
 LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28

--- a/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.pro
+++ b/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.pro
@@ -41,7 +41,7 @@ QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../libmythservicecontracts
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../libmythtv
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../libmythfreemheg
 
-!using_system_libexiv {
+!using_system_libexiv2 {
     LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28
     QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/libexiv2 -lexpat
     freebsd: LIBS += -lprocstat -liconv

--- a/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.pro
+++ b/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.pro
@@ -47,7 +47,7 @@ QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libpostproc
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libswresample
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../
 
-!using_system_libexiv {
+!using_system_libexiv2 {
     LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28
     QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/libexiv2 -lexpat
     freebsd: LIBS += -lprocstat -liconv

--- a/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.pro
+++ b/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.pro
@@ -48,7 +48,7 @@ QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libpostproc
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/FFmpeg/libswresample
 QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../
 
-!using_system_libexiv {
+!using_system_libexiv2 {
     LIBS += -L../../../../external/libexiv2 -lmythexiv2-0.28
     QMAKE_LFLAGS += -Wl,$$_RPATH_$(PWD)/../../../../external/libexiv2 -lexpat
     freebsd: LIBS += -lprocstat -liconv


### PR DESCRIPTION
Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

---

While initially C++17 support was not expected to be available until version 1.0, for various organizational reasons 0.28 includes the needed support.

There are currently few distros with 0.28.

NOTE: Compile tested only