### PR TITLE
SCAN_t: move to its own header

### DIFF
--- a/mythtv/libs/libmythtv/libmythtv.pro
+++ b/mythtv/libs/libmythtv/libmythtv.pro
@@ -148,6 +148,7 @@ HEADERS += recordingfile.h
 HEADERS += driveroption.h
 HEADERS += mythhdrvideometadata.h
 HEADERS += mythhdrtracker.h
+HEADERS += scantype.h
 
 SOURCES += bytereader.cpp
 SOURCES += recordinginfo.cpp

--- a/mythtv/libs/libmythtv/mpeg/H2645Parser.h
+++ b/mythtv/libs/libmythtv/mpeg/H2645Parser.h
@@ -30,11 +30,11 @@
 #include "libmythbase/compat.h" // for uint on Darwin, MinGW
 #include "libmythbase/mythconfig.h"
 #include "libmythbase/mythlogging.h"
-#include "libmythtv/recorders/recorderbase.h" // for ScanType
+
+#include "libmythtv/scantype.h"
 
 class BitReader;
 class FrameRate;
-enum class SCAN_t : uint8_t;
 
 class H2645Parser {
   public:

--- a/mythtv/libs/libmythtv/recorders/dtvrecorder.h
+++ b/mythtv/libs/libmythtv/recorders/dtvrecorder.h
@@ -17,6 +17,7 @@
 #include "libmythtv/mpeg/H2645Parser.h"
 #include "libmythtv/mpeg/streamlisteners.h"
 #include "libmythtv/recorders/recorderbase.h"
+#include "libmythtv/scantype.h"
 
 class MPEGStreamData;
 class TSPacket;

--- a/mythtv/libs/libmythtv/recorders/recorderbase.h
+++ b/mythtv/libs/libmythtv/recorders/recorderbase.h
@@ -18,6 +18,7 @@
 #include "libmythtv/mythtvexp.h"
 #include "libmythtv/recordingfile.h"
 #include "libmythtv/recordingquality.h"
+#include "libmythtv/scantype.h"
 
 extern "C"
 {
@@ -50,13 +51,6 @@ public:
 private:
     uint m_num;
     uint m_den;
-};
-
-enum class SCAN_t : uint8_t {
-    UNKNOWN_SCAN,
-    INTERLACED,
-    PROGRESSIVE,
-    VARIABLE
 };
 
 /** \class RecorderBase

--- a/mythtv/libs/libmythtv/scantype.h
+++ b/mythtv/libs/libmythtv/scantype.h
@@ -1,0 +1,13 @@
+#ifndef SCAN_TYPE_H_
+#define SCAN_TYPE_H_
+
+#include <cstdint>
+
+enum class SCAN_t : uint8_t {
+    UNKNOWN_SCAN,
+    INTERLACED,
+    PROGRESSIVE,
+    VARIABLE
+};
+
+#endif // SCAN_TYPE_H_


### PR DESCRIPTION
This is intended to reduce unnecessary transitive includes in the H.264 and H.265 parsers, particularly "libavcodec/avcodec.h".

This was separated out from an upcoming change to create a MythAVRational wrapper class.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

