### PR TITLE
Eliminate usage of internal FFmpeg headers

### DIFF
--- a/cmake/embeddedlibs/FindOrBuildFFmpeg.cmake
+++ b/cmake/embeddedlibs/FindOrBuildFFmpeg.cmake
@@ -136,18 +136,6 @@ function(find_or_build_ffmpeg)
     WORKING_DIRECTORY <BINARY_DIR>
     COMMAND ${MAKE_EXECUTABLE} install-pkgconfig)
 
-  #
-  # Install internal headers that are used by MythTV.  This must go away if
-  # MythTV is ever want to use the distribution supplied FFmpeg.
-  #
-  set(FFMPEG_INSTALL_INCLUDEDIR ${FFMPEG_INSTALL_PREFIX}/include/mythtv/)
-  ExternalProject_Add_Step(
-    FFmpeg expose_internal_headers_hack
-    DEPENDEES install
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/mythtv/external/FFmpeg
-    COMMAND ${CMAKE_COMMAND} -E copy libavformat/url.h
-            ${FFMPEG_INSTALL_INCLUDEDIR}/libavformat/
-
 endfunction()
 
 find_or_build_ffmpeg()

--- a/cmake/embeddedlibs/FindOrBuildFFmpeg.cmake
+++ b/cmake/embeddedlibs/FindOrBuildFFmpeg.cmake
@@ -145,16 +145,8 @@ function(find_or_build_ffmpeg)
     FFmpeg expose_internal_headers_hack
     DEPENDEES install
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/mythtv/external/FFmpeg
-    COMMAND ${CMAKE_COMMAND} -E make_directory
-            ${FFMPEG_INSTALL_INCLUDEDIR}/compat/cuda
     COMMAND ${CMAKE_COMMAND} -E copy libavformat/url.h
             ${FFMPEG_INSTALL_INCLUDEDIR}/libavformat/
-    COMMAND ${CMAKE_COMMAND} -E copy libavutil/wchar_filename.h
-            ${FFMPEG_INSTALL_INCLUDEDIR}/libavutil/
-    COMMAND ${CMAKE_COMMAND} -E copy compat/w32dlfcn.h
-            ${FFMPEG_INSTALL_INCLUDEDIR}/compat/
-    COMMAND ${CMAKE_COMMAND} -E copy compat/cuda/dynlink_loader.h
-            ${FFMPEG_INSTALL_INCLUDEDIR}/compat/cuda/)
 
 endfunction()
 

--- a/mythtv/external/FFmpeg/compat/w32dlfcn.h
+++ b/mythtv/external/FFmpeg/compat/w32dlfcn.h
@@ -35,7 +35,7 @@ static inline wchar_t *get_module_filename(HMODULE module)
 
     do {
         path_size = path_size ? FFMIN(2 * path_size, INT16_MAX + 1) : MAX_PATH;
-        new_path = (wchar_t *)av_realloc_array(path, path_size, sizeof *path);
+        new_path = av_realloc_array(path, path_size, sizeof *path);
         if (!new_path) {
             av_free(path);
             return NULL;

--- a/mythtv/external/FFmpeg/libavformat/libavformat.v
+++ b/mythtv/external/FFmpeg/libavformat/libavformat.v
@@ -1,12 +1,6 @@
 LIBAVFORMAT_MAJOR {
     global:
         av*;
-        ffurl_read;
-        ffurl_seek;
-        ffurl_size;
-        ffurl_open_whitelist;
-        ffurl_close;
-        ffurl_write;
     local:
         *;
 };

--- a/mythtv/libs/libmythbase/mythlogging.h
+++ b/mythtv/libs/libmythbase/mythlogging.h
@@ -73,6 +73,12 @@ MBASE_PUBLIC QString logStrerror(int errnum);
 #define ENO (QString("\n\t\t\teno: ") + logStrerror(errno))
 #define ENO_STR ENO.toLocal8Bit().constData()
 
+inline QString pointerToQString(const void *p)
+{
+    return QStringLiteral("0x%1").arg(reinterpret_cast<quintptr>(p),
+                    sizeof(void*) * 2, 16, QChar('0'));
+}
+
 #endif
 
 /*

--- a/mythtv/libs/libmythtv/HLS/httplivestreambuffer.h
+++ b/mythtv/libs/libmythtv/HLS/httplivestreambuffer.h
@@ -26,11 +26,6 @@
 #include "libmythbase/mythcorecontext.h"
 #include "libmythtv/io/mythmediabuffer.h"
 
-extern "C" {
-#include "libavformat/avformat.h"
-#include "libavformat/url.h"
-}
-
 class MythDownloadManager;
 class HLSStream;
 class HLSSegment;

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -455,8 +455,9 @@ void AvFormatDecoder::CloseContext()
     {
         CloseCodecs();
 
-        av_free(m_ic->pb->buffer);
-        av_free(m_ic->pb);
+        delete m_avfRingBuffer;
+        m_avfRingBuffer = nullptr;
+        m_ic->pb = nullptr;
         avformat_close_input(&m_ic);
         m_ic = nullptr;
     }
@@ -861,28 +862,6 @@ bool AvFormatDecoder::CanHandle(TestBufferVec & testbuf, const QString &filename
     return av_probe_input_format2(&probe, static_cast<int>(true), &score) != nullptr;
 }
 
-void AvFormatDecoder::InitByteContext(bool forceseek)
-{
-    int buf_size                  = m_ringBuffer->BestBufferSize();
-    bool streamed                 = m_ringBuffer->IsStreamed();
-    m_readContext.prot            = MythAVFormatBuffer::GetURLProtocol();
-    m_readContext.flags           = AVIO_FLAG_READ;
-    m_readContext.is_streamed     = static_cast<int>(streamed);
-    m_readContext.max_packet_size = 0;
-    m_readContext.priv_data       = m_avfRingBuffer;
-    auto *buffer                  = (unsigned char *)av_malloc(buf_size);
-    m_ic->pb                      = avio_alloc_context(buffer, buf_size, 0,
-                                                      &m_readContext,
-                                                      MythAVFormatBuffer::ReadPacket,
-                                                      MythAVFormatBuffer::WritePacket,
-                                                      MythAVFormatBuffer::SeekPacket);
-
-    // We can always seek during LiveTV
-    m_ic->pb->seekable = static_cast<int>(!streamed || forceseek);
-    LOG(VB_PLAYBACK, LOG_INFO, LOC + QString("Buffer size: %1 Streamed %2 Seekable %3 Available %4")
-        .arg(buf_size).arg(streamed).arg(m_ic->pb->seekable).arg(m_ringBuffer->GetReadBufAvail()));
-}
-
 extern "C" void HandleStreamChange(void *data)
 {
     auto *decoder = reinterpret_cast<AvFormatDecoder*>(data);
@@ -936,9 +915,6 @@ int AvFormatDecoder::OpenFile(MythMediaBuffer *Buffer, bool novideo,
     // a DVD, in which case don't so that we don't show
     // anything whilst probing the data streams.
     m_processFrames = !m_ringBuffer->IsDVD();
-
-    delete m_avfRingBuffer;
-    m_avfRingBuffer = new MythAVFormatBuffer(Buffer);
 
     const AVInputFormat *fmt = nullptr;
     QString        fnames   = m_ringBuffer->GetFilename();
@@ -1000,8 +976,16 @@ int AvFormatDecoder::OpenFile(MythMediaBuffer *Buffer, bool novideo,
                 return -1;
             }
 
+            delete m_avfRingBuffer;
+            m_avfRingBuffer = new MythAVFormatBuffer(m_ringBuffer, false, m_livetv);
+            m_ic->pb = m_avfRingBuffer->getAVIOContext();
+            LOG(VB_PLAYBACK, LOG_INFO, LOC +
+                QString("Buffer size: %1 Streamed %2 Seekable %3 Available %4")
+                .arg(m_ringBuffer->BestBufferSize())
+                .arg(m_ringBuffer->IsStreamed())
+                .arg(m_ic->pb->seekable)
+                .arg(m_ringBuffer->GetReadBufAvail()));
             m_avfRingBuffer->SetInInit(false);
-            InitByteContext(m_livetv);
 
             err = avformat_open_input(&m_ic, filename, fmt, nullptr);
             if (err < 0)

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -198,7 +198,6 @@ class AvFormatDecoder : public DecoderBase
 
     void DecodeDTVCC(const uint8_t *buf, uint buf_size, bool scte);
     void DecodeCCx08(const uint8_t *buf, uint buf_size, bool scte);
-    void InitByteContext(bool forceseek = false);
     void InitVideoCodec(AVStream *stream, AVCodecContext *enc,
                         bool selectedStream = false);
 
@@ -259,8 +258,6 @@ class AvFormatDecoder : public DecoderBase
     MythCodecMap       m_codecMap;
 
     // AVFormatParameters params;
-
-    URLContext         m_readContext                  {};
 
     int                m_frameDecoded                 {0};
     MythVideoFrame    *m_decodedVideoFrame            {nullptr};

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -195,11 +195,6 @@ class AvFormatDecoder : public DecoderBase
 
     friend int get_avf_buffer(struct AVCodecContext *c, AVFrame *pic,
                               int flags);
-    friend int open_avf(URLContext *h, const char *filename, int flags);
-    friend int read_avf(URLContext *h, uint8_t *buf, int buf_size);
-    friend int write_avf(URLContext *h, uint8_t *buf, int buf_size);
-    friend int64_t seek_avf(URLContext *h, int64_t offset, int whence);
-    friend int close_avf(URLContext *h);
 
     void DecodeDTVCC(const uint8_t *buf, uint buf_size, bool scte);
     void DecodeCCx08(const uint8_t *buf, uint buf_size, bool scte);

--- a/mythtv/libs/libmythtv/decoders/mythnvdeccontext.cpp
+++ b/mythtv/libs/libmythtv/decoders/mythnvdeccontext.cpp
@@ -9,6 +9,14 @@
 #include "opengl/mythnvdecinterop.h"
 
 extern "C" {
+#include "libavutil/log.h"
+#define FFNV_LOG_FUNC(logctx, msg, ...) av_log(logctx, AV_LOG_ERROR, msg,  __VA_ARGS__)
+#define FFNV_DEBUG_LOG_FUNC(logctx, msg, ...) av_log(logctx, AV_LOG_DEBUG, msg,  __VA_ARGS__)
+#include <ffnvcodec/dynlink_loader.h>
+}
+
+extern "C" {
+#include "libavutil/hwcontext_cuda.h"
 #include "libavutil/opt.h"
 }
 

--- a/mythtv/libs/libmythtv/decoders/mythnvdeccontext.h
+++ b/mythtv/libs/libmythtv/decoders/mythnvdeccontext.h
@@ -15,7 +15,8 @@ extern "C" {
 #include "libavutil/hwcontext.h"
 #include "libavcodec/avcodec.h"
 #include "libavutil/pixdesc.h"
-#include "compat/cuda/dynlink_loader.h"
+#include <ffnvcodec/dynlink_cuda.h>
+#include <ffnvcodec/dynlink_cuviddec.h>
 }
 
 // Std

--- a/mythtv/libs/libmythtv/io/mythavformatbuffer.cpp
+++ b/mythtv/libs/libmythtv/io/mythavformatbuffer.cpp
@@ -10,16 +10,6 @@ MythAVFormatBuffer::MythAVFormatBuffer(MythMediaBuffer *Buffer)
 {
 }
 
-void MythAVFormatBuffer::SetBuffer(MythMediaBuffer *Buffer)
-{
-    m_buffer = Buffer;
-}
-
-MythMediaBuffer* MythAVFormatBuffer::GetBuffer(void)
-{
-    return m_buffer;
-}
-
 int MythAVFormatBuffer::Open(URLContext *Context, const char* /*Filename*/, int /*Flags*/)
 {
     Context->priv_data = nullptr;
@@ -32,7 +22,7 @@ int MythAVFormatBuffer::Read(URLContext *Context, uint8_t *Buffer, int Size)
     if (!avfr)
         return 0;
 
-    int ret = avfr->GetBuffer()->Read(Buffer, Size);
+    int ret = avfr->m_buffer->Read(Buffer, Size);
 
     if (ret == 0)
         ret = AVERROR_EOF;
@@ -45,7 +35,7 @@ int MythAVFormatBuffer::Write(URLContext *Context, const uint8_t *Buffer, int Si
     if (!avfr)
         return 0;
 
-    return avfr->GetBuffer()->Write(Buffer, static_cast<uint>(Size));
+    return avfr->m_buffer->Write(Buffer, static_cast<uint>(Size));
 }
 
 int64_t MythAVFormatBuffer::Seek(URLContext *Context, int64_t Offset, int Whence)
@@ -55,12 +45,12 @@ int64_t MythAVFormatBuffer::Seek(URLContext *Context, int64_t Offset, int Whence
         return 0;
 
     if (Whence == AVSEEK_SIZE)
-        return avfr->GetBuffer()->GetRealFileSize();
+        return avfr->m_buffer->GetRealFileSize();
 
     if (Whence == SEEK_END)
-        return avfr->GetBuffer()->GetRealFileSize() + Offset;
+        return avfr->m_buffer->GetRealFileSize() + Offset;
 
-    return avfr->GetBuffer()->Seek(Offset, Whence);
+    return avfr->m_buffer->Seek(Offset, Whence);
 }
 
 int MythAVFormatBuffer::Close(URLContext* /*Context*/)
@@ -115,7 +105,7 @@ URLProtocol *MythAVFormatBuffer::GetURLProtocol(void)
 void MythAVFormatBuffer::SetInInit(bool State)
 {
     m_initState = State;
-    GetBuffer()->SetReadInternalMode(State);
+    m_buffer->SetReadInternalMode(State);
 }
 
 bool MythAVFormatBuffer::IsInInit(void) const

--- a/mythtv/libs/libmythtv/io/mythavformatbuffer.h
+++ b/mythtv/libs/libmythtv/io/mythavformatbuffer.h
@@ -14,8 +14,6 @@ class MythAVFormatBuffer
 {
   public:
     explicit MythAVFormatBuffer(MythMediaBuffer *Buffer = nullptr);
-    void                SetBuffer      (MythMediaBuffer *Buffer);
-    MythMediaBuffer*    GetBuffer      (void);
     static URLProtocol* GetURLProtocol (void);
     static int          WritePacket    (void* Context, uint8_t *Buffer, int Size);
     static int          ReadPacket     (void* Context, uint8_t *Buffer, int Size);

--- a/mythtv/libs/libmythtv/io/mythavformatbuffer.h
+++ b/mythtv/libs/libmythtv/io/mythavformatbuffer.h
@@ -6,29 +6,29 @@
 
 // FFmpeg
 extern "C" {
-#include "libavformat/avformat.h"
-#include "libavformat/url.h"
+#include "libavformat/avio.h"
 }
 
 class MythAVFormatBuffer
 {
   public:
-    explicit MythAVFormatBuffer(MythMediaBuffer *Buffer = nullptr);
-    static URLProtocol* GetURLProtocol (void);
-    static int          WritePacket    (void* Context, uint8_t *Buffer, int Size);
-    static int          ReadPacket     (void* Context, uint8_t *Buffer, int Size);
-    static int64_t      SeekPacket     (void* Context, int64_t Offset, int Whence);
-    static int          Open           (URLContext* Context, const char *Filename, int Flags);
-    static int          Read           (URLContext* Context, uint8_t *Buffer, int Size);
-    static int          Write          (URLContext* Context, const uint8_t *Buffer, int Size);
-    static int64_t      Seek           (URLContext* Context, int64_t Offset, int Whence);
-    static int          Close          (URLContext* /*Context*/);
+    MythAVFormatBuffer(MythMediaBuffer *Buffer, bool write_flag, bool force_seek);
+    ~MythAVFormatBuffer();
+
     void                SetInInit      (bool State);
     bool                IsInInit       (void) const;
 
+    AVIOContext*        getAVIOContext() { return m_avioContext; }
+
   private:
+    static int read_packet(void *opaque, uint8_t *buf, int buf_size);
+    static int write_packet(void *opaque, uint8_t *buf, int buf_size);
+    static int64_t seek(void *opaque, int64_t offset, int whence);
+
+    AVIOContext* alloc_context(bool write_flag, bool force_seek);
+
     MythMediaBuffer    *m_buffer       { nullptr };
     bool                m_initState    { true    };
-    static URLProtocol  s_avfrURL;
+    AVIOContext        *m_avioContext  { nullptr };
 };
 #endif

--- a/mythtv/libs/libmythtv/io/mythavformatwriter.h
+++ b/mythtv/libs/libmythtv/io/mythavformatwriter.h
@@ -36,6 +36,7 @@ class MTV_PUBLIC MythAVFormatWriter : public MythMediaWriter
     bool ReOpen              (const QString& Filename);
 
   private:
+    bool      openFileHelper();
     AVStream* AddVideoStream (void);
     bool      OpenVideo      (void);
     AVStream* AddAudioStream (void);

--- a/mythtv/libs/libmythtv/io/mythstreamingbuffer.cpp
+++ b/mythtv/libs/libmythtv/io/mythstreamingbuffer.cpp
@@ -1,10 +1,16 @@
+#include "io/mythstreamingbuffer.h"
+
 // Qt
 #include <QUrl>
 
 // MythTV
 #include "libmythbase/mythcorecontext.h"
 #include "libmythbase/mythlogging.h"
-#include "io/mythstreamingbuffer.h"
+
+// FFmpeg
+extern "C" {
+#include "libavformat/avio.h"
+}
 
 #define LOC QString("StreamRingBuf(%1): ").arg(m_filename)
 
@@ -21,7 +27,7 @@ MythStreamingBuffer::~MythStreamingBuffer()
 
     m_rwLock.lockForWrite();
     if (m_context)
-        ffurl_close(m_context);
+        avio_closep(&m_context);
     m_rwLock.unlock();
 }
 
@@ -61,23 +67,21 @@ bool MythStreamingBuffer::OpenFile(const QString &Filename, std::chrono::millise
     if (url.path().endsWith(QLatin1String("m3u8"), Qt::CaseInsensitive))
         url.setScheme("hls+http");
 
-    int res = ffurl_open_whitelist(&m_context, url.toString().toLatin1(), AVIO_FLAG_READ, nullptr, nullptr, nullptr, nullptr, nullptr);
-    if (res >= 0 && m_context && !m_context->is_streamed && ffurl_seek(m_context, 0, SEEK_SET) >= 0)
-    {
-        m_streamed   = false;
-        m_allowSeeks = true;
-    }
-
-    LOG(VB_GENERAL, LOG_INFO, LOC + QString("Trying %1 (allow seeks: %2")
-        .arg(m_filename).arg(m_allowSeeks));
-
+    int res = avio_open(&m_context, url.toString().toLatin1(), AVIO_FLAG_READ);
     if (res < 0 || !m_context)
     {
-        LOG(VB_GENERAL, LOG_ERR, LOC + QString("Failed to open stream (error %1)") .arg(res));
+        LOG(VB_GENERAL, LOG_ERR, LOC + QString("Failed to open stream (%1) (error %2)")
+            .arg(m_filename, QString::number(res)));
         m_lastError = QObject::tr("Failed to open stream (%1)").arg(res);
         m_rwLock.unlock();
         return false;
     }
+
+    m_streamed   = (m_context->seekable & AVIO_SEEKABLE_NORMAL) == 0;
+    m_allowSeeks = !m_streamed && avio_seek(m_context, 0, SEEK_SET) >= 0;
+
+    LOG(VB_GENERAL, LOG_INFO, LOC + QString("Opened %1 (allow seeks: %2")
+        .arg(m_filename, QVariant(m_allowSeeks).toString()));
 
     m_rwLock.unlock();
     return true;
@@ -89,7 +93,7 @@ long long MythStreamingBuffer::SeekInternal(long long Position, int Whence)
         return 0;
 
     m_posLock.lockForWrite();
-    int seek = static_cast<int>(ffurl_seek(m_context, Position, Whence));
+    int64_t seek = avio_seek(m_context, Position, Whence);
     m_posLock.unlock();
 
     if (seek < 0)
@@ -97,7 +101,7 @@ long long MythStreamingBuffer::SeekInternal(long long Position, int Whence)
         m_ateof = true;
         return 0;
     }
-    return Position;
+    return seek;
 }
 
 int MythStreamingBuffer::SafeRead(void *Buffer, uint Size)
@@ -108,7 +112,7 @@ int MythStreamingBuffer::SafeRead(void *Buffer, uint Size)
     {
         while (len < static_cast<int>(Size))
         {
-            int ret = ffurl_read(m_context, static_cast<unsigned char*>(Buffer) + len,
+            int ret = avio_read(m_context, static_cast<unsigned char*>(Buffer) + len,
                                  static_cast<int>(Size) - len);
             if (ret < 0)
             {
@@ -130,7 +134,7 @@ long long MythStreamingBuffer::GetRealFileSizeInternal(void) const
     long long result = -1;
     m_rwLock.lockForRead();
     if (m_context)
-        result = ffurl_size(m_context);
+        result = avio_size(m_context);
     m_rwLock.unlock();
     return result;
 }

--- a/mythtv/libs/libmythtv/io/mythstreamingbuffer.h
+++ b/mythtv/libs/libmythtv/io/mythstreamingbuffer.h
@@ -4,12 +4,6 @@
 // MythTV
 #include "io/mythmediabuffer.h"
 
-// FFmpeg
-extern "C" {
-#include "libavformat/avformat.h"
-#include "libavformat/url.h"
-}
-
 class MythStreamingBuffer : public MythMediaBuffer
 {
   public:
@@ -29,7 +23,7 @@ class MythStreamingBuffer : public MythMediaBuffer
     long long SeekInternal      (long long Position, int Whence) override;
 
   private:
-    URLContext *m_context    { nullptr };
+    struct AVIOContext *m_context    { nullptr };
     bool        m_streamed   { true    };
     bool        m_allowSeeks { false   };
 };

--- a/mythtv/libs/libmythtv/opengl/mythnvdecinterop.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythnvdecinterop.cpp
@@ -8,6 +8,13 @@
 #include <chrono>
 #include <thread>
 
+extern "C" {
+#include "libavutil/log.h"
+#define FFNV_LOG_FUNC(logctx, msg, ...) av_log(logctx, AV_LOG_ERROR, msg,  __VA_ARGS__)
+#define FFNV_DEBUG_LOG_FUNC(logctx, msg, ...) av_log(logctx, AV_LOG_DEBUG, msg,  __VA_ARGS__)
+#include <ffnvcodec/dynlink_loader.h>
+}
+
 #define LOC QString("NVDECInterop: ")
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)

--- a/mythtv/libs/libmythtv/opengl/mythnvdecinterop.h
+++ b/mythtv/libs/libmythtv/opengl/mythnvdecinterop.h
@@ -4,10 +4,9 @@
 // MythTV
 #include "opengl/mythopenglinterop.h"
 
-// FFmpeg
 extern "C" {
-#include "compat/cuda/dynlink_loader.h"
-#include "libavutil/hwcontext_cuda.h"
+#include <ffnvcodec/dynlink_cuda.h>
+struct CudaFunctions;
 }
 
 class MythNVDECInterop : public MythOpenGLInterop


### PR DESCRIPTION
This eliminates the use of FFmpeg's private headers.  There are still other modifications to FFmpeg's public headers preventing use of an unmodified FFmpeg; however, this works towards that goal.

I performed a few tests, but I am not aware of any HTTP streams to test with.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

