### PR TITLE
Fix GCC warnings about missing initializers

### DIFF
--- a/mythtv/libs/libmythtv/osd.h
+++ b/mythtv/libs/libmythtv/osd.h
@@ -82,9 +82,9 @@ class MythOSDDialogData
     };
 
     QString m_dialogName;
-    QString m_message;
+    QString m_message { };
     std::chrono::milliseconds m_timeout { 0ms };
-    std::vector<MythOSDDialogButton> m_buttons;
+    std::vector<MythOSDDialogButton> m_buttons { };
     MythOSDBackButton m_back { };
 };
 


### PR DESCRIPTION
Compiling tv_play.cpp gives a few compiler warnings like this: tv_play.cpp: In member function ‘void TV::ShowOSDAskAllow()’: tv_play.cpp:1739:73: warning: missing initializer for member ‘MythOSDDialogData::m_buttons’ [-Wmissing-field-initializers]
 1739 |         MythOSDDialogData dialog { OSD_DLG_ASKALLOW, message, timeuntil };
and
tv_play.cpp: In member function ‘void TV::StartChannelEditMode()’:
tv_play.cpp:7857:29: warning: missing initializer for member ‘MythOSDDialogData::m_message’ [-Wmissing-field-initializers]
 7857 |         emit ChangeOSDDialog({ OSD_DLG_EDITOR })
These warnings can be fixed by initializing m_buttons and m_message in osd.h.

