### PR TITLE
IPTV Download not OK with network error

### DIFF
--- a/mythtv/libs/libmythtv/HLS/m3u.cpp
+++ b/mythtv/libs/libmythtv/HLS/m3u.cpp
@@ -130,15 +130,12 @@ namespace M3U
          */
         QString attr;
 
-        /* The PROGRAM-ID attribute of the EXT-X-STREAM-INF and the EXT-X-I-
-         * FRAME-STREAM-INF tags was removed in protocol version 6.
-         */
         attr = ParseAttributes(line, "PROGRAM-ID");
         if (attr.isNull())
         {
             LOG(VB_RECORD, LOG_INFO, loc +
-                "#EXT-X-STREAM-INF: No PROGRAM-ID=<value>, using 1");
-            id = 1;
+                "#EXT-X-STREAM-INF: expected PROGRAM-ID=<value>, using -1");
+            id = -1;
         }
         else
         {
@@ -276,7 +273,6 @@ namespace M3U
         if (!ParseDecimalValue(line, sequence_num))
         {
             LOG(VB_RECORD, LOG_ERR, loc + "expected #EXT-X-MEDIA-SEQUENCE:<s>");
-            sequence_num = 0;
             return false;
         }
 
@@ -395,8 +391,6 @@ namespace M3U
          * #EXT-X-ALLOW-CACHE:<YES|NO>
          */
 
-        /* The EXT-X-ALLOW-CACHE tag was removed in protocol version 7.
-         */
         int pos = line.indexOf(QLatin1String(":"));
         if (pos < 0)
         {

--- a/mythtv/libs/libmythtv/HLS/m3u.cpp
+++ b/mythtv/libs/libmythtv/HLS/m3u.cpp
@@ -130,12 +130,15 @@ namespace M3U
          */
         QString attr;
 
+        /* The PROGRAM-ID attribute of the EXT-X-STREAM-INF and the EXT-X-I-
+         * FRAME-STREAM-INF tags was removed in protocol version 6.
+         */
         attr = ParseAttributes(line, "PROGRAM-ID");
         if (attr.isNull())
         {
             LOG(VB_RECORD, LOG_INFO, loc +
-                "#EXT-X-STREAM-INF: expected PROGRAM-ID=<value>, using -1");
-            id = -1;
+                "#EXT-X-STREAM-INF: No PROGRAM-ID=<value>, using 1");
+            id = 1;
         }
         else
         {
@@ -273,6 +276,7 @@ namespace M3U
         if (!ParseDecimalValue(line, sequence_num))
         {
             LOG(VB_RECORD, LOG_ERR, loc + "expected #EXT-X-MEDIA-SEQUENCE:<s>");
+            sequence_num = 0;
             return false;
         }
 
@@ -391,6 +395,8 @@ namespace M3U
          * #EXT-X-ALLOW-CACHE:<YES|NO>
          */
 
+        /* The EXT-X-ALLOW-CACHE tag was removed in protocol version 7.
+         */
         int pos = line.indexOf(QLatin1String(":"));
         if (pos < 0)
         {

--- a/mythtv/libs/libmythtv/recorders/httptsstreamhandler.cpp
+++ b/mythtv/libs/libmythtv/recorders/httptsstreamhandler.cpp
@@ -179,7 +179,11 @@ bool HTTPReader::DownloadStream(const QUrl& url)
     QMutexLocker  replylock(&m_replylock);
     if (m_reply->error() != QNetworkReply::NoError)
     {
-        LOG(VB_RECORD, LOG_ERR, LOC + "DownloadStream exited with " + m_reply->errorString());
+        LOG(VB_RECORD, LOG_ERR, LOC + "DownloadStream exited with error " +
+            QString("%1 '%2'").arg(m_reply->error()).arg(m_reply->errorString()));
+
+        // Download is not OK when there is a network error
+        m_ok = false;
     }
 
     delete m_reply;


### PR DESCRIPTION
Set download status to not OK when a network error is reported for the download. This fixes an endless loop / log pollution when server access is not allowed, reported as  error 201 (HTTP error 403).

