### PR TITLE
Github workflow: Remove macOS cross-compile for macOS14

### DIFF
--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -323,16 +323,6 @@ jobs:
             configureopts: '--disable-firewire  --enable-libmp3lame --enable-libvpx  --enable-libxvid --enable-libx264 --enable-libx265 --enable-bdjava'
             linkerflags: '-Wl,-ld_classic'
             cross_compile: false
-          - desc: 'macOS 14 (Sonoma) x86_64'
-            runner: 'macOS-14'
-            arch: 'x86_64'
-            python_dot_version: '3.11'
-            qt_version: 'qt5'
-            database_version: 'mysql8'
-            extrapkgs: ''
-            configureopts: '--disable-firewire  --enable-libmp3lame --enable-libvpx  --enable-libxvid --enable-libx264 --enable-libx265 --enable-bdjava'
-            linkerflags: '-Wl,-ld_classic'
-            cross_compile: true
           - desc: 'macOS 14 (Sonoma) arm64'
             runner: 'macOS-14'
             arch: 'arm64'


### PR DESCRIPTION
 The macOS 14 runner hardware is arm64 requiring the x86_64 build to
 cross-compile via rosetta2.  Unfortunately, this cross-compile
 mechanism has a tendency to stall out leading to false negatives in
 the CI process.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

