### PR TITLE
Harmonize Title-Parsing of Movies and TV-Series

### DIFF
--- a/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
@@ -12,7 +12,7 @@
 #-----------------------
 __title__ = "TheMovieDB.org V3"
 __author__ = "Raymond Wagner, Roland Ernst"
-__version__ = "0.3.11"
+__version__ = "0.3.12"
 # 0.1.0 Initial version
 # 0.2.0 Add language support, move cache to home directory
 # 0.3.0 Enable version detection to allow use in MythTV
@@ -32,6 +32,7 @@ __version__ = "0.3.11"
 # 0.3.9 Support TV lookup
 # 0.3.10 Use new API for release dates for movies
 # 0.3.11 Allow queries for specials in series in TV lookup
+# 0.3.12 `buildMovieList` searches now for movies with year
 
 # ~ from optparse import OptionParser
 import sys
@@ -189,10 +190,10 @@ def buildMovieList(query, opts):
     # as negative to all text that comes afterwards
     query = query.replace('-',' ')
 
-    from MythTV.tmdb3 import searchMovie
+    from MythTV.tmdb3 import searchMovieWithYear
     from MythTV import VideoMetadata
     from lxml import etree
-    results = iter(searchMovie(query))
+    results = iter(searchMovieWithYear(query))
     tree = etree.XML('<metadata></metadata>')
     mapping = [['runtime',      'runtime'],     ['title',       'originaltitle'],
                ['releasedate',  'releasedate'], ['tagline',     'tagline'],

--- a/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.h
+++ b/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.h
@@ -62,7 +62,7 @@ class Testvideometadata: public QObject
     {
         // With Spaces as separator
         TestMetadata(QString("A Movie Title (1984).mpg"),
-                     QString("A Movie Title"),
+                     QString("A Movie Title (1984)"),
                      QString(""),
                      0,
                      0);

--- a/mythtv/libs/libmythmetadata/videometadata.cpp
+++ b/mythtv/libs/libmythmetadata/videometadata.cpp
@@ -1210,8 +1210,8 @@ QString VideoMetadata::FilenameToMeta(const QString &file_name, int position)
         title = title.right(title.length() -
                      title.lastIndexOf('/') -1);
 
+        // Allow parentheses "()", but remove content inside other braces
         title = eatBraces(title, "[", "]");
-        title = eatBraces(title, "(", ")");
         title = eatBraces(title, "{", "}");
         return title.trimmed();
     }


### PR DESCRIPTION
MythTV parses filenames of movies and series according
the scheme defined in
https://www.mythtv.org/wiki/MythVideo_File_Parsing

For tv-series, it is allowed to add the year in the title,
like `The Forsyte Saga (1967)` or `The Forsyte Saga (2002)`,
e.g.: `The Forsyte Saga (1967) 1x01 A Family Festival.mkv`
is correctly parsed.
This may help the television grabber of MythTV to find the
correct entry.

In contrast, all kind of braces are removed from the filename
when parsing video titles:
`Ocean's Eleven (2001).mp4` becomes `Ocean's Eleven 2001`
according the filename convention on the wiki.
This confuses the movie grabber of MythTV because it
cannot be distinguished whether the year is part of the
title or it is the year of the release. For exact this reason,
grabbing for titles ending with a year is not implemented in
the movie grabber tmdb3.py.
Popular examples for different movies with year in the title:
`Wonder Woman` vs. `Wonder Woman 1984`
`Blues Brothers` vs. `Blues Brothers 2000`

This change respects parentheses "()" in the filename of
a movie, thus parsing of the release year will work.
Furhermore, it enables correct parsing of titles containing
parentheses, like `I (Almost) Got away with It` or
`(T)Raumschiff Surprise - Periode 1`.
Advanced searches on imdb.com for 'parenthesis in title'
and 'movies with year in the title' show a lot of matches,
but I found no movie title that ends with a year (4 digits)
in parentheses.

The wiki page at https://www.mythtv.org/wiki/MythVideo_File_Parsing
needs to be upated that the correct syntax is from now on
"A Movie Title (YYYY).mpg" instead of "A Movie Title YYYY.mpg".
The latter was introduced in 2012 without providing a rationale,
but afaik never implemented by the MyhTV movie grabbers
(ttmdb3.py, tmdb.py or its predecessor jamu.py).
Backward compatibility is provided, i.e.: adding a releaase year
without parentheses works the same way as before this change:
The movie grabber will probably not find the correct entry.

This pull reqest supersedes PR #103 .

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x ] code compiles successfully without errors
- [x ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x ] documentation added/updated/removed where necessary
- [x ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

