### PR TITLE
AvFormatDecoder cleanup

### DIFF
--- a/mythtv/libs/libmythtv/DVD/mythdvddecoder.cpp
+++ b/mythtv/libs/libmythtv/DVD/mythdvddecoder.cpp
@@ -269,7 +269,7 @@ void MythDVDDecoder::CheckContext(int64_t Pts)
 }
 
 
-bool MythDVDDecoder::ProcessVideoPacket(AVStream *Stream, AVPacket *Pkt, bool &Retry)
+bool MythDVDDecoder::ProcessVideoPacket(AVCodecContext* codecContext, AVStream *Stream, AVPacket *Pkt, bool &Retry)
 {
     int64_t pts = Pkt->pts;
 
@@ -278,7 +278,7 @@ bool MythDVDDecoder::ProcessVideoPacket(AVStream *Stream, AVPacket *Pkt, bool &R
 
     CheckContext(pts);
 
-    bool ret = AvFormatDecoder::ProcessVideoPacket(Stream, Pkt, Retry);
+    bool ret = AvFormatDecoder::ProcessVideoPacket(codecContext, Stream, Pkt, Retry);
     if (Retry)
         return ret;
 
@@ -330,7 +330,7 @@ bool MythDVDDecoder::ProcessVideoPacket(AVStream *Stream, AVPacket *Pkt, bool &R
     return ret;
 }
 
-bool MythDVDDecoder::ProcessVideoFrame(AVStream *Stream, AVFrame *Frame)
+bool MythDVDDecoder::ProcessVideoFrame(AVCodecContext* codecContext, AVStream *Stream, AVFrame *Frame)
 {
     bool ret = true;
 
@@ -338,7 +338,7 @@ bool MythDVDDecoder::ProcessVideoFrame(AVStream *Stream, AVFrame *Frame)
     {
         // Only process video frames if we're not searching for
         // the previous video frame after seeking in a slideshow.
-        ret = AvFormatDecoder::ProcessVideoFrame(Stream, Frame);
+        ret = AvFormatDecoder::ProcessVideoFrame(codecContext, Stream, Frame);
     }
 
     return ret;

--- a/mythtv/libs/libmythtv/DVD/mythdvddecoder.h
+++ b/mythtv/libs/libmythtv/DVD/mythdvddecoder.h
@@ -23,8 +23,8 @@ class MythDVDDecoder : public AvFormatDecoder
 
   protected:
     int  ReadPacket        (AVFormatContext *Ctx, AVPacket *Pkt, bool &StorePacket) override;
-    bool ProcessVideoPacket(AVStream *Stream, AVPacket *Pkt, bool &Retry) override;
-    bool ProcessVideoFrame (AVStream *Stream, AVFrame *Frame) override;
+    bool ProcessVideoPacket(AVCodecContext* codecContext, AVStream *Stream, AVPacket *Pkt, bool &Retry) override;
+    bool ProcessVideoFrame (AVCodecContext* codecContext, AVStream *Stream, AVFrame *Frame) override;
     bool ProcessDataPacket (AVStream *Curstream, AVPacket *Pkt, DecodeType Decodetype) override;
 
   private:

--- a/mythtv/libs/libmythtv/captions/cc708reader.cpp
+++ b/mythtv/libs/libmythtv/captions/cc708reader.cpp
@@ -61,11 +61,6 @@ void CC708Reader::DefineWindow(
     int row_lock,         int column_lock,
     int pen_style,        int window_style)
 {
-    if (m_parent && m_parent->GetDecoder())
-    {
-        StreamInfo si {-1, static_cast<int>(service_num)};
-        m_parent->GetDecoder()->InsertTrack(kTrackTypeCC708, si);
-    }
 
     CHECKENABLED;
 

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -4779,6 +4779,7 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype, bool &Retry)
         }
 
         enum AVMediaType codec_type = curstream->codecpar->codec_type;
+        const AVCodecID codec_id = curstream->codecpar->codec_id;
 
         if (storevideoframes && codec_type == AVMEDIA_TYPE_VIDEO)
         {
@@ -4804,7 +4805,7 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype, bool &Retry)
         }
 
         if (codec_type == AVMEDIA_TYPE_SUBTITLE &&
-            curstream->codecpar->codec_id == AV_CODEC_ID_TEXT)
+            codec_id == AV_CODEC_ID_TEXT)
         {
             ProcessRawTextPacket(pkt);
             av_packet_unref(pkt);
@@ -4812,7 +4813,7 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype, bool &Retry)
         }
 
         if (codec_type == AVMEDIA_TYPE_SUBTITLE &&
-            curstream->codecpar->codec_id == AV_CODEC_ID_DVB_TELETEXT)
+            codec_id == AV_CODEC_ID_DVB_TELETEXT)
         {
             ProcessDVBDataPacket(curstream, pkt);
             av_packet_unref(pkt);
@@ -4826,17 +4827,20 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype, bool &Retry)
             continue;
         }
 
-        AVCodecContext *ctx = m_codecMap.GetCodecContext(curstream);
-        if (!ctx)
+        // ensure there is an AVCodecContext for this stream
+        AVCodecContext *context = m_codecMap.GetCodecContext(curstream);
+        if (context == nullptr)
         {
             if (codec_type != AVMEDIA_TYPE_VIDEO)
             {
                 LOG(VB_PLAYBACK, LOG_ERR, LOC +
                     QString("No codec for stream index %1, type(%2) id(%3:%4)")
-                        .arg(pkt->stream_index)
-                    .arg(AVMediaTypeToString(codec_type),
-                         avcodec_get_name(curstream->codecpar->codec_id))
-                        .arg(curstream->codecpar->codec_id));
+                        .arg(QString::number(pkt->stream_index),
+                             AVMediaTypeToString(codec_type),
+                             avcodec_get_name(codec_id),
+                             QString::number(codec_id)
+                            )
+                   );
                 // Process Stream Change in case we have no audio
                 if (codec_type == AVMEDIA_TYPE_AUDIO && !m_audio->HasAudioIn())
                     m_streamsChanged = true;
@@ -4894,8 +4898,8 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype, bool &Retry)
             {
                 LOG(VB_GENERAL, LOG_ERR, LOC +
                     QString("Decoding - id(%1) type(%2)")
-                        .arg(avcodec_get_name(ctx->codec_id),
-                             AVMediaTypeToString(ctx->codec_type)));
+                        .arg(avcodec_get_name(codec_id),
+                             AVMediaTypeToString(codec_type)));
                 have_err = true;
                 break;
             }

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -1880,6 +1880,11 @@ void AvFormatDecoder::ScanDSMCCStreams(AVBufferRef* pmt_section)
 
 int AvFormatDecoder::autoSelectVideoTrack(int& scanerror)
 {
+    m_tracks[kTrackTypeVideo].clear();
+    m_selectedTrack[kTrackTypeVideo].m_av_stream_index = -1;
+    m_currentTrack[kTrackTypeVideo] = -1;
+    m_fps = 0;
+
     const AVCodec *codec = nullptr;
     LOG(VB_PLAYBACK, LOG_INFO, LOC + "Trying to select best video track");
 
@@ -1911,6 +1916,7 @@ int AvFormatDecoder::autoSelectVideoTrack(int& scanerror)
 
     m_tracks[kTrackTypeVideo].push_back(si);
     m_selectedTrack[kTrackTypeVideo] = si;
+    m_currentTrack[kTrackTypeVideo] = m_tracks[kTrackTypeVideo].size() - 1;
 
     QString codectype(AVMediaTypeToString(codecContext->codec_type));
     if (codecContext->codec_type == AVMEDIA_TYPE_VIDEO)
@@ -2112,13 +2118,7 @@ int AvFormatDecoder::ScanStreams(bool novideo)
     m_tracks[kTrackTypeTeletextCaptions].clear();
     m_tracks[kTrackTypeTeletextMenu].clear();
     m_tracks[kTrackTypeRawText].clear();
-    if (!novideo)
-    {
-        // we will rescan video streams
-        m_tracks[kTrackTypeVideo].clear();
-        m_selectedTrack[kTrackTypeVideo].m_av_stream_index = -1;
-        m_fps = 0;
-    }
+
     std::map<int,uint> lang_sub_cnt;
     uint subtitleStreamCount = 0;
     std::map<int,uint> lang_aud_cnt;

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -4806,6 +4806,14 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype, bool &Retry)
                 }
             }
             break;
+        case AVMEDIA_TYPE_AUDIO:
+            // FFmpeg does not currently have an AC-4 decoder
+            if (codec_id == AV_CODEC_ID_AC4)
+            {
+                av_packet_unref(pkt);
+                continue;
+            }
+            break;
         case AVMEDIA_TYPE_SUBTITLE:
             switch (codec_id)
             {

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -2207,16 +2207,6 @@ int AvFormatDecoder::ScanStreams(bool novideo)
             }
             case AVMEDIA_TYPE_AUDIO:
             {
-                enc = m_codecMap.FindCodecContext(m_ic->streams[strm]);
-                if (enc && enc->internal)
-                {
-                    LOG(VB_GENERAL, LOG_WARNING, LOC +
-                        QString("Warning, audio codec 0x%1 id(%2) "
-                                "type (%3) already open, leaving it alone.")
-                            .arg(reinterpret_cast<unsigned long long>(enc), 0, 16)
-                            .arg(avcodec_get_name(enc->codec_id),
-                                 AVMediaTypeToString(enc->codec_type)));
-                }
                 LOG(VB_GENERAL, LOG_INFO, LOC +
                     QString("codec %1 has %2 channels")
                         .arg(avcodec_get_name(par->codec_id))

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -1101,8 +1101,6 @@ int AvFormatDecoder::OpenFile(MythMediaBuffer *Buffer, bool novideo,
         return err;
     }
 
-    AutoSelectTracks(); // This is needed for transcoder
-
 #ifdef USING_MHEG
     {
         int initialAudio = -1;
@@ -1732,6 +1730,8 @@ void AvFormatDecoder::UpdateATSCCaptionTracks(void)
                 .arg(nsi.m_stream_id)
                 .arg(iso639_key_toName(nsi.m_language)));
     }
+    AutoSelectTrack(kTrackTypeCC608);
+    AutoSelectTrack(kTrackTypeCC708);
 }
 
 void AvFormatDecoder::ScanTeletextCaptions(int av_index)
@@ -2112,12 +2112,19 @@ int AvFormatDecoder::ScanStreams(bool novideo)
     int scanerror = 0;
     m_bitrate     = 0;
 
-    m_tracks[kTrackTypeAttachment].clear();
-    m_tracks[kTrackTypeAudio].clear();
-    m_tracks[kTrackTypeSubtitle].clear();
-    m_tracks[kTrackTypeTeletextCaptions].clear();
-    m_tracks[kTrackTypeTeletextMenu].clear();
-    m_tracks[kTrackTypeRawText].clear();
+    constexpr std::array<TrackType, 6> types {
+        kTrackTypeAttachment,
+        kTrackTypeAudio,
+        kTrackTypeSubtitle,
+        kTrackTypeTeletextCaptions,
+        kTrackTypeTeletextMenu,
+        kTrackTypeRawText,
+        };
+    for (const auto type : types)
+    {
+        m_tracks[type].clear();
+        m_currentTrack[type] = -1;
+    }
 
     std::map<int,uint> lang_sub_cnt;
     uint subtitleStreamCount = 0;
@@ -2393,8 +2400,10 @@ int AvFormatDecoder::ScanStreams(bool novideo)
 
     PostProcessTracks();
 
-    // Select a new track at the next opportunity.
-    ResetTracks();
+    for (const auto type : types)
+    {
+        AutoSelectTrack(type);
+    }
 
     // We have to do this here to avoid the NVP getting stuck
     // waiting on audio.
@@ -3602,6 +3611,7 @@ void AvFormatDecoder::ProcessVBIDataPacket(
                     m_trackLock.lock();
                     m_tracks[kTrackTypeTeletextMenu].push_back(si);
                     m_trackLock.unlock();
+                    AutoSelectTrack(kTrackTypeTeletextMenu);
                 }
                 m_trackLock.unlock();
                 m_ttd->Decode(buf+1, VBI_IVTV);
@@ -4586,8 +4596,6 @@ bool AvFormatDecoder::GetFrame(DecodeType decodetype, bool &Retry)
 
     m_allowedQuit = false;
     bool storevideoframes = false;
-
-    AutoSelectTracks();
 
     m_skipAudio = (m_lastVPts == 0ms);
 

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -4104,6 +4104,48 @@ int AvFormatDecoder::filter_max_ch(const AVFormatContext *ic,
     return selectedTrack;
 }
 
+int AvFormatDecoder::selectBestAudioTrack(int lang_key, const std::vector<int> &ftype)
+{
+    const sinfo_vec_t &atracks = m_tracks[kTrackTypeAudio];
+    int selTrack = -1;
+
+    std::vector<int> flang = filter_lang(atracks, lang_key, ftype);
+
+    if (m_audio->CanDTSHD())
+    {
+        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
+                                 FF_PROFILE_DTS_HD_MA);
+        if (selTrack >= 0)
+            return selTrack;
+    }
+    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_TRUEHD);
+    if (selTrack >= 0)
+        return selTrack;
+
+    if (m_audio->CanDTSHD())
+    {
+        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
+                                 FF_PROFILE_DTS_HD_HRA);
+        if (selTrack >= 0)
+            return selTrack;
+    }
+    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_EAC3);
+    if (selTrack >= 0)
+        return selTrack;
+
+    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS);
+    if (selTrack >= 0)
+        return selTrack;
+
+    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_AC3);
+    if (selTrack >= 0)
+        return selTrack;
+
+    selTrack = filter_max_ch(m_ic, atracks, flang);
+
+    return selTrack;
+}
+
 /** \fn AvFormatDecoder::AutoSelectAudioTrack(void)
  *  \brief Selects the best audio track.
  *
@@ -4242,28 +4284,7 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
                 uint language_key = iso639_str3_to_key(language_key_convert);
                 uint canonical_key = iso639_key_to_canonical_key(language_key);
 
-                std::vector<int> flang = filter_lang(atracks, canonical_key, ftype);
-
-                if (m_audio->CanDTSHD())
-                    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
-                                             FF_PROFILE_DTS_HD_MA);
-                if (selTrack < 0)
-                    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_TRUEHD);
-
-                if (selTrack < 0 && m_audio->CanDTSHD())
-                    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
-                                             FF_PROFILE_DTS_HD_HRA);
-                if (selTrack < 0)
-                    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_EAC3);
-
-                if (selTrack < 0)
-                    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS);
-
-                if (selTrack < 0)
-                    selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_AC3);
-
-                if (selTrack < 0)
-                    selTrack = filter_max_ch(m_ic, atracks, flang);
+                selTrack = selectBestAudioTrack(canonical_key, ftype);
 
                 // Try to get best track for most preferred language for audio.
                 // Set by the "Guide Data" "Audio Language" preference in Appearance.
@@ -4272,31 +4293,7 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
                     auto it = m_languagePreference.begin();
                     for (; it !=  m_languagePreference.end() && selTrack < 0; ++it)
                     {
-                        flang = filter_lang(atracks, *it, ftype);
-
-                        if (m_audio->CanDTSHD())
-                            selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
-                                                     FF_PROFILE_DTS_HD_MA);
-                        if (selTrack < 0)
-                            selTrack = filter_max_ch(m_ic, atracks, flang,
-                                                     AV_CODEC_ID_TRUEHD);
-
-                        if (selTrack < 0 && m_audio->CanDTSHD())
-                            selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
-                                                     FF_PROFILE_DTS_HD_HRA);
-
-                        if (selTrack < 0)
-                            selTrack = filter_max_ch(m_ic, atracks, flang,
-                                                     AV_CODEC_ID_EAC3);
-
-                        if (selTrack < 0)
-                            selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS);
-
-                        if (selTrack < 0)
-                            selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_AC3);
-
-                        if (selTrack < 0)
-                            selTrack = filter_max_ch(m_ic, atracks, flang);
+                        selTrack = selectBestAudioTrack(*it, ftype);
                     }
                 }
 
@@ -4320,29 +4317,7 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
                 {
                     LOG(VB_AUDIO, LOG_INFO, LOC +
                         "Trying to select audio track (wo/lang)");
-                    flang = filter_lang(atracks, -1, ftype);
-
-                    if (m_audio->CanDTSHD())
-                        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
-                                                 FF_PROFILE_DTS_HD_MA);
-                    if (selTrack < 0)
-                        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_TRUEHD);
-
-                    if (selTrack < 0 && m_audio->CanDTSHD())
-                        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS,
-                                                 FF_PROFILE_DTS_HD_HRA);
-
-                    if (selTrack < 0)
-                        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_EAC3);
-
-                    if (selTrack < 0)
-                        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_DTS);
-
-                    if (selTrack < 0)
-                        selTrack = filter_max_ch(m_ic, atracks, flang, AV_CODEC_ID_AC3);
-
-                    if (selTrack < 0)
-                        selTrack = filter_max_ch(m_ic, atracks, flang);
+                    selTrack = selectBestAudioTrack(-1, ftype);
                 }
             }
         }

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -4160,6 +4160,9 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
     int               &ctrack  = m_currentTrack[kTrackTypeAudio];
 
     uint numStreams = atracks.size();
+    int selTrack = -1;
+    if (numStreams > 0)
+    {
     if ((ctrack >= 0) && (ctrack < (int)numStreams))
         return ctrack; // audio already selected
 
@@ -4174,7 +4177,12 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
             );
     }
 
-    int selTrack = (1 == numStreams) ? 0 : -1;
+    if (1 == numStreams)
+    {
+        selTrack = 0;
+    }
+    else
+    {
     int wlang    = wtrack.m_language;
 
     if ((selTrack < 0) && (wtrack.m_av_substream_index >= 0))
@@ -4195,7 +4203,7 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
         }
     }
 
-    if ((selTrack < 0) && wlang >= -1 && numStreams)
+    if ((selTrack < 0) && wlang >= -1)
     {
         LOG(VB_AUDIO, LOG_INFO, LOC + "Trying to reselect audio track");
         // Try to reselect user selected audio stream.
@@ -4214,7 +4222,7 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
         }
     }
 
-    if (selTrack < 0 && numStreams)
+    if (selTrack < 0)
     {
         LOG(VB_AUDIO, LOG_INFO, LOC + "Trying to select audio track (w/lang)");
 
@@ -4336,6 +4344,8 @@ int AvFormatDecoder::AutoSelectAudioTrack(void)
             if (selTrack < 0)
                 selTrack = filter_max_ch(m_ic, atracks, flang);
         }
+    }
+    }
     }
 
     if (selTrack < 0)

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -2289,52 +2289,14 @@ int AvFormatDecoder::ScanStreams(bool novideo)
         if (!enc)
             enc = m_codecMap.GetCodecContext(m_ic->streams[strm]);
 
-        const AVCodec *codec = nullptr;
-        if (enc)
-            codec = enc->codec;
-        else
+        if (enc == nullptr)
         {
-            LOG(VB_GENERAL, LOG_ERR, LOC +
+            LOG(VB_GENERAL, LOG_WARNING, LOC +
                 QString("Could not find decoder for codec (%1), ignoring.")
                     .arg(avcodec_get_name(par->codec_id)));
-
-            // Nigel's bogus codec-debug. Dump the list of codecs & decoders,
-            // and have one last attempt to find a decoder. This is usually
-            // only caused by build problems, where libavcodec needs a rebuild
-            if (VERBOSE_LEVEL_CHECK(VB_LIBAV, LOG_ANY))
-            {
-                void *opaque = nullptr;
-                const AVCodec *p = av_codec_iterate(&opaque);
-                while (p)
-                {
-                    QString msg;
-
-                    if (p->name[0] != '\0')
-                        msg = QString("Codec %1:").arg(p->name);
-                    else
-                        msg = QString("Codec %1, null name,").arg(strm);
-
-                    LOG(VB_LIBAV, LOG_INFO, LOC + msg);
-
-                    if (p->id == par->codec_id)
-                    {
-                        codec = p;
-                        break;
-                    }
-
-                    LOG(VB_LIBAV, LOG_INFO, LOC +
-                        QString("Codec 0x%1 != 0x%2") .arg(p->id, 0, 16)
-                            .arg(par->codec_id, 0, 16));
-                    p = av_codec_iterate(&opaque);
-                }
-            }
-            if (codec)
-                enc = m_codecMap.GetCodecContext(m_ic->streams[strm], codec);
-            else
-                continue;
-        }
-        if (!enc)
+            LOG(VB_LIBAV, LOG_INFO, "For a list of all codecs, run `mythffmpeg -codecs`.");
             continue;
+        }
 
         if (enc->codec && par->codec_id != enc->codec_id)
         {
@@ -2345,7 +2307,7 @@ int AvFormatDecoder::ScanStreams(bool novideo)
             m_codecMap.FreeCodecContext(m_ic->streams[strm]);
             enc = m_codecMap.GetCodecContext(m_ic->streams[strm]);
         }
-        if (!OpenAVCodec(enc, codec))
+        if (!OpenAVCodec(enc, enc->codec))
             continue;
         if (!enc)
             continue;

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -180,14 +180,14 @@ class AvFormatDecoder : public DecoderBase
                         bool selectedStream = false);
 
     /// Preprocess a packet, setting the video parms if necessary.
-    void MpegPreProcessPkt(AVStream *stream, AVPacket *pkt);
-    int  H264PreProcessPkt(AVStream *stream, AVPacket *pkt);
-    bool PreProcessVideoPacket(AVStream *stream, AVPacket *pkt);
-    virtual bool ProcessVideoPacket(AVStream *stream, AVPacket *pkt, bool &Retry);
-    virtual bool ProcessVideoFrame(AVStream *Stream, AVFrame *AvFrame);
-    bool ProcessAudioPacket(AVStream *stream, AVPacket *pkt,
+    void MpegPreProcessPkt(AVCodecContext* codecContext, AVStream *stream, AVPacket *pkt);
+    int  H264PreProcessPkt(AVCodecContext* codecContext, AVStream *stream, AVPacket *pkt);
+    bool PreProcessVideoPacket(AVCodecContext* codecContext, AVStream *stream, AVPacket *pkt);
+    virtual bool ProcessVideoPacket(AVCodecContext* codecContext, AVStream *stream, AVPacket *pkt, bool &Retry);
+    virtual bool ProcessVideoFrame(AVCodecContext* codecContext, AVStream *Stream, AVFrame *AvFrame);
+    bool ProcessAudioPacket(AVCodecContext* codecContext, AVStream *stream, AVPacket *pkt,
                             DecodeType decodetype);
-    bool ProcessSubtitlePacket(AVStream *stream, AVPacket *pkt);
+    bool ProcessSubtitlePacket(AVCodecContext* codecContext, AVStream *stream, AVPacket *pkt);
     bool ProcessRawTextPacket(AVPacket* Packet);
     virtual bool ProcessDataPacket(AVStream *curstream, AVPacket *pkt,
                                    DecodeType decodetype);

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -175,7 +175,7 @@ class AvFormatDecoder : public DecoderBase
                               int flags);
 
     void DecodeCCx08(const uint8_t *buf, uint buf_size);
-    void InitVideoCodec(AVStream *stream, AVCodecContext *enc,
+    void InitVideoCodec(AVStream *stream, AVCodecContext *codecContext,
                         bool selectedStream = false);
 
     /// Preprocess a packet, setting the video parms if necessary.

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -170,6 +170,7 @@ class AvFormatDecoder : public DecoderBase
                        const std::vector<int>&fs,
                        enum AVCodecID         codecId = AV_CODEC_ID_NONE,
                        int                    profile = -1);
+    int selectBestAudioTrack(int lang_key, const std::vector<int> &ftype);
 
     friend int get_avf_buffer(struct AVCodecContext *c, AVFrame *pic,
                               int flags);

--- a/mythtv/libs/libmythtv/decoders/decoderbase.cpp
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.cpp
@@ -1160,7 +1160,7 @@ int DecoderBase::AutoSelectTrack(uint Type)
             .arg(m_currentTrack[Type]+1).arg(Type).arg(iso639_key_toName(lang)).arg(lang));
 
     if (m_parent && (oldTrack != m_currentTrack[Type]))
-        emit m_parent->SignalTracksChanged(Type);
+        m_parent->tracksChanged(Type);
 
     return selTrack;
 }

--- a/mythtv/libs/libmythtv/decoders/decoderbase.cpp
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.cpp
@@ -1013,24 +1013,6 @@ int DecoderBase::NextTrack(uint Type)
     return next_track;
 }
 
-bool DecoderBase::InsertTrack(uint Type, const StreamInfo &Info)
-{
-    QMutexLocker locker(&m_trackLock);
-
-    if (std::any_of(m_tracks[Type].cbegin(), m_tracks[Type].cend(),
-                    [&](const StreamInfo& Si) { return Si.m_stream_id == Info.m_stream_id; } ))
-    {
-        return false;
-    }
-
-    m_tracks[Type].push_back(Info);
-
-    if (m_parent)
-        emit m_parent->SignalTracksChanged(Type);
-
-    return true;
-}
-
 /** \fn DecoderBase::BestTrack(uint, bool)
  *  \brief Determine the best track according to weights
  *

--- a/mythtv/libs/libmythtv/decoders/decoderbase.h
+++ b/mythtv/libs/libmythtv/decoders/decoderbase.h
@@ -233,7 +233,6 @@ class DecoderBase
     int          GetTrack(uint Type);
     StreamInfo   GetTrackInfo(uint Type, uint TrackNo);
     int          ChangeTrack(uint Type, int Dir);
-    virtual bool InsertTrack(uint Type, const StreamInfo &Info);
     int          NextTrack(uint Type);
 
     virtual int  GetTeletextDecoderType(void) const { return -1; }

--- a/mythtv/libs/libmythtv/mythplayer.h
+++ b/mythtv/libs/libmythtv/mythplayer.h
@@ -101,7 +101,6 @@ class MTV_PUBLIC MythPlayer : public QObject
     void SeekingDone();
     void PauseChanged(bool Paused);
     void RequestResetCaptions();
-    void SignalTracksChanged(uint Type);
 
   public:
     explicit MythPlayer(PlayerContext* Context, PlayerFlags Flags = kNoFlags);
@@ -203,6 +202,8 @@ class MTV_PUBLIC MythPlayer : public QObject
     // forced on even if the user doesn't have them turned on.)
     // These two functions are not thread-safe (UI thread use only).
     bool GetAllowForcedSubtitles(void) const { return m_allowForcedSubtitles; }
+
+    virtual void tracksChanged([[maybe_unused]] uint TrackType) {}
 
     // LiveTV public stuff
     void CheckTVChain();

--- a/mythtv/libs/libmythtv/mythplayercaptionsui.cpp
+++ b/mythtv/libs/libmythtv/mythplayercaptionsui.cpp
@@ -47,7 +47,6 @@ MythPlayerCaptionsUI::MythPlayerCaptionsUI(MythMainWindow* MainWindow, TV* Tv, P
 
     // Signalled from the decoder
     connect(this, &MythPlayerCaptionsUI::EnableSubtitles, this, [this](bool Enable) { this->SetCaptionsEnabled(Enable, false); });
-    connect(this, &MythPlayerCaptionsUI::SignalTracksChanged, this, &MythPlayerCaptionsUI::TracksChanged);
 
     // Signalled from the base class
     connect(this, &MythPlayerCaptionsUI::RequestResetCaptions, this, &MythPlayerCaptionsUI::ResetCaptions);
@@ -251,7 +250,7 @@ void MythPlayerCaptionsUI::EnableCaptions(uint Mode, bool UpdateOSD)
 /*! \brief This tries to re-enable captions/subtitles if the user
  * wants them and one of the captions/subtitles tracks has changed.
  */
-void MythPlayerCaptionsUI::TracksChanged(uint TrackType)
+void MythPlayerCaptionsUI::tracksChanged(uint TrackType)
 {
     if (m_textDesired && (TrackType >= kTrackTypeSubtitle) && (TrackType <= kTrackTypeTeletextCaptions))
         SetCaptionsEnabled(true, false);

--- a/mythtv/libs/libmythtv/mythplayercaptionsui.h
+++ b/mythtv/libs/libmythtv/mythplayercaptionsui.h
@@ -32,9 +32,10 @@ class MTV_PUBLIC MythPlayerCaptionsUI : public MythPlayerAudioUI
     std::chrono::milliseconds GetStreamMaxPos();
     InteractiveTV* GetInteractiveTV() override;
 
+    void tracksChanged(uint TrackType) override;
+
   protected slots:
     void InitialiseState() override;
-    void TracksChanged(uint TrackType);
     void SetAllowForcedSubtitles(bool Allow);
     void ToggleCaptions();
     void ToggleCaptionsByType(uint Type);


### PR DESCRIPTION
The first few of these commits were originally added to https://github.com/MythTV/mythtv/pull/950, but were separated out since they were mostly extraneous.

Ignoring AV_CODEC_ID_AC4, which was added in FFmpeg 7.1, does resolve an abort on an ATSC 3.0 sample.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

