### PR TITLE
Avoid removing PID filters when using virtual channel tuning

### DIFF
--- a/mythtv/libs/libmythtv/recorders/hdhrstreamhandler.cpp
+++ b/mythtv/libs/libmythtv/recorders/hdhrstreamhandler.cpp
@@ -182,7 +182,10 @@ void HDHRStreamHandler::run(void)
     }
     LOG(VB_RECORD, LOG_INFO, LOC + "RunTS(): " + "shutdown");
 
-    RemoveAllPIDFilters();
+    if (m_tuneMode != hdhrTuneModeVChannel)
+    {
+        RemoveAllPIDFilters();
+    }
 
     {
         QMutexLocker locker(&m_hdhrLock);
@@ -237,7 +240,8 @@ bool HDHRStreamHandler::UpdateFilters(void)
     if (m_tuneMode != hdhrTuneModeFrequencyPid)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC +
-            "UpdateFilters called in wrong tune mode");
+            QString("UpdateFilters called in wrong tune mode, %1")
+                .arg(m_tuneMode));
         return false;
     }
 
@@ -529,7 +533,9 @@ bool HDHRStreamHandler::TuneProgram(uint mpeg_prog_num)
 
     if (m_tuneMode != hdhrTuneModeFrequencyProgram)
     {
-        LOG(VB_GENERAL, LOG_ERR, LOC + "TuneProgram called in wrong tune mode");
+        LOG(VB_GENERAL, LOG_ERR, LOC +
+            QString("TuneProgram called in wrong tune mode, %1")
+                .arg(m_tuneMode));
         return false;
     }
 


### PR DESCRIPTION
The first step is to improve the error messages. In two
places the "UpdateFilters called in wrong tune mode"
message has been updated to specify the value of the
wrong tune mode.

After these updates, an example of the error message is:

_mythbackend: mythbackend[779282]: E HDHRStreamHandler
hdhrstreamhandler.cpp:242 (UpdateFilters) HDHRSH\[4\]
(13249773): UpdateFilters called in wrong tune mode, 4_

The tune mode was **hdhrTuneModeVChannel** (= 4), and
we know that **UpdateFilters** was called, but in
hdhrstreamhandler.cpp, the only call to it is avoided for
Vchan tuning.
```
108 void HDHRStreamHandler::run(void)
...
140             UpdateFiltersFromStreamData();
141             if (m_tuneMode != hdhrTuneModeVChannel)
142                 UpdateFilters();
```
Code examination reveals that the offending invocation of
**UpdateFilters()** is in **StreamHandler::RemoveAllPIDFilters()**.

This routine is called unconditionally in
```
108 void HDHRStreamHandler::run(void)
...
183     LOG(VB_RECORD, LOG_INFO, LOC + "RunTS(): " + "shutdown");
184
185     RemoveAllPIDFilters();
```
The solution is to condition the call to **RemoveAllPIDFilters()** in the same way the call to **UpdateFilters()** was previously conditioned. If we're using Virtual Channel Tuning, then don't bother removing filters which were never created in the first place.

After applying this solution, the **_UpdateFilters called in wrong tune
mode_** error messages no longer appear in mythbackend.log.

Resolves #905

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

