### PR TITLE
Fix failure to clear last forced subtitle in a sequence

### DIFF
--- a/mythtv/libs/libmythtv/captions/subtitlereader.cpp
+++ b/mythtv/libs/libmythtv/captions/subtitlereader.cpp
@@ -77,7 +77,7 @@ bool SubtitleReader::AddAVSubtitle(AVSubtitle &subtitle,
 
     if (!m_avSubtitlesEnabled && !isExternal)
     {
-        if (!forced)
+        if (!(is_selected_forced_track || forced))
         {
             FreeAVSubtitle(subtitle);
             return enableforced;


### PR DESCRIPTION
Some types of subtitle, rather than being tagged with a duration, rely on the next in sequence to clear them, specifically with an empty subtitle at the end of the sequence. AddAVSubtitle has to handle forced subtitles, causing them to be displayed even when subtitles are off. It was detecting a subtitle being forced by looking for a "forced" flag amongst the subtitle's rectangles. That failed to detect the case of an empty subtitle. Hence the last non-empty forced subtitle was not being cleared by the subsequent empty one. This commit changes the detection condition, using instead a flag that denotes whether the subtitle is from the currently selected forced track.

This fixes Issue #978

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

