### PR TITLE
Workflows:  Provide the cache clean action the permission it needs

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -9,7 +9,8 @@
 # useful.  Delete them.
 #
 # Code copied from:  https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
-# 
+# modified based on: https://github.com/actions/gh-actions-cache/issues/85
+#
 
 name: Cleanup caches after PR closed
 
@@ -21,6 +22,8 @@ on:                # yamllint disable-line rule:truthy
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cleanup
         run: |


### PR DESCRIPTION
Provide the cache clean action the permission it needs

The github workflow to clean up PR caches failed with:
  Error: Resource not accessible by integration

The issue is that the gh-actions-cleanup requires the permission to delete caches, per:
https://github.com/actions/gh-actions-cache/issues/85



Thank you for contributing to MythTV!



Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

