### PR TITLE
Support USB HID media control keys now common on remotes and keyboards.

### DIFF
--- a/mythplugins/mythbrowser/mythbrowser/libmythbrowser.cpp
+++ b/mythplugins/mythbrowser/mythbrowser/libmythbrowser.cpp
@@ -103,7 +103,7 @@ static void runHomepage()
 static void setupKeys(void)
 {
     REG_KEY("Browser", "NEXTTAB", QT_TRANSLATE_NOOP("MythControls",
-        "Move to next browser tab"), "P");
+        "Move to next browser tab"), "P,Media Play");
     REG_KEY("Browser", "PREVTAB", QT_TRANSLATE_NOOP("MythControls",
         "Move to previous browser tab"), "");
 

--- a/mythplugins/mythgame/mythgame/mythgame.cpp
+++ b/mythplugins/mythgame/mythgame/mythgame.cpp
@@ -115,7 +115,7 @@ static void setupKeys(void)
     REG_KEY("Game", "TOGGLEFAV", QT_TRANSLATE_NOOP("MythControls",
         "Toggle the current game as a favorite"), "?,/");
     REG_KEY("Game", "INCSEARCH", QT_TRANSLATE_NOOP("MythControls",
-        "Show incremental search dialog"), "Ctrl+S");
+        "Show incremental search dialog"), "Ctrl+S,Search");
     REG_KEY("Game", "INCSEARCHNEXT", QT_TRANSLATE_NOOP("MythControls",
         "Incremental search find next match"), "Ctrl+N");
     REG_KEY("Game","DOWNLOADDATA", QT_TRANSLATE_NOOP("MythControls",

--- a/mythplugins/mythmusic/mythmusic/mythmusic.cpp
+++ b/mythplugins/mythmusic/mythmusic/mythmusic.cpp
@@ -799,19 +799,19 @@ static void setupKeys(void)
         "", "", showMiniPlayer, false);
 
     REG_KEY("Music", "NEXTTRACK",  QT_TRANSLATE_NOOP("MythControls",
-        "Move to the next track"),     ">,.,Z,End");
+        "Move to the next track"),     ">,.,Z,End,Media Next");
     REG_KEY("Music", "PREVTRACK",  QT_TRANSLATE_NOOP("MythControls",
-        "Move to the previous track"), ",,<,Q,Home");
+        "Move to the previous track"), ",,<,Q,Home,Media Previous");
     REG_KEY("Music", "FFWD",       QT_TRANSLATE_NOOP("MythControls",
-        "Fast forward"),               "PgDown");
+        "Fast forward"),               "PgDown,Ctrl+F,Media Fast Forward");
     REG_KEY("Music", "RWND",       QT_TRANSLATE_NOOP("MythControls",
-        "Rewind"),                     "PgUp");
+        "Rewind"),                     "PgUp,Ctrl+B,Media Rewind");
     REG_KEY("Music", "PAUSE",      QT_TRANSLATE_NOOP("MythControls",
-        "Pause/Start playback"),       "P");
+        "Pause/Start playback"),       "P,Media Play");
     REG_KEY("Music", "PLAY",       QT_TRANSLATE_NOOP("MythControls",
         "Start playback"),             "");
     REG_KEY("Music", "STOP",       QT_TRANSLATE_NOOP("MythControls",
-        "Stop playback"),              "O");
+        "Stop playback"),              "O,Media Stop");
     REG_KEY("Music", "VOLUMEDOWN", QT_TRANSLATE_NOOP("MythControls",
         "Volume down"),       "[,{,F10,Volume Down");
     REG_KEY("Music", "VOLUMEUP",   QT_TRANSLATE_NOOP("MythControls",

--- a/mythplugins/mythnews/mythnews/libmythnews.cpp
+++ b/mythplugins/mythnews/mythnews/libmythnews.cpp
@@ -43,9 +43,9 @@ static void setupKeys(void)
         "RSS News feed reader"), "", runNews);
 
     REG_KEY("News", "RETRIEVENEWS",
-        QT_TRANSLATE_NOOP("MythControls", "Update news items"), "I");
+        QT_TRANSLATE_NOOP("MythControls", "Update news items"), "I,Home Page");
     REG_KEY("News", "FORCERETRIEVE",
-        QT_TRANSLATE_NOOP("MythControls", "Force update news items"), "M");
+        QT_TRANSLATE_NOOP("MythControls", "Force update news items"), "M,Menu");
     REG_KEY("News", "CANCEL",
         QT_TRANSLATE_NOOP("MythControls", "Cancel news item updating"), "C");
 }

--- a/mythplugins/mythweather/mythweather/mythweather.cpp
+++ b/mythplugins/mythweather/mythweather/mythweather.cpp
@@ -47,7 +47,7 @@ static void setupKeys()
     REG_JUMP("MythWeather", QT_TRANSLATE_NOOP("MythControls",
         "Weather forecasts"), "", runWeather);
     REG_KEY("Weather", "PAUSE", QT_TRANSLATE_NOOP("MythControls",
-        "Pause current page"), "P");
+        "Pause current page"), "P,Media Play");
     REG_KEY("Weather", "SEARCH", QT_TRANSLATE_NOOP("MythControls",
         "Search List"), "/");
     REG_KEY("Weather", "NEXTSEARCH", QT_TRANSLATE_NOOP("MythControls",

--- a/mythtv/keybindings.txt
+++ b/mythtv/keybindings.txt
@@ -1,3 +1,35 @@
+Modern Remote Control Media Keys, MythTV 35+
+--------------------------------------------
+
+In addition to the below standard keyboard keys, modern USB HID remote
+control media keys should also work as expected in most contexts.
+They simulate the historical standard "Like" key:
+
+Like    Modern USB HID Key      Description                     Also
+====    ==================      ===========                     ====
+M       Menu                    MENU of options per context     Ctrl+M
+I       Home Page               INFORMATION per context         Ctrl+I
+Esc     Back                    ESCAPE BACK to prior screen
+Ctrl+S  Search                  incremental SEARCH of a list
+P       Media Play              PLAY or PAUSE audio / video
+O	Media Stop		STOP audio playback (in Music)
+<       Media Rewind            REWIND, move left, zoom out     Ctrl+B
+>       Media Fast Forward      FORWARD, move right, zoom in    Ctrl+F
+Home    Media Previous          PREVIOUS commercial, day, song
+End     Media Next              NEXT commercial, day, song...
+|       Volume Mute             Toggle mute                     F9
+[       Volume Down             Decrease volume                 F10
+]       Volume Up               Increase volume                 F11
+
+New version 35+ installs should get bindings for these special keys by
+default.  In existing installs the keybindings table of the database
+may still apply in which case the above keys may need mapped manually
+as recommended at:
+
+https://www.mythtv.org/wiki/MX3_Air_Mouse_Remote#Edit_Keys
+
+------------------------------------------------------------
+
 Various keys and their actions:
 
 mythfrontend
@@ -61,7 +93,7 @@ Watching TV or a recording
 - | or F9     Toggle mute
 - [ or F10    Decrease volume
 - ] or F11    Increase volume
-- Ctrl+B      Jump to the beginning of the recording / ringbuffer.
+- Ctrl+A      Jump to the beginning of the recording / ringbuffer.
 - < starts sticky rewind mode
     If a jump amount is entered, jump to that position.
 - > starts sticky fast forward mode

--- a/mythtv/libs/libmythtv/tv_play.cpp
+++ b/mythtv/libs/libmythtv/tv_play.cpp
@@ -457,19 +457,19 @@ void TV::SetFuncPtr(const char* Name, void* Pointer)
 void TV::InitKeys()
 {
     REG_KEY("TV Frontend", ACTION_PLAYBACK, QT_TRANSLATE_NOOP("MythControls",
-            "Play Program"), "P");
+            "Play Program"), "P,Media Play");
     REG_KEY("TV Frontend", ACTION_STOP, QT_TRANSLATE_NOOP("MythControls",
             "Stop Program"), "");
     REG_KEY("TV Frontend", ACTION_TOGGLERECORD, QT_TRANSLATE_NOOP("MythControls",
             "Toggle recording status of current program"), "R");
     REG_KEY("TV Frontend", ACTION_DAYLEFT, QT_TRANSLATE_NOOP("MythControls",
-            "Page the program guide back one day"), "Home");
+            "Page the program guide back one day"), "Home,Media Previous");
     REG_KEY("TV Frontend", ACTION_DAYRIGHT, QT_TRANSLATE_NOOP("MythControls",
-            "Page the program guide forward one day"), "End");
+            "Page the program guide forward one day"), "End,Media Next");
     REG_KEY("TV Frontend", ACTION_PAGELEFT, QT_TRANSLATE_NOOP("MythControls",
-            "Page the program guide left"), ",,<");
+            "Page the program guide left"), ",,<,Ctrl+B,Media Rewind");
     REG_KEY("TV Frontend", ACTION_PAGERIGHT, QT_TRANSLATE_NOOP("MythControls",
-            "Page the program guide right"), ">,.");
+            "Page the program guide right"), ">,.,Ctrl+F,Media Fast Forward");
     REG_KEY("TV Frontend", ACTION_TOGGLEFAV, QT_TRANSLATE_NOOP("MythControls",
             "Toggle the current channel as a favorite"), "?");
     REG_KEY("TV Frontend", ACTION_TOGGLEPGORDER, QT_TRANSLATE_NOOP("MythControls",
@@ -547,13 +547,13 @@ void TV::InitKeys()
     REG_KEY("TV Playback", ACTION_TOGGLEBOOKMARK, QT_TRANSLATE_NOOP("MythControls",
             "Toggle Bookmark"), togBkmKeys);
     REG_KEY("TV Playback", "BACK", QT_TRANSLATE_NOOP("MythControls",
-            "Exit or return to DVD menu"), "Esc");
+            "Exit or return to DVD menu"), "Esc,Back");
     REG_KEY("TV Playback", ACTION_MENUCOMPACT, QT_TRANSLATE_NOOP("MythControls",
             "Playback Compact Menu"), "Alt+M");
     REG_KEY("TV Playback", ACTION_CLEAROSD, QT_TRANSLATE_NOOP("MythControls",
             "Clear OSD"), "Backspace");
     REG_KEY("TV Playback", ACTION_PAUSE, QT_TRANSLATE_NOOP("MythControls",
-            "Pause"), "P,Space");
+            "Pause"), "P,Space,Media Play");
     REG_KEY("TV Playback", ACTION_SEEKFFWD, QT_TRANSLATE_NOOP("MythControls",
             "Fast Forward"), "Right");
     REG_KEY("TV Playback", ACTION_SEEKRWND, QT_TRANSLATE_NOOP("MythControls",
@@ -579,9 +579,9 @@ void TV::InitKeys()
     REG_KEY("TV Playback", ACTION_JUMPBKMRK, QT_TRANSLATE_NOOP("MythControls",
             "Jump to bookmark"), "K");
     REG_KEY("TV Playback", "FFWDSTICKY", QT_TRANSLATE_NOOP("MythControls",
-            "Fast Forward (Sticky) or Forward one second while paused"), ">,.");
+            "Fast Forward (Sticky) or Forward one second while paused"), ">,.,Ctrl+F,Media Fast Forward");
     REG_KEY("TV Playback", "RWNDSTICKY", QT_TRANSLATE_NOOP("MythControls",
-            "Rewind (Sticky) or Rewind one second while paused"), ",,<");
+            "Rewind (Sticky) or Rewind one second while paused"), ",,<,Ctrl+B,Media Rewind");
     REG_KEY("TV Playback", "NEXTSOURCE", QT_TRANSLATE_NOOP("MythControls",
             "Next Video Source"), "Y");
     REG_KEY("TV Playback", "PREVSOURCE", QT_TRANSLATE_NOOP("MythControls",
@@ -591,11 +591,11 @@ void TV::InitKeys()
     REG_KEY("TV Playback", "NEXTCARD", QT_TRANSLATE_NOOP("MythControls",
             "Next Card"), "");
     REG_KEY("TV Playback", "SKIPCOMMERCIAL", QT_TRANSLATE_NOOP("MythControls",
-            "Skip Commercial"), "Z,End");
+            "Skip Commercial"), "Z,End,Media Next");
     REG_KEY("TV Playback", "SKIPCOMMBACK", QT_TRANSLATE_NOOP("MythControls",
-            "Skip Commercial (Reverse)"), "Q,Home");
+            "Skip Commercial (Reverse)"), "Q,Home,Media Previous");
     REG_KEY("TV Playback", ACTION_JUMPSTART, QT_TRANSLATE_NOOP("MythControls",
-            "Jump to the start of the recording."), "Ctrl+B");
+            "Jump to the start of the recording."), "Ctrl+A");
     REG_KEY("TV Playback", "TOGGLEBROWSE", QT_TRANSLATE_NOOP("MythControls",
             "Toggle channel browse mode"), "O");
     REG_KEY("TV Playback", ACTION_TOGGLERECORD, QT_TRANSLATE_NOOP("MythControls",
@@ -835,19 +835,19 @@ void TV::InitKeys()
     REG_KEY("TV Editing", ACTION_CLEARMAP,    QT_TRANSLATE_NOOP("MythControls",
             "Clear editing cut points"), "C,Q,Home");
     REG_KEY("TV Editing", ACTION_INVERTMAP,   QT_TRANSLATE_NOOP("MythControls",
-            "Invert Begin/End cut points"),"I");
+            "Invert Begin/End cut points"),"I,Home Page");
     REG_KEY("TV Editing", ACTION_SAVEMAP,     QT_TRANSLATE_NOOP("MythControls",
             "Save cuts"),"");
     REG_KEY("TV Editing", ACTION_LOADCOMMSKIP,QT_TRANSLATE_NOOP("MythControls",
             "Load cuts from detected commercials"), "Z,End");
     REG_KEY("TV Editing", ACTION_NEXTCUT,     QT_TRANSLATE_NOOP("MythControls",
-            "Jump to the next cut point"), "PgDown");
+            "Jump to the next cut point"), "PgDown,Media Next");
     REG_KEY("TV Editing", ACTION_PREVCUT,     QT_TRANSLATE_NOOP("MythControls",
-            "Jump to the previous cut point"), "PgUp");
+            "Jump to the previous cut point"), "PgUp,Media Previous");
     REG_KEY("TV Editing", ACTION_BIGJUMPREW,  QT_TRANSLATE_NOOP("MythControls",
-            "Jump back 10x the normal amount"), ",,<");
+            "Jump back 10x the normal amount"), ",,<,Ctrl+B,Media Rewind");
     REG_KEY("TV Editing", ACTION_BIGJUMPFWD,  QT_TRANSLATE_NOOP("MythControls",
-            "Jump forward 10x the normal amount"), ">,.");
+            "Jump forward 10x the normal amount"), ">,.,Ctrl+F,Media Fast Forward");
     REG_KEY("TV Editing", ACTION_MENUCOMPACT, QT_TRANSLATE_NOOP("MythControls",
             "Cut point editor compact menu"), "Alt+M");
 

--- a/mythtv/libs/libmythui/mythmainwindow.cpp
+++ b/mythtv/libs/libmythui/mythmainwindow.cpp
@@ -808,13 +808,13 @@ void MythMainWindow::InitKeys()
     RegisterKey("Global", "BACKSPACE", QT_TRANSLATE_NOOP("MythControls",
         "Backspace"),       "Backspace");
     RegisterKey("Global", "ESCAPE", QT_TRANSLATE_NOOP("MythControls",
-        "Escape"),                "Esc");
+        "Escape"),                "Esc,Back");
     RegisterKey("Global", "MENU", QT_TRANSLATE_NOOP("MythControls",
-        "Pop-up menu"),             "M,Meta+Enter");
+        "Pop-up menu"),             "M,Meta+Enter,Ctrl+M,Menu");
     RegisterKey("Global", "INFO", QT_TRANSLATE_NOOP("MythControls",
-        "More information"),        "I");
+        "More information"),        "I,Ctrl+I,Home Page");
     RegisterKey("Global", "DELETE", QT_TRANSLATE_NOOP("MythControls",
-        "Delete"),                  "D");
+        "Delete"),                  "D,Ctrl+E");
     RegisterKey("Global", "EDIT", QT_TRANSLATE_NOOP("MythControls",
         "Edit"),                    "E");
     RegisterKey("Global", ACTION_SCREENSHOT, QT_TRANSLATE_NOOP("MythControls",
@@ -834,9 +834,9 @@ void MythMainWindow::InitKeys()
         "Page to bottom of list"),   "");
 
     RegisterKey("Global", "PREVVIEW", QT_TRANSLATE_NOOP("MythControls",
-        "Previous View"),        "Home");
+        "Previous View"),        "Home,Media Previous");
     RegisterKey("Global", "NEXTVIEW", QT_TRANSLATE_NOOP("MythControls",
-        "Next View"),             "End");
+        "Next View"),             "End,Media Next");
 
     RegisterKey("Global", "HELP", QT_TRANSLATE_NOOP("MythControls",
         "Help"),                   "F1");
@@ -856,7 +856,7 @@ void MythMainWindow::InitKeys()
     RegisterKey("Global", "REDO", QT_TRANSLATE_NOOP("MythControls",
         "Redo"), "Ctrl+Y");
     RegisterKey("Global", "SEARCH", QT_TRANSLATE_NOOP("MythControls",
-        "Show incremental search dialog"), "Ctrl+S");
+        "Show incremental search dialog"), "Ctrl+S,Search");
 
     RegisterKey("Global", ACTION_0, QT_TRANSLATE_NOOP("MythControls","0"), "0");
     RegisterKey("Global", ACTION_1, QT_TRANSLATE_NOOP("MythControls","1"), "1");
@@ -897,9 +897,9 @@ void MythMainWindow::InitKeys()
 
     // these are for the html viewer widget (MythUIWebBrowser)
     RegisterKey("Browser", "ZOOMIN",          QT_TRANSLATE_NOOP("MythControls",
-        "Zoom in on browser window"),           ".,>");
+        "Zoom in on browser window"),           ".,>,Ctrl+F,Media Fast Forward");
     RegisterKey("Browser", "ZOOMOUT",         QT_TRANSLATE_NOOP("MythControls",
-        "Zoom out on browser window"),          ",,<");
+        "Zoom out on browser window"),          ",,<,Ctrl+B,Media Rewind");
     RegisterKey("Browser", "TOGGLEINPUT",     QT_TRANSLATE_NOOP("MythControls",
         "Toggle where keyboard input goes to"),  "F1");
 
@@ -935,7 +935,7 @@ void MythMainWindow::InitKeys()
         "Go forward to previous page"),     "F");
 
     RegisterKey("Main Menu",    "EXITPROMPT", QT_TRANSLATE_NOOP("MythControls",
-        "Display System Exit Prompt"),      "Esc");
+        "Display System Exit Prompt"),      "Esc,Back");
     RegisterKey("Main Menu",    "EXIT",       QT_TRANSLATE_NOOP("MythControls",
         "System Exit"),                     "");
     RegisterKey("Main Menu",    "STANDBYMODE",QT_TRANSLATE_NOOP("MythControls",

--- a/mythtv/programs/mythfrontend/mythfrontend.cpp
+++ b/mythtv/programs/mythfrontend/mythfrontend.cpp
@@ -1636,7 +1636,7 @@ static void InitKeys(void)
      REG_KEY("Video","DECPARENT", QT_TRANSLATE_NOOP("MythControls",
          "Decrease Parental Level"), "[,{,F10");
      REG_KEY("Video","INCSEARCH", QT_TRANSLATE_NOOP("MythControls",
-         "Show Incremental Search Dialog"), "Ctrl+S");
+         "Show Incremental Search Dialog"), "Ctrl+S,Search");
      REG_KEY("Video","DOWNLOADDATA", QT_TRANSLATE_NOOP("MythControls",
          "Download metadata for current item"), "W");
      REG_KEY("Video","ITEMDETAIL", QT_TRANSLATE_NOOP("MythControls",
@@ -1644,7 +1644,7 @@ static void InitKeys(void)
 
      // Gallery keybindings
      REG_KEY("Images", "PLAY", QT_TRANSLATE_NOOP("MythControls",
-         "Start/Stop Slideshow"), "P");
+         "Start/Stop Slideshow"), "P,Media Play");
      REG_KEY("Images", "RECURSIVESHOW", QT_TRANSLATE_NOOP("MythControls",
          "Start Recursive Slideshow"), "R");
      REG_KEY("Images", "ROTRIGHT", QT_TRANSLATE_NOOP("MythControls",
@@ -1656,9 +1656,9 @@ static void InitKeys(void)
      REG_KEY("Images", "FLIPVERTICAL", QT_TRANSLATE_NOOP("MythControls",
          "Flip image vertically"), "");
      REG_KEY("Images", "ZOOMOUT", QT_TRANSLATE_NOOP("MythControls",
-         "Zoom image out"), "7");
+         "Zoom image out"), "7,<,Ctrl+B,Media Rewind");
      REG_KEY("Images", "ZOOMIN", QT_TRANSLATE_NOOP("MythControls",
-         "Zoom image in"), "9");
+         "Zoom image in"), "9,>,Ctrl+F,Media Fast Forward");
      REG_KEY("Images", "FULLSIZE", QT_TRANSLATE_NOOP("MythControls",
          "Full-size (un-zoom) image"), "0");
      REG_KEY("Images", "MARK", QT_TRANSLATE_NOOP("MythControls",


### PR DESCRIPTION
Appears that USB HID standardized common media control keys some years after MythTV was invented.  These have Keysyms in X11 and then Qt for several years now but it wasn't until 2019 and later that web browsers finally started supporting these keys.

So rather than all users manually mapping these, seems MythTV should support them out of the box.  Home Page makes a great Info button on the MX3 but might be in an odd place on other remotes.  But if this key is anywhere and makes it to MythTV it might as well do something useful, right?  All others are hopefully self explanatory.

While here, also map emacs-like Ctrl+B and Ctrl+F for rewind and fast foward as on older MCE remotes like ARC-1100.  This required moving "jump to start" from Ctrl+B to Ctrl+A.  Menu, Info and Delete are also mapped to the control keys of the colored ARC-1100 buttons.

I assume this might have no effect on current installs if they keep the bindings as-is in the database.  I don't have a way to test currently.  But at least this should get the keys working on new installs.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

