### PR TITLE
fixes to 1 Install Mythtv.cmd

### DIFF
--- a/platform/win32/w64-mingw32/Installer/1 Install Mythtv.cmd
+++ b/platform/win32/w64-mingw32/Installer/1 Install Mythtv.cmd
@@ -16,20 +16,20 @@ pause
 robocopy share C:\ProgramData\ /E
 
 if not exist xampp-portable-windows.zip (
-    curl -L "https://sourceforge.net/projects/xampp/files/XAMPP%%20Windows/8.0.9/xampp-portable-windows-x64-8.0.9-0-VS16.zip/download" > xampp-portable-windows.zip
+    curl -kL "https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/8.0.25/xampp-portable-windows-x64-8.0.25-0-VS16.zip/download" > xampp-portable-windows.zip
 )
 
 if not exist timezone_2021a_leaps.zip (
-    curl -L https://downloads.mysql.com/general/timezone_2021a_leaps.zip > timezone_2021a_leaps.zip
+    curl -kL https://downloads.mysql.com/general/timezone_2021a_leaps.zip > timezone_2021a_leaps.zip
 )
 
 echo "copying files.."
-tar -xf xampp-portable-windows.zip
-tar -xf timezone_2021a_leaps.zip
+tar -vxf xampp-portable-windows.zip
+tar -vxf timezone_2021a_leaps.zip
 
 robocopy timezone_2021a_leaps\ xampp\mysql\data\mysql\
 
-rmdir -r timezone_2021a_leaps /s /q
+rmdir timezone_2021a_leaps /s /q
 
 cd xampp
 start /min cmd /k "setup_xampp.bat"
@@ -37,7 +37,8 @@ TIMEOUT 5 /nobreak
 start /min cmd /k "mysql\bin\mysqld --defaults-file=mysql\bin\my.ini --standalone"
 TIMEOUT 7 /nobreak
 echo "creating user"
-"mysql\bin\mysql.exe" -u root -e "CREATE USER 'mythtv'@'localhost' IDENTIFIED BY 'mythtv';CREATE DATABASE mythconverg;GRANT ALL PRIVILEGES ON *.* TO 'mythtv'@'localhost';"
+"mysql\bin\mysql.exe" -u root --skip-password  -e "CREATE USER 'mythtv'@'localhost' IDENTIFIED BY 'mythtv';CREATE DATABASE mythconverg;GRANT ALL PRIVILEGES ON *.* TO 'mythtv'@'localhost';"
+"mysql\bin\mysql.exe" -u root -e "SELECT user FROM mysql.user where user = 'mythtv';"
 
 cd ..
 TIMEOUT 1 /nobreak


### PR DESCRIPTION

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)


* Curl now uses the parameter "-k"
* Bump xampp version to 8.0.25. 
* Remove parameter -r from rmdir
* For aesthetics, add verbose "-v" parameter to tar
* To mysql command add the parameter "--skip-password"
* For aethetics very the by querying and viewing the new user "mythtv" in the mysql database

```
C:\INSTALL>curl -L "https://sourceforge.net/projects/xampp/files/XAMPP%%20Windows/8.0.9/xampp-portable-windows-x64-8.0.9-0-VS16.zip/download" > xampp-portable-windows.zip)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (35) schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate.
```
Fix: curl now needs -k parameter . . . adding . . .

```
C:\INSTALL>curl -kL "https://sourceforge.net/projects/xampp/files/XAMPP%%20Windows/8.0.9/xampp-portable-windows-x64-8.0.9-0-VS16.zip/download" > xampp-portable-windows.zip)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   155  100   155    0     0   1381      0 --:--:-- --:--:-- --:--:--  1422
```
Fix: version 8.0.9 is no longer available to download.  Bumping version to 8.025 . . . bumped . . .

```
C:\INSTALL>curl -kL "https://sourceforge.net/projects/xampp/files/XAMPP%20Windows/8.0.25/xampp-portable-windows-x64-8.0.25-0-VS16.zip/download" > xampp-portable-windows.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   679    0   679    0     0   2459      0 --:--:-- --:--:-- --:--:--  2487
100   433  100   433    0     0    462      0 --:--:-- --:--:-- --:--:--   708
100  201M  100  201M    0     0  4854k      0  0:00:42  0:00:42 --:--:-- 5055k
```

```
C:\INSTALL>curl -L https://downloads.mysql.com/general/timezone_2021a_leaps.zip > timezone_2021a_leaps.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (35) schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate.
```
Fix: curl now needs -k parameter . . . adding . . .


```
C:\INSTALL>curl -kL https://downloads.mysql.com/general/timezone_2021a_leaps.zip > timezone_2021a_leaps.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  402k  100  402k    0     0   512k      0 --:--:-- --:--:-- --:--:--  514k

C:\INSTALL>

```

For aesthetics, adding "-v" verbose
```
C:\INSTALL>tar -v -xf timezone_2021a_leaps.zip
x timezone_2021a_leaps/
x timezone_2021a_leaps/time_zone.MYD
x timezone_2021a_leaps/time_zone.MYI
x timezone_2021a_leaps/time_zone.frm
x timezone_2021a_leaps/time_zone_leap_second.MYD
x timezone_2021a_leaps/time_zone_leap_second.MYI
x timezone_2021a_leaps/time_zone_leap_second.frm
x timezone_2021a_leaps/time_zone_name.MYD
x timezone_2021a_leaps/time_zone_name.MYI
x timezone_2021a_leaps/time_zone_name.frm
x timezone_2021a_leaps/time_zone_transition.MYD
x timezone_2021a_leaps/time_zone_transition.MYI
x timezone_2021a_leaps/time_zone_transition.frm
x timezone_2021a_leaps/time_zone_transition_type.MYD
x timezone_2021a_leaps/time_zone_transition_type.MYI
x timezone_2021a_leaps/time_zone_transition_type.frm
```

```
C:\INSTALL>rmdir -r timezone_2021a_leaps /s /q
The system cannot find the file specified.
```
Fix -r is not a parameter of "rmdir." . . . Elimininating "-r" . . .

```
C:\INSTALL>rmdir timezone_2021a_leaps /s /q

C:\INSTALL>
```

```
C:\INSTALL\xampp>"mysql\bin\mysql.exe" -u root -e "CREATE USER 'mythtv'@'localhost' IDENTIFIED BY 'mythtv';CREATE DATABASE mythconverg;GRANT ALL PRIVILEGES ON *.* TO 'mythtv'@'localhost';"
ERROR 1396 (HY000) at line 1: Operation CREATE USER failed for 'mythtv'@'localhost'
```
Fix: add the parameter --skip-password

```
C:\INSTALL\xampp>"mysql\bin\mysql.exe" -u root --skip-password  -e "CREATE USER 'mythtv'@'localhost' IDENTIFIED BY 'mythtv';CREATE DATABASE mythconverg;GRANT ALL PRIVILEGES ON *.* TO 'mythtv'@'localhost';"
```

For aethetics, added . . . 
```
"mysql\bin\mysql.exe" -u root -e "SELECT user FROM mysql.user where user = 'mythtv';"

```
```
--------+
| User   |
+--------+
| mythtv |
+--------+
```
