### PR TITLE
Do not delete IPTV channel in DeleteChannel

### DIFF
--- a/mythtv/libs/libmythtv/channelutil.cpp
+++ b/mythtv/libs/libmythtv/channelutil.cpp
@@ -1822,17 +1822,6 @@ bool ChannelUtil::DeleteChannel(uint channel_id)
         return false;
     }
 
-    query.prepare(
-        "DELETE FROM iptv_channel "
-        "WHERE chanid = :ID");
-    query.bindValue(":ID", channel_id);
-
-    if (!query.exec())
-    {
-        MythDB::DBError("Delete Channel 2", query);
-        return false;
-    }
-
     return true;
 }
 


### PR DESCRIPTION
The function DeleteChannel does not really delete a channel but marks it for deletion when it is no longer referenced. This is introduced in commit 2e26f7f12fce13c155e43ff536b1e09a342e1722. Because the channel is not really deleted, as in removed from the database, the associated record in table iptv_channel should also not be deleted here.
The channel is removed from the database in a periodic housekeeping task when there are no more recordings referencing that channel and when at least one day has passed since the channel was marked for deletion.
When the channel is finally deleted then also the corresponding entry in iptv_channel, when it exists, should be deleted.
