### PR TITLE
BitReader cleanup

### DIFF
--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -55,12 +55,12 @@ class BitReader
         else
         {
             n -= m_cacheSize;
-            m_cacheSize = 0;
-            m_cache      = 0;
-            m_bitIndex += n;
-            int quotient = m_bitIndex / CHAR_BIT;
-            m_bitIndex %= CHAR_BIT;
-            m_buffer    += quotient;
+            m_cacheSize        = 0;
+            m_cache            = 0;
+            m_bitIndex        += n;
+            unsigned quotient  = m_bitIndex / CHAR_BIT;
+            m_bitIndex         = m_bitIndex % CHAR_BIT;
+            m_buffer          += quotient;
         }
     }
     uint32_t show_bits(unsigned n)

--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -69,7 +69,7 @@ class BitReader
         {
             refill_cache(32);
         }
-        return uint32_t(get_upper_bits(m_cache, n));
+        return static_cast<uint32_t>(get_upper_bits(m_cache, n));
     }
     uint64_t show_bits64(unsigned n)
     {
@@ -154,7 +154,7 @@ class BitReader
 
     int64_t get_bits_left()
     {
-        return m_cacheSize + k_bitsPerRead * int64_t(m_bufferEnd - m_buffer) - m_bitIndex;
+        return m_cacheSize + k_bitsPerRead * static_cast<int64_t>(m_bufferEnd - m_buffer) - m_bitIndex;
     }
 
   private:
@@ -182,7 +182,7 @@ class BitReader
         v |= v >> 8;
         v |= v >> 16;
 
-        return 31 - MultiplyDeBruijnBitPosition[(uint32_t)(v * 0x07C4ACDDU) >> 27];
+        return 31 - MultiplyDeBruijnBitPosition[static_cast<uint32_t>(v * 0x07C4ACDDU) >> 27];
 #endif
     }
 

--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -261,14 +261,14 @@ inline void BitReader::refill_cache(unsigned min_bits)
         unsigned bits  = k_bitsPerRead  - m_bitIndex;
         if (shift >= bits)
         {
-            m_cache |= static_cast<uint64_t>(*m_buffer & ((1 << bits) - 1)) << (shift - bits);
+            m_cache |= static_cast<uint64_t>(*m_buffer) << (shift - bits);
             m_bitIndex   = 0;
             m_buffer++;
             m_cacheSize += bits;
         }
         else
         {
-            m_cache |= static_cast<uint64_t>(*m_buffer & ((1 << bits) - 1)) >> (bits - shift);
+            m_cache |= static_cast<uint64_t>(*m_buffer) >> (bits - shift);
             m_bitIndex  += shift;
             m_cacheSize += shift;
             return; // m_cacheSize == k_cacheSizeMax

--- a/mythtv/libs/libmythtv/bitreader.h
+++ b/mythtv/libs/libmythtv/bitreader.h
@@ -248,7 +248,7 @@ inline void BitReader::refill_cache(unsigned min_bits)
         int bits = CHAR_BIT - m_bitIndex;
         if (shift > bits)
         {
-            m_cache |= int64_t(*m_buffer & ((1 << bits) - 1)) << (shift - bits);
+            m_cache |= static_cast<uint64_t>(*m_buffer & ((1 << bits) - 1)) << (shift - bits);
             m_bitIndex   = 0;
             m_buffer++;
             m_cacheSize += bits;
@@ -256,7 +256,7 @@ inline void BitReader::refill_cache(unsigned min_bits)
         else
         {
             // NOLINTNEXTLINE(clang-analyzer-core.BitwiseShift)
-            m_cache |= int64_t(*m_buffer & ((1 << bits) - 1)) >> (bits - shift);
+            m_cache |= static_cast<uint64_t>(*m_buffer & ((1 << bits) - 1)) >> (bits - shift);
             m_bitIndex  += shift;
             m_cacheSize += shift;
         }

--- a/mythtv/libs/libmythtv/bytereader.cpp
+++ b/mythtv/libs/libmythtv/bytereader.cpp
@@ -21,17 +21,6 @@
 
 #include "bytereader.h"
 
-extern "C" {
-#include "libavutil/intreadwrite.h"
-#ifndef AV_RB32
-#   define AV_RB32(x)                                \
-    (((uint32_t)((const uint8_t*)(x))[0] << 24) |    \
-               (((const uint8_t*)(x))[1] << 16) |    \
-               (((const uint8_t*)(x))[2] <<  8) |    \
-                ((const uint8_t*)(x))[3])
-#endif
-}
-
 const uint8_t* ByteReader::find_start_code(const uint8_t * p,
                                            const uint8_t * const end,
                                            uint32_t * const start_code)
@@ -74,7 +63,10 @@ const uint8_t* ByteReader::find_start_code(const uint8_t * p,
     if (p > end)
         p = end;
     // read the previous 4 bytes, i.e. bytes {p - 4, p - 3, p - 2, p - 1}
-    *start_code = AV_RB32(p - 4);
+    *start_code = static_cast<uint32_t>(p[-4]) << 24 |
+                  static_cast<uint32_t>(p[-3]) << 16 |
+                  static_cast<uint32_t>(p[-2]) <<  8 |
+                  static_cast<uint32_t>(p[-1]);
     return p;
 }
 


### PR DESCRIPTION
This is a change to make ByteReader not depend on FFmpeg and some minor tweaks to BitReader.  The only functional change is in the last commit in regards to how BitReader responds when the data it is reading has been modified since it was constructed (which should never happen).  See the individual commits for details.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

