### PR TITLE
Fix detection of libglslang in configure

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -6134,7 +6134,16 @@ case $ID in
        esac
 esac
 
-enabled vulkan && enabled libglslang && require_cpp libglslang glslang/SPIRV/GlslangToSpv.h "glslang::TIntermediate*" -lglslang ${EXTRA_GLSLANG_LIBS:-} -lOSDependent -lHLSL -lOGLCompiler -lSPVRemapper -lSPIRV -lSPIRV-Tools-opt -lSPIRV-Tools -lpthread
+if enabled vulkan && enabled libglslang ; then
+    # Debian sid no longer ships the OSDependent and HLSL libraries,
+    # but vulkan support on that platform compiles fine without them.
+    # Test to see if these libraries are present, and if not, test
+    # again to see if the compile works without them.
+    GLSLANG_LIBS="${EXTRA_GLSLANG_LIBS:-} -lOSDependent -lSPVRemapper -lSPIRV -lSPIRV-Tools-opt -lSPIRV-Tools -lpthread"
+    check_lib_cpp glslang/SPIRV/GlslangToSpv.h "glslang::TIntermediate*" -lglslang ${GLSLANG_LIBS} -lHLSL -lOGLCompiler \
+    || check_lib_cpp glslang/SPIRV/GlslangToSpv.h "glslang::TIntermediate*" -lglslang ${GLSLANG_LIBS}  \
+    || die "ERROR: libglslang (or dependent) library not found"
+fi
 
 # Qt private headers are required for wayland extras and some DRM functionality on linux
 if enabled qtprivateheaders ; then


### PR DESCRIPTION
Detection of libglslang by the configure script fails on Fedora 39 for MythTV version 34. Detection in master works good, so this is the backport of that code into the configure of MythTV version 34.
