### PR TITLE
fix QT>=6.4 segfault by always setting surface type

### DIFF
--- a/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
+++ b/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
@@ -541,12 +541,10 @@ void MythRenderOpenGL::SetWidget(QWidget *Widget)
         return;
     }
 
-#ifdef Q_OS_ANDROID
     // Ensure surface type is always OpenGL
     m_window->setSurfaceType(QWindow::OpenGLSurface);
     if (native && native->windowHandle())
         native->windowHandle()->setSurfaceType(QWindow::OpenGLSurface);
-#endif
 
 #ifdef USING_QTWEBENGINE
     auto * globalcontext = QOpenGLContext::globalShareContext();


### PR DESCRIPTION
See #754 for details but this is the recommendation from QT dev @alpqr  that 100% WFM.   Note, as I mention there officially the old behavior would be best replicated by setting this to the internal value `QSurface::RasterGLSurface` from https://doc.qt.io/qt-6/qsurface.html#SurfaceType-enum  as this is what QT 6.3 and lower did.  If you want me to update the PR to that I can.  I don't have osx to test there.  

Clearly people are running mythtv with QT > 6.3 so I am not sure why only some users hit this bug.   Maybe it is only if they have hardware rendering enabled? Given how long it has stood though there must be something scoping it to just a select few of us.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x ] code compiles successfully without errors
- [x ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ x] documentation added/updated/removed where necessary
- [ x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

Fixes #754 