### PR TITLE
Improved scheduler log messages

### DIFF
--- a/mythtv/programs/mythbackend/scheduler.cpp
+++ b/mythtv/programs/mythbackend/scheduler.cpp
@@ -1095,7 +1095,9 @@ bool Scheduler::FindNextConflict(
             continue;
 
         if (debugConflicts)
-            msg = QString("comparing with '%1' ").arg(q->GetTitle());
+            msg = QString("comparing '%1' on %2 with '%3' on %4")
+                .arg(p->GetTitle()).arg(p->GetChanNum())
+                .arg(q->GetTitle()).arg(q->GetChanNum());
 
         if (p->GetInputID() != q->GetInputID() && !ignoreinput)
         {
@@ -1145,7 +1147,7 @@ bool Scheduler::FindNextConflict(
         {
             LOG(VB_SCHEDULE, LOG_INFO, msg);
             LOG(VB_SCHEDULE, LOG_INFO,
-                QString("  cardid's: [%1], [%2] Share an input group"
+                QString("  cardid's: [%1], [%2] Share an input group, "
                         "mplexid's: %3, %4")
                      .arg(p->GetInputID()).arg(q->GetInputID())
                      .arg(p->m_mplexId).arg(q->m_mplexId));


### PR DESCRIPTION
The comparing message has been updated to specify
both programs, and to show the channels for those
programs.

The "groupmplexid's" message has been updated to
separate the words which have been smashed
together.

Resolves: #967

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

