### PR TITLE
Python tmdb3tv: Allow specials with season number 0

### DIFF
--- a/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
@@ -12,7 +12,7 @@
 #-----------------------
 __title__ = "TheMovieDB.org V3"
 __author__ = "Raymond Wagner, Roland Ernst"
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 # 0.1.0 Initial version
 # 0.2.0 Add language support, move cache to home directory
 # 0.3.0 Enable version detection to allow use in MythTV
@@ -31,6 +31,7 @@ __version__ = "0.3.10"
 # 0.3.8 Sort posters by system language or 'en', if not found for given language
 # 0.3.9 Support TV lookup
 # 0.3.10 Use new API for release dates for movies
+# 0.3.11 Allow queries for specials in series in TV lookup
 
 # ~ from optparse import OptionParser
 import sys
@@ -340,7 +341,7 @@ def buildEpisode(args, opts):
 
     # process seasons backwards because it is more likely
     # that you have a recent one than an old one
-    while season_number > 0:
+    while season_number >= 0:
         season = Season(inetref,str(season_number))
         if episode_number:
             episode = season.episodes[episode_number]


### PR DESCRIPTION
tmdb3 lookup.py does not allow queries for tv-season number 0
as raised by @davidjo in #902.

Provided patch in #902 works for me, tested with:
```
tmdb3tv.py -l en -a GB -D 62974 0 5
tmdb3tv.py -l de -a AT -D 53193 0 3
```
otherwise, one gets:
```
~/MythTV/issue_902$ ./share/mythtv/metadata/Television/tmdb3tv.py -l en -a GB -D 62974 0 5
Traceback (most recent call last):
  File "~/MythTV/issue_902/./share/mythtv/metadata/Television/tmdb3tv.py", line 159, in <module>
    sys.exit(main("television",'tmdb3tv.py'))
  File "~/MythTV/issue_902/./share/mythtv/metadata/Television/tmdb3tv.py", line 136, in main
    xml = buildEpisode(args[0:3], opts)
  File "~/MythTV/issue_902/MythTV/tmdb3/lookup.py", line 397, in buildEpisode
    if season.poster:
UnboundLocalError: local variable 'season' referenced before assignment
```
### Checklist
- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

