### PR TITLE
Remove duplicate browse channel list

### DIFF
--- a/mythtv/libs/libmythtv/tvbrowsehelper.cpp
+++ b/mythtv/libs/libmythtv/tvbrowsehelper.cpp
@@ -54,8 +54,6 @@ void TVBrowseHelper::BrowseInit(std::chrono::seconds BrowseMaxForward, bool Brow
         m_dbChannumToChanids.insert(chan.m_chanNum,chan.m_chanId);
     }
 
-    m_dbAllVisibleChannels = ChannelUtil::GetChannels(0, true, "channum, callsign");
-    ChannelUtil::SortChannels(m_dbAllVisibleChannels, DBChannelOrdering, false);
     start();
 }
 
@@ -342,7 +340,7 @@ void TVBrowseHelper::GetNextProgramDB(BrowseDirection direction, InfoMap& Infoma
 
     if (chandir != -1)
     {
-        chanid = ChannelUtil::GetNextChannel(m_dbAllVisibleChannels,
+        chanid = ChannelUtil::GetNextChannel(m_dbAllChannels,
                                             chanid,
                                              0 /* mplexid_restriction */,
                                              0 /* chanid restriction */,

--- a/mythtv/libs/libmythtv/tvbrowsehelper.h
+++ b/mythtv/libs/libmythtv/tvbrowsehelper.h
@@ -72,7 +72,6 @@ class TVBrowseHelper : public MThread
 
     TV*                     m_parent                { nullptr };
     ChannelInfoList         m_dbAllChannels;
-    ChannelInfoList         m_dbAllVisibleChannels;
     std::chrono::seconds    m_dbBrowseMaxForward    { 0s };
     bool                    m_dbBrowseAllTuners     { false };
     bool                    m_dbUseChannelGroups    { false };


### PR DESCRIPTION
When starting TV playback, either from a recording or live, a list of all channels is created that can be used to select another channel with the up/down keys while watching.
This channel list is created twice; as the name implies one for all channels and one for all visible channels. However, both lists are identical and contain all channels. The check on visible or not was already been done somewhere else in the code.
Therefore only one list with all channels is needed. Note that the time to create this list can be significant when there are a large number of channels. With satellites and especially with IPTV the number of channels can easily become very large, as in several thousands.
