### PR TITLE
DeleteAllInputs must not delete iptv_channel

### DIFF
--- a/mythtv/libs/libmythtv/cardutil.cpp
+++ b/mythtv/libs/libmythtv/cardutil.cpp
@@ -2894,8 +2894,7 @@ bool CardUtil::DeleteAllInputs(void)
     return (query.exec("TRUNCATE TABLE inputgroup") &&
             query.exec("TRUNCATE TABLE diseqc_config") &&
             query.exec("TRUNCATE TABLE diseqc_tree") &&
-            query.exec("TRUNCATE TABLE capturecard") &&
-            query.exec("TRUNCATE TABLE iptv_channel"));
+            query.exec("TRUNCATE TABLE capturecard"));
 }
 
 std::vector<uint> CardUtil::GetInputList(void)


### PR DESCRIPTION
The CardUtil function DeleteAllInputs does delete the content of all four tables related to inputs but it does also delete the content of table iptv_channel.
This is not correct; table iptv_channel contains the URLs of the channels that are IPTV channels.
This bug has been introduced as part of commit d4c0f13. The entries in table iptv_channel can only be removed when the corresponding channel has been deleted.
This is done as part of a periodic housekeeping task.

Refs #936