### PR TITLE
Fix cmake compilation with dvdcss

### DIFF
--- a/mythtv/external/libmythdvdnav/CMakeLists.txt
+++ b/mythtv/external/libmythdvdnav/CMakeLists.txt
@@ -122,6 +122,9 @@ target_link_libraries(mythdvdnav PUBLIC ${CMAKE_DL_LIBS})
 if(APPLE)
   target_link_libraries(mythdvdnav PRIVATE ${APPLE_CORE_FOUNDATION})
 endif()
+if(HAVE_DVDCSS_DVDCSS_H)
+  target_link_libraries(mythdvdnav PRIVATE dvdcss)
+endif()
 
 #
 # The MythTV customization to dvdnav adds references to the MythFile* functions,


### PR DESCRIPTION
The commit fixes the following error, trying to link libmythdvdnav

/usr/bin/ld: ../../../../external/libmythdvdnav/libmythdvdnav-35.so.35.0: undefined reference to `dvdcss_open'
/usr/bin/ld: ../../../../external/libmythdvdnav/libmythdvdnav-35.so.35.0: undefined reference to `dvdcss_close'
/usr/bin/ld: ../../../../external/libmythdvdnav/libmythdvdnav-35.so.35.0: undefined reference to `dvdcss_open_stream'
/usr/bin/ld: ../../../../external/libmythdvdnav/libmythdvdnav-35.so.35.0: undefined reference to `dvdcss_read'
/usr/bin/ld: ../../../../external/libmythdvdnav/libmythdvdnav-35.so.35.0: undefined reference to `dvdcss_seek'
collect2: error: ld returned 1 exit status

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

