### PR TITLE
Clean up EIT fixes for ProSiebenSat.1 and Vodafone Germany

### DIFF
--- a/mythtv/libs/libmythtv/eithelper.cpp
+++ b/mythtv/libs/libmythtv/eithelper.cpp
@@ -1124,10 +1124,6 @@ static void init_fixup(FixupMap &fix)
     fix[      1089LL << 32 |     1  << 16] = // DVB-S
     fix[ 1041LL << 32 | 1 << 16] = // DVB-S RTL Group HD Austria Transponder
     fix[ 1057LL << 32 | 1 << 16] = // DVB-S RTL Group HD Transponder
-        fix[   773LL << 32 |  8468U << 16] = // DVB-T Berlin/Brandenburg
-        fix[  2819LL << 32 |  8468U << 16] = // DVB-T Niedersachsen + Bremen
-        fix[  8706LL << 32 |  8468U << 16] = // DVB-T NRW
-        fix[ 12801LL << 32 |  8468U << 16] = // DVB-T Bayern
         EITFixUp::kFixRTL;
 
     // Mark HD+ channels as HDTV
@@ -1136,19 +1132,17 @@ static void init_fixup(FixupMap &fix)
     fix[   1057LL << 32 |  1 << 16] = EITFixUp::kFixHDTV;
     fix[   1109LL << 32 |  1 << 16] = EITFixUp::kFixHDTV;
 
-    // PRO7/SAT.1
-    fix[   1017LL << 32 |    1 << 16] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1;
-    fix[   1031LL << 32 |    1 << 16 | 5300] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1;
-    fix[   1031LL << 32 |    1 << 16 | 5301] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1;
-    fix[   1031LL << 32 |    1 << 16 | 5302] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1;
-    fix[   1031LL << 32 |    1 << 16 | 5303] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1;
-    fix[   1031LL << 32 |    1 << 16 | 5310] = EITFixUp::kFixP7S1;
-    fix[   1031LL << 32 |    1 << 16 | 5311] = EITFixUp::kFixP7S1;
-    fix[   1107LL << 32 |    1 << 16] = EITFixUp::kFixP7S1;
-    fix[   1082LL << 32 |    1 << 16] = EITFixUp::kFixP7S1;
-    fix[      5LL << 32 |  133 << 16 |   776] = EITFixUp::kFixP7S1;
-    fix[                  8468 << 16 | 16426] = EITFixUp::kFixP7S1; // ProSieben MAXX - DVB-T Rhein/Main
-    fix[   8707LL << 32 | 8468 << 16]         = EITFixUp::kFixP7S1; // ProSieben Sat.1 Mux - DVB-T Rhein/Main
+    // PRO7/SAT.1 DVB-S
+    fix[   1017LL << 32 |    1 << 16] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1; // DVB-S ProSiebenSat.1 Austria transponder
+    fix[   1031LL << 32 |    1 << 16 | 5300] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1; // SAT.1 HD Austria
+    fix[   1031LL << 32 |    1 << 16 | 5301] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1; // ProSieben HD Austria
+    fix[   1031LL << 32 |    1 << 16 | 5302] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1; // kabel eins HD Austria
+    fix[   1031LL << 32 |    1 << 16 | 5303] = EITFixUp::kFixHDTV | EITFixUp::kFixP7S1; // PULS 4 HD Austria
+    fix[   1031LL << 32 |    1 << 16 | 5310] = EITFixUp::kFixP7S1; // SAT.1 Gold Austria
+    fix[   1031LL << 32 |    1 << 16 | 5311] = EITFixUp::kFixP7S1; // Pro7 MAXX Austria
+    fix[   1107LL << 32 |    1 << 16] = EITFixUp::kFixP7S1; // DVB-S ProSiebenSat.1 Germany transponder
+    fix[   1082LL << 32 |    1 << 16] = EITFixUp::kFixP7S1; // DVB-S ProSiebenSat.1 Switzerland transponder
+    fix[      5LL << 32 |  133 << 16 |   776] = EITFixUp::kFixP7S1; // DVB-S ProSiebenSat.1 Germany transponder
 
     // ATV / ATV2
     fix[   1117LL << 32 |  1 << 16 | 13012 ] = EITFixUp::kFixATV; // ATV
@@ -1244,79 +1238,24 @@ static void init_fixup(FixupMap &fix)
     fix[4097U << 16] |= EITFixUp::kEFixForceISO8859_1;
     fix[4098U << 16] |= EITFixUp::kEFixForceISO8859_1;
 
-    //DVB-T Germany Berlin HSE/MonA TV
-    fix[  772LL << 32 | 8468 << 16 | 16387] = EITFixUp::kEFixForceISO8859_15;
-    //DVB-T Germany Ruhrgebiet Tele 5
-    //fix[ 8707LL << 32 | 8468 << 16 | 16413] = EITFixUp::kEFixForceISO8859_15; // they are sending the ISO 8859-9 signalling now
-    // ANIXE
-    fix[ 8707LL << 32 | 8468U << 16 | 16426 ] = // DVB-T Rhein-Main
-        EITFixUp::kEFixForceISO8859_9;
-
-    // DVB-C Kabel Deutschland encoding fixes Germany
-    fix[   112LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    fix[ 10000LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    fix[ 10001LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    fix[ 10002LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    fix[ 10003LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    fix[ 10006LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    fix[ 10009LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    fix[ 10010LL << 32 | 61441U << 16] = EITFixUp::kEFixForceISO8859_15;
-    // Mark program on the HD transponders as HDTV
-    fix[ 10012LL << 32 | 61441U << 16] = EITFixUp::kFixHDTV;
-    fix[ 10013LL << 32 | 61441U << 16] = EITFixUp::kFixHDTV;
-    // On transport 10004 only DMAX needs no fixing:
-    fix[10004LL<<32 | 61441U << 16 | 50403] = // BBC World Service
-    fix[10004LL<<32 | 61441U << 16 | 53101] = // BBC Prime (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53108] = // Toon Disney (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53109] = // Sky News (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53406] = // BBC Prime
-    fix[10004LL<<32 | 61441U << 16 | 53407] = // Boomerang (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53404] = // Boomerang
-    fix[10004LL<<32 | 61441U << 16 | 53408] = // TCM Classic Movies (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53409] = // Extreme Sports
-    fix[10004LL<<32 | 61441U << 16 | 53410] = // CNBC Europe (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53503] = // Detski Mir
-    fix[10004LL<<32 | 61441U << 16 | 53411] = // Sat.1 Comedy
-    fix[10004LL<<32 | 61441U << 16 | 53412] = // kabel eins classics
-    fix[10004LL<<32 | 61441U << 16 | 53112] = // Extreme Sports (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53513] = // Playhouse Disney (engl)
-    fix[10004LL<<32 | 61441U << 16 | 53618] = // K1010
-    fix[10004LL<<32 | 61441U << 16 | 53619] = // GemsTV
-        EITFixUp::kEFixForceISO8859_15;
-    // On transport 10005 QVC and Giga Digital  needs no fixing:
-    fix[10005LL<<32 | 61441U << 16 | 50104] = // E! Entertainment
-    fix[10005LL<<32 | 61441U << 16 | 50107] = // 13th Street (KD)
-    fix[10005LL<<32 | 61441U << 16 | 50301] = // ESPN Classic
-    fix[10005LL<<32 | 61441U << 16 | 50302] = // VH1 Classic
-    fix[10005LL<<32 | 61441U << 16 | 50303] = // Wein TV
-    fix[10005LL<<32 | 61441U << 16 | 50304] = // AXN
-    fix[10005LL<<32 | 61441U << 16 | 50305] = // Silverline
-    fix[10005LL<<32 | 61441U << 16 | 50306] = // NASN
-    fix[10005LL<<32 | 61441U << 16 | 50307] = // Disney Toon
-    fix[10005LL<<32 | 61441U << 16 | 53105] = // NASN (engl)
-    fix[10005LL<<32 | 61441U << 16 | 53115] = // VH1 Classic (engl)
-    fix[10005LL<<32 | 61441U << 16 | 53405] = // ESPN Classic (engl)
-    fix[10005LL<<32 | 61441U << 16 | 53402] = // AXN (engl)
-    fix[10005LL<<32 | 61441U << 16 | 53613] = // CNN (engl)
-    fix[10005LL<<32 | 61441U << 16 | 53516] = // Voyages Television
-    fix[10005LL<<32 | 61441U << 16 | 53611] = // Der Schmuckkanal
-    fix[10005LL<<32 | 61441U << 16 | 53104] = // Jukebox
-        EITFixUp::kEFixForceISO8859_15;
-    // On transport 10007 only following channels need fixing:
-    fix[10007LL<<32| 61441U << 16 | 53607] = // Eurosport
-    fix[10007LL<<32| 61441U << 16 | 53608] = // Das Vierte
-    fix[10007LL<<32| 61441U << 16 | 53609] = // Viva
-    fix[10007LL<<32| 61441U << 16 | 53628] = // COMEDY CENTRAL
-        EITFixUp::kEFixForceISO8859_15;
-    // RTL Subtitle parsing
-    fix[10007LL<<32| 61441U << 16 | 53601] = // RTL
-    fix[10007LL<<32| 61441U << 16 | 53602] = // Super RTL
-    fix[10007LL<<32| 61441U << 16 | 53604] = // VOX
-    fix[10007LL<<32| 61441U << 16 | 53606] = // n-tv
-        EITFixUp::kFixRTL | EITFixUp::kFixCategory;
-    // On transport 10008 only following channels need fixing:
-    fix[    10008LL<<32 | 61441U << 16 | 53002] = // Tele 5
-        EITFixUp::kEFixForceISO8859_15;
+    // DVB-C Vodafone Germany
+    fix[ 10000LL<<32 | 61441U << 16 | 53626 ] = EITFixUp::kFixP7S1; // SAT.1
+    fix[ 10006LL<<32 | 61441U << 16 | 50019 ] = EITFixUp::kFixP7S1; // sixx HD
+    fix[ 10008LL<<32 | 61441U << 16 | 53621 ] = EITFixUp::kFixP7S1; // ProSieben
+    fix[ 10008LL<<32 | 61441U << 16 | 53622 ] = EITFixUp::kFixP7S1; // kabel eins
+    fix[ 10008LL<<32 | 61441U << 16 | 50700 ] = EITFixUp::kFixP7S1; // sixx
+    fix[ 10011LL<<32 | 61441U << 16 | 50056 ] = EITFixUp::kFixP7S1; // kabel eins CLASSICS HD
+    fix[ 10011LL<<32 | 61441U << 16 | 50058 ] = EITFixUp::kFixP7S1; // SAT.1 emotions HD
+    fix[ 10013LL<<32 | 61441U << 16 | 50015 ] = EITFixUp::kFixP7S1; // ProSieben HD
+    fix[ 10013LL<<32 | 61441U << 16 | 50057 ] = EITFixUp::kFixP7S1; // ProSieben FUN HD
+    fix[ 10013LL<<32 | 61441U << 16 | 50086 ] = EITFixUp::kFixP7S1; // Kabel eins Doku HD
+    fix[ 10014LL<<32 | 61441U << 16 | 50086 ] = EITFixUp::kFixP7S1; // kabel eins HD
+    fix[ 10017LL<<32 | 61441U << 16 | 50122 ] = EITFixUp::kFixP7S1; // kabel eins Doku
+    fix[ 10017LL<<32 | 61441U << 16 | 53009 ] = EITFixUp::kFixP7S1; // ProSieben MAXX
+    fix[ 10017LL<<32 | 61441U << 16 | 53324 ] = EITFixUp::kFixP7S1; // SAT.1 Gold
+    fix[ 10019LL<<32 | 61441U << 16 | 50018 ] = EITFixUp::kFixP7S1; // SAT.1 HD
+    fix[ 10020LL<<32 | 61441U << 16 | 50046 ] = EITFixUp::kFixP7S1; // ProSieben MAXX HD
+    fix[ 10020LL<<32 | 61441U << 16 | 50074 ] = EITFixUp::kFixP7S1; // SAT.1 Gold HD
 
     // DVB-C Unitymedia Germany
     fix[ 9999 << 16 |   161LL << 32 | 12101 ] = // RTL Television

--- a/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.cpp
+++ b/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.cpp
@@ -540,28 +540,38 @@ void TestEITFixups::testUKXFiles()
 void TestEITFixups::testDEPro7Sat1()
 {
     DBEventEIT *event = SimpleDBEventEIT (EITFixUp::kFixP7S1,
-                                         "Titel",
-                                         "Folgentitel, Mystery, USA 2011",
+                                         "The Big Bang Theory",
+                                         "Eine Nacht pro Woche Sitcom, USA 2015 Altersfreigabe: Ohne Altersbeschränkung (WH vom Montag, 18.11.2024, 15:35 Uhr)",
                                          "Beschreibung");
 
     PRINT_EVENT(*event);
     EITFixUp::Fix(*event);
     PRINT_EVENT(*event);
-    QCOMPARE(event->m_title,    QString("Titel"));
-    QCOMPARE(event->m_subtitle, QString("Folgentitel"));
-    QCOMPARE(event->m_airdate,  (unsigned short) 2011);
+    QCOMPARE(event->m_title, QString("The Big Bang Theory"));
+    QCOMPARE(event->m_subtitle, QString("Eine Nacht pro Woche"));
+    QCOMPARE(event->m_description, QString("Beschreibung (USA 2015)"));
+    QCOMPARE(event->m_category, QString("Sitcom"));
+    QCOMPARE(event->m_airdate, (unsigned short) 2015);
+    QCOMPARE(event->m_originalairdate, QDate(2015, 1, 1));
+    QCOMPARE(event->m_previouslyshown, true);
+    checkRating(*event, "DE", "0");
 
     delete event;
 
     DBEventEIT *event2 = SimpleDBEventEIT (EITFixUp::kFixP7S1,
-                                           "Titel",
-                                           "Kurznachrichten, D 2015",
+                                           "taff",
+                                           "taff Infotainment, D 2024",
                                            "Beschreibung");
     PRINT_EVENT(*event2);
     EITFixUp::Fix(*event2);
     PRINT_EVENT(*event2);
+    QCOMPARE(event2->m_title, QString("taff"));
     QCOMPARE(event2->m_subtitle, QString(""));
-    QCOMPARE(event2->m_airdate,  (unsigned short) 2015);
+    QCOMPARE(event2->m_description, QString("Beschreibung (D 2024)"));
+    QCOMPARE(event2->m_category, QString("Infotainment"));
+    QCOMPARE(event2->m_airdate, (unsigned short) 2024);
+    QCOMPARE(event2->m_originalairdate, QDate(2024, 1, 1));
+    QCOMPARE(event2->m_previouslyshown, false);
 
     delete event2;
 
@@ -572,65 +582,68 @@ void TestEITFixups::testDEPro7Sat1()
     PRINT_EVENT(*event3);
     EITFixUp::Fix(*event3);
     PRINT_EVENT(*event3);
+    QCOMPARE(event3->m_title, QString("Titel"));
     QCOMPARE(event3->m_subtitle, QString("Folgentitel"));
-    QCOMPARE(event3->m_airdate,  (unsigned short) 0);
+    QCOMPARE(event3->m_description, QString("Beschreibung"));
+    QCOMPARE(event3->m_airdate, (unsigned short) 0);
+    QCOMPARE(event3->m_previouslyshown, false);
 
     delete event3;
 
+
     DBEventEIT *event4 = SimpleDBEventEIT (EITFixUp::kFixP7S1,
-                                           "Titel",
-                                           "\"Lokal\", Ort, Doku-Soap, D 2015",
+                                           "The Taste",
+                                           "The Taste Kochshow, D 2024 Altersfreigabe: ab 6 Mit Gebärdensprache (Online-Stream)",
                                            "Beschreibung");
     PRINT_EVENT(*event4);
     EITFixUp::Fix(*event4);
     PRINT_EVENT(*event4);
-    QCOMPARE(event4->m_subtitle, QString("\"Lokal\", Ort"));
-    QCOMPARE(event4->m_airdate,  (unsigned short) 2015);
+    QCOMPARE(event4->m_title, QString("The Taste"));
+    QCOMPARE(event4->m_subtitle, QString(""));
+    QCOMPARE(event4->m_description, QString("Beschreibung (D 2024)"));
+    QCOMPARE(event4->m_category, QString("Kochshow"));
+    QCOMPARE(event4->m_airdate, (unsigned short) 2024);
+    QCOMPARE(event4->m_originalairdate, QDate(2024, 1, 1));
+    QCOMPARE(event4->m_previouslyshown, false);
+    checkRating(*event4, "DE", "6");
 
     delete event4;
 
     DBEventEIT *event5 = SimpleDBEventEIT (EITFixUp::kFixP7S1,
                                            "Titel",
-                                           "In Morpheus' Armen, Science-Fiction, CDN/USA 2006",
+                                           "Event Horizon - Am Rande des Universums Science-Fiction, USA/GB 1997 Altersfreigabe: ab 16",
                                            "Beschreibung");
     PRINT_EVENT(*event5);
     EITFixUp::Fix(*event5);
     PRINT_EVENT(*event5);
-    QCOMPARE(event5->m_subtitle, QString("In Morpheus' Armen"));
-    QCOMPARE(event5->m_airdate,  (unsigned short) 2006);
+    QCOMPARE(event5->m_title, QString("Titel"));
+    QCOMPARE(event5->m_subtitle, QString("Event Horizon - Am Rande des Universums"));
+    QCOMPARE(event5->m_description, QString("Beschreibung (USA/GB 1997)"));
+    QCOMPARE(event5->m_airdate, (unsigned short) 1997);
+    QCOMPARE(event5->m_originalairdate, QDate(1997, 1, 1));
+    QCOMPARE(event5->m_category, QString("Science-Fiction"));
+    QCOMPARE(event5->m_previouslyshown, false);
+    checkRating(*event5, "DE", "16");
 
     delete event5;
 
     DBEventEIT *event6 = SimpleDBEventEIT (EITFixUp::kFixP7S1,
                                            "Titel",
-                                           "Drei Kleintiere durchschneiden (1), Zeichentrick, J 2014",
+                                           "Doku-Reihe, USA 2016 Altersfreigabe: ab 12",
                                            "Beschreibung");
     PRINT_EVENT(*event6);
     EITFixUp::Fix(*event6);
     PRINT_EVENT(*event6);
-    QCOMPARE(event6->m_subtitle, QString("Drei Kleintiere durchschneiden (1)"));
-    QCOMPARE(event6->m_airdate,  (unsigned short) 2014);
+    QCOMPARE(event6->m_title, QString("Titel"));
+    QCOMPARE(event6->m_subtitle, QString(""));
+    QCOMPARE(event6->m_description, QString("Beschreibung (USA 2016)"));
+    QCOMPARE(event6->m_category, QString("Doku-Reihe"));
+    QCOMPARE(event6->m_airdate, (unsigned short) 2016);
+    QCOMPARE(event6->m_originalairdate, QDate(2016, 1, 1));
+    QCOMPARE(event6->m_previouslyshown, false);
+    checkRating(*event6, "DE", "12");
 
     delete event6;
-
-    /* #12151 */
-    DBEventEIT *event7 = SimpleDBEventEIT (EITFixUp::kFixP7S1,
-                                           "Criminal Minds",
-                                           "<episode title>, Crime-Serie, USA 2011",
-                                           "<plot summary>\n\n"
-                                           "Regie: Frau Regisseur\n"
-                                           "Drehbuch: Lieschen Mueller, Frau Meier\n\n"
-                                           "Darsteller:\n"
-                                           "Herr Schauspieler (in einer (kleinen) Rolle)\n"
-                                           "Frau Schauspielerin (in einer Rolle)");
-    PRINT_EVENT(*event7);
-    EITFixUp::Fix(*event7);
-    PRINT_EVENT(*event7);
-    QCOMPARE(event7->m_subtitle, QString("<episode title>"));
-    QCOMPARE(event7->m_airdate,  (unsigned short) 2011);
-    QCOMPARE(event7->m_description, QString("<plot summary>"));
-
-    delete event7;
 }
 
 void TestEITFixups::testHTMLFixup()


### PR DESCRIPTION
* Update EIT fixes for ProSiebenSat.1 (Europe): EIT of ProSiebenSat.1 has changed years ago, old fixes do not work any more. ProSiebenSat.1 still dumps all kind of metadata into the subtitle field from where it can be retrieved.

* Remove most fixes for Kabel Deutschland: EPG of Vodafone's (formerly Kabel Deutschland) DVB-C is much better today, most fixes are superflous now. Due to frequency/channel changes, the old fixes did not work any more anyway. Only use updated fixes for ProSiebenSat.1

* Remove fixups for German DVB-T: Service got disabled in 2019.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

