### PR TITLE
Add EXTINF format

### DIFF
--- a/mythtv/libs/libmythtv/channelscan/iptvchannelfetcher.cpp
+++ b/mythtv/libs/libmythtv/channelscan/iptvchannelfetcher.cpp
@@ -628,6 +628,22 @@ static bool parse_extinf(const QString &line,
         return true;
     }
 
+    // #EXTINF:0,Channel Title
+    {
+        static const QRegularExpression chanNumName
+            { "^(\\d+),(.*)$" };
+        match = chanNumName.match(line);
+        if (match.hasMatch())
+        {
+            channum = match.captured(1).simplified();
+            name = match.captured(2).simplified();
+
+            if (name.isEmpty())
+                return false;
+
+            return true;
+        }
+    }
 
     // Not one of the formats we support
     QString msg = LOC + QString("Invalid header in channel list line \n\t\t\tEXTINF:%1").arg(line);


### PR DESCRIPTION
Add a simple EXTINF format in the IPTV channel fetcher that can parse the format "EXTINF:0,Channel_Title".

Refs #936

