### PR TITLE
GitHub Actions: fix Fedora CMake build

### DIFF
--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -4012,7 +4012,7 @@ static int64_t mpegts_get_dts(AVFormatContext *s, int stream_index,
 /**************************************************************/
 /* parsing functions - called from other demuxers such as RTP */
 
-MpegTSContext *avpriv_mpegts_parse_open(AVFormatContext *s)
+MpegTSContext *avpriv_mythtv_mpegts_parse_open(AVFormatContext *s)
 {
     MpegTSContext *ts;
 
@@ -4034,7 +4034,7 @@ MpegTSContext *avpriv_mpegts_parse_open(AVFormatContext *s)
 
 /* return the consumed length if a packet was output, or -1 if no
  * packet is output */
-int avpriv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
+int avpriv_mythtv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
                                const uint8_t *buf, int len)
 {
     int len1;
@@ -4059,7 +4059,7 @@ int avpriv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
     return len1 - len;
 }
 
-void avpriv_mpegts_parse_close(MpegTSContext *ts)
+void avpriv_mythtv_mpegts_parse_close(MpegTSContext *ts)
 {
     mpegts_free(ts);
     av_free(ts);

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.c
@@ -1920,7 +1920,7 @@ static const uint8_t opus_channel_map[8][8] = {
     { 0,6,1,2,3,4,5,7 },
 };
 
-int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
+int ff_mythtv_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
                               const uint8_t **pp, const uint8_t *desc_list_end,
                               Mp4Descr *mp4_descr, int mp4_descr_count, int pid,
                               MpegTSContext *ts)
@@ -2946,7 +2946,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         if (desc_list_end > p_end)
             goto out;
         for (;;) {
-            if (ff_parse_mpeg2_descriptor(ts->stream, st, stream_type, &p,
+            if (ff_mythtv_parse_mpeg2_descriptor(ts->stream, st, stream_type, &p,
                                           desc_list_end, mp4_descr,
                                           mp4_descr_count, pid, ts) < 0)
                 break;

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.h
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.h
@@ -182,10 +182,10 @@
 
 typedef struct MpegTSContext MpegTSContext;
 
-MpegTSContext *avpriv_mpegts_parse_open(AVFormatContext *s);
-int avpriv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
+MpegTSContext *avpriv_mythtv_mpegts_parse_open(AVFormatContext *s);
+int avpriv_mythtv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
                            const uint8_t *buf, int len);
-void avpriv_mpegts_parse_close(MpegTSContext *ts);
+void avpriv_mythtv_mpegts_parse_close(MpegTSContext *ts);
 
 typedef struct SLConfigDescr {
     int use_au_start;

--- a/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.h
+++ b/mythtv/external/FFmpeg/libavformat/mpegts-mythtv.h
@@ -236,7 +236,7 @@ typedef struct DVBAC3Descriptor {
  * @param desc_list_end             End of buffer
  * @return <0 to stop processing
  */
-int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
+int ff_mythtv_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
                               const uint8_t **pp, const uint8_t *desc_list_end,
                               Mp4Descr *mp4_descr, int mp4_descr_count, int pid,
                               MpegTSContext *ts);

--- a/mythtv/external/FFmpeg/libavformat/mpegts.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts.c
@@ -3371,7 +3371,7 @@ static int64_t mpegts_get_dts(AVFormatContext *s, int stream_index,
 /**************************************************************/
 /* parsing functions - called from other demuxers such as RTP */
 
-MpegTSContext *avpriv_old_mpegts_parse_open(AVFormatContext *s)
+MpegTSContext *avpriv_mpegts_parse_open(AVFormatContext *s)
 {
     MpegTSContext *ts;
 
@@ -3393,7 +3393,7 @@ MpegTSContext *avpriv_old_mpegts_parse_open(AVFormatContext *s)
 
 /* return the consumed length if a packet was output, or -1 if no
  * packet is output */
-int avpriv_old_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
+int avpriv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
                                const uint8_t *buf, int len)
 {
     int len1;
@@ -3418,7 +3418,7 @@ int avpriv_old_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
     return len1 - len;
 }
 
-void avpriv_old_mpegts_parse_close(MpegTSContext *ts)
+void avpriv_mpegts_parse_close(MpegTSContext *ts)
 {
     mpegts_free(ts);
     av_free(ts);

--- a/mythtv/external/FFmpeg/libavformat/mpegts.c
+++ b/mythtv/external/FFmpeg/libavformat/mpegts.c
@@ -1806,7 +1806,7 @@ static const uint8_t opus_channel_map[8][8] = {
     { 0,6,1,2,3,4,5,7 },
 };
 
-int ff_old_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
+int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
                               const uint8_t **pp, const uint8_t *desc_list_end,
                               Mp4Descr *mp4_descr, int mp4_descr_count, int pid,
                               MpegTSContext *ts)
@@ -2504,7 +2504,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         if (desc_list_end > p_end)
             goto out;
         for (;;) {
-            if (ff_old_parse_mpeg2_descriptor(ts->stream, st, stream_type, &p,
+            if (ff_parse_mpeg2_descriptor(ts->stream, st, stream_type, &p,
                                           desc_list_end, mp4_descr,
                                           mp4_descr_count, pid, ts) < 0)
                 break;

--- a/mythtv/external/FFmpeg/libavformat/mpegts.h
+++ b/mythtv/external/FFmpeg/libavformat/mpegts.h
@@ -166,10 +166,10 @@
 
 typedef struct MpegTSContext MpegTSContext;
 
-MpegTSContext *avpriv_old_mpegts_parse_open(AVFormatContext *s);
-int avpriv_old_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
+MpegTSContext *avpriv_mpegts_parse_open(AVFormatContext *s);
+int avpriv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
                            const uint8_t *buf, int len);
-void avpriv_old_mpegts_parse_close(MpegTSContext *ts);
+void avpriv_mpegts_parse_close(MpegTSContext *ts);
 
 typedef struct SLConfigDescr {
     int use_au_start;

--- a/mythtv/external/FFmpeg/libavformat/mpegts.h
+++ b/mythtv/external/FFmpeg/libavformat/mpegts.h
@@ -168,7 +168,7 @@ typedef struct MpegTSContext MpegTSContext;
 
 MpegTSContext *avpriv_mpegts_parse_open(AVFormatContext *s);
 int avpriv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
-                           const uint8_t *buf, int len);
+                               const uint8_t *buf, int len);
 void avpriv_mpegts_parse_close(MpegTSContext *ts);
 
 typedef struct SLConfigDescr {

--- a/mythtv/external/FFmpeg/libavformat/mpegts.h
+++ b/mythtv/external/FFmpeg/libavformat/mpegts.h
@@ -220,7 +220,7 @@ typedef struct DVBAC3Descriptor {
  * @param desc_list_end             End of buffer
  * @return <0 to stop processing
  */
-int ff_old_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
+int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
                               const uint8_t **pp, const uint8_t *desc_list_end,
                               Mp4Descr *mp4_descr, int mp4_descr_count, int pid,
                               MpegTSContext *ts);

--- a/mythtv/external/FFmpeg/libavformat/rtpdec_mpegts.c
+++ b/mythtv/external/FFmpeg/libavformat/rtpdec_mpegts.c
@@ -35,13 +35,13 @@ static void mpegts_close_context(PayloadContext *data)
     if (!data)
         return;
     if (data->ts)
-        avpriv_mpegts_parse_close(data->ts);
+        avpriv_mythtv_mpegts_parse_close(data->ts);
 }
 
 static av_cold int mpegts_init(AVFormatContext *ctx, int st_index,
                                PayloadContext *data)
 {
-    data->ts = avpriv_mpegts_parse_open(ctx);
+    data->ts = avpriv_mythtv_mpegts_parse_open(ctx);
     if (!data->ts)
         return AVERROR(ENOMEM);
     return 0;
@@ -63,7 +63,7 @@ static int mpegts_handle_packet(AVFormatContext *ctx, PayloadContext *data,
     if (!buf) {
         if (data->read_buf_index >= data->read_buf_size)
             return AVERROR(EAGAIN);
-        ret = avpriv_mpegts_parse_packet(data->ts, pkt, data->buf + data->read_buf_index,
+        ret = avpriv_mythtv_mpegts_parse_packet(data->ts, pkt, data->buf + data->read_buf_index,
                                          data->read_buf_size - data->read_buf_index);
         if (ret < 0)
             return AVERROR(EAGAIN);
@@ -74,7 +74,7 @@ static int mpegts_handle_packet(AVFormatContext *ctx, PayloadContext *data,
             return 0;
     }
 
-    ret = avpriv_mpegts_parse_packet(data->ts, pkt, buf, len);
+    ret = avpriv_mythtv_mpegts_parse_packet(data->ts, pkt, buf, len);
     /* The only error that can be returned from avpriv_mpegts_parse_packet
      * is "no more data to return from the provided buffer", so return
      * AVERROR(EAGAIN) for all errors */

--- a/mythtv/external/FFmpeg/libavformat/rtsp.c
+++ b/mythtv/external/FFmpeg/libavformat/rtsp.c
@@ -527,7 +527,7 @@ static void sdp_parse_line(AVFormatContext *s, SDPParseState *s1,
             /* no corresponding stream */
             if (rt->transport == RTSP_TRANSPORT_RAW) {
                 if (CONFIG_RTPDEC && !rt->ts)
-                    rt->ts = avpriv_mpegts_parse_open(s);
+                    rt->ts = avpriv_mythtv_mpegts_parse_open(s);
             } else {
                 const RTPDynamicProtocolHandler *handler;
                 handler = ff_rtp_handler_find_by_id(
@@ -817,7 +817,7 @@ void ff_rtsp_close_streams(AVFormatContext *s)
         avformat_close_input(&rt->asf_ctx);
     }
     if (CONFIG_RTPDEC && rt->ts)
-        avpriv_mpegts_parse_close(rt->ts);
+        avpriv_mythtv_mpegts_parse_close(rt->ts);
     av_freep(&rt->p);
     av_freep(&rt->recvbuf);
 }
@@ -2213,7 +2213,7 @@ int ff_rtsp_fetch_packet(AVFormatContext *s, AVPacket *pkt)
         } else if (rt->transport == RTSP_TRANSPORT_RTP) {
             ret = ff_rtp_parse_packet(rt->cur_transport_priv, pkt, NULL, 0);
         } else if (CONFIG_RTPDEC && rt->ts) {
-            ret = avpriv_mpegts_parse_packet(rt->ts, pkt, rt->recvbuf + rt->recvbuf_pos, rt->recvbuf_len - rt->recvbuf_pos);
+            ret = avpriv_mythtv_mpegts_parse_packet(rt->ts, pkt, rt->recvbuf + rt->recvbuf_pos, rt->recvbuf_len - rt->recvbuf_pos);
             if (ret >= 0) {
                 rt->recvbuf_pos += ret;
                 ret = rt->recvbuf_pos < rt->recvbuf_len;
@@ -2328,7 +2328,7 @@ redo:
             }
         }
     } else if (CONFIG_RTPDEC && rt->ts) {
-        ret = avpriv_mpegts_parse_packet(rt->ts, pkt, rt->recvbuf, len);
+        ret = avpriv_mythtv_mpegts_parse_packet(rt->ts, pkt, rt->recvbuf, len);
         if (ret >= 0) {
             if (ret < len) {
                 rt->recvbuf_len = len;

--- a/mythtv/external/FFmpeg/libavformat/wtvdec.c
+++ b/mythtv/external/FFmpeg/libavformat/wtvdec.c
@@ -855,7 +855,7 @@ static int parse_chunks(AVFormatContext *s, int mode, int64_t seekts, int *len_p
                 buf_size = FFMIN(len - consumed, sizeof(buf));
                 avio_read(pb, buf, buf_size);
                 consumed += buf_size;
-                ff_old_parse_mpeg2_descriptor(s, st, 0, &pbuf, buf + buf_size, NULL, 0, 0, NULL);
+                ff_parse_mpeg2_descriptor(s, st, 0, &pbuf, buf + buf_size, NULL, 0, 0, NULL);
             }
         } else if (!ff_guidcmp(g, EVENTID_AudioTypeSpanningEvent)) {
             int stream_index = ff_find_stream_index(s, sid);

--- a/mythtv/programs/mythbackend/CMakeLists.txt
+++ b/mythtv/programs/mythbackend/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(
   servicesv2/v2channelGroup.h
   servicesv2/v2channelGroupList.h
   servicesv2/v2channelInfoList.h
+  servicesv2/v2channelRestore.h
   servicesv2/v2channelScan.h
   servicesv2/v2commMethod.h
   servicesv2/v2config.cpp


### PR DESCRIPTION
The GitHub Actions Fedora CMake builder is now building libavdevice/iec61883.c which includes and uses FFmpeg’s mpegts.h, causing it to not compile.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

