### PR TITLE
Fix CMake build broken by 2272bae340

### DIFF
--- a/mythtv/programs/mythbackend/CMakeLists.txt
+++ b/mythtv/programs/mythbackend/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(
   servicesv2/v2musicMetadataInfoList.h
   servicesv2/v2myth.cpp
   servicesv2/v2myth.h
+  servicesv2/v2playGroup.h
   servicesv2/v2programAndChannel.h
   servicesv2/v2programGuide.h
   servicesv2/v2programList.h


### PR DESCRIPTION
Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)


This fixes the CMake build inadvertently broken by commit 2272bae340