### PR TITLE
Remove macOS 12 CI build job from the actions workflow

### DIFF
--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -303,16 +303,6 @@ jobs:
       matrix:
         os:
           # macOS group
-          - desc: 'macOS 12 (Monterey) x86_64'
-            runner: 'macOS-12'
-            arch: 'x86_64'
-            python_dot_version: '3.11'
-            qt_version: 'qt5'
-            database_version: 'mysql8'
-            extrapkgs: ''
-            configureopts: '--disable-firewire  --enable-libmp3lame --enable-libvpx  --enable-libxvid --enable-libx264 --enable-libx265 --enable-bdjava'
-            linkerflags: ''
-            cross_compile: false
           - desc: 'macOS 13 (Ventura) x86_64'
             runner: 'macOS-13'
             arch: 'x86_64'


### PR DESCRIPTION
Per https://github.com/actions/runner-images/issues/10721
macOS 12 will be removed from github action runners on
12/03/24.

Remove the CI build from the workflow



Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

