### PR TITLE
Python: Fix deprecation warnings in 3.11+

### DIFF
--- a/mythtv/bindings/python/MythTV/utility/dt.py
+++ b/mythtv/bindings/python/MythTV/utility/dt.py
@@ -14,6 +14,9 @@ from collections import namedtuple
 import os
 import re
 import time
+import sys
+
+IS_PY312plus = (sys.version_info[:3] >= (3, 12, 0))
 
 HAVEZONEINFO = False
 try:
@@ -356,8 +359,11 @@ class datetime( _pydatetime ):
 
     @classmethod
     def utcnow(cls):
-        obj = super(datetime, cls).utcnow()
-        return obj.replace(tzinfo=cls.UTCTZ())
+        if IS_PY312plus:
+            return cls.now(tz=cls.UTCTZ())
+        else:
+            obj = super(datetime, cls).utcnow()
+            return obj.replace(tzinfo=cls.UTCTZ())
 
     @classmethod
     def fromtimestamp(cls, timestamp, tz=None):
@@ -368,8 +374,11 @@ class datetime( _pydatetime ):
 
     @classmethod
     def utcfromtimestamp(cls, timestamp):
-        obj = super(datetime, cls).utcfromtimestamp(float(timestamp))
-        return obj.replace(tzinfo=cls.UTCTZ())
+        if IS_PY312plus:
+            return cls.fromtimestamp(timestamp, tz=cls.UTCTZ())
+        else:
+            obj = super(datetime, cls).utcfromtimestamp(float(timestamp))
+            return obj.replace(tzinfo=cls.UTCTZ())
 
     @classmethod
     def strptime(cls, datestring, format, tzinfo=None):

--- a/mythtv/bindings/python/tmdb3/tmdb3/locales.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/locales.py
@@ -7,6 +7,7 @@
 
 from .tmdb_exceptions import *
 import locale
+import sys
 
 syslocale = None
 
@@ -130,7 +131,10 @@ def set_locale(language=None, country=None, fallthrough=False):
     global syslocale
     LocaleBase.fallthrough = fallthrough
 
-    sysloc, sysenc = locale.getdefaultlocale()
+    if sys.version_info >= (3,11):
+        sysloc, sysenc = locale.getlocale()
+    else:
+        sysloc, sysenc = locale.getdefaultlocale()
 
     if (not language) or (not country):
         dat = None
@@ -154,7 +158,11 @@ def get_locale(language=-1, country=-1):
     global syslocale
     # pull existing stored values
     if syslocale is None:
-        loc = Locale(None, None, locale.getdefaultlocale()[1])
+        try:
+            # Python >= 3.11
+            loc = Locale(None, None, locale.getencoding())
+        except AttributeError:
+            loc = Locale(None, None, locale.getdefaultlocale()[1])
     else:
         loc = syslocale
 

--- a/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/lookup.py
@@ -144,8 +144,18 @@ def buildSingle(inetref, opts):
     # tmdb already sorts the posters by language
     # if no poster of given language was found,
     # try to sort by system language and then by language "en"
-    system_language = py_locale.getdefaultlocale()[0].split("_")[0]
-    system_country = py_locale.getdefaultlocale()[0].split("_")[1]
+    if sys.version_info >= (3,11):
+        s_locale = py_locale.getlocale()
+    else:
+        s_locale = py_locale.getdefaultlocale()
+
+    #  locale might be 'C.UTF-8'
+    if "_" in s_locale[0]:
+        system_language = s_locale[0].split("_")[0]
+        system_country = s_locale[0].split("_")[1]
+    else:
+        system_language = 'en'
+        system_country = 'US'
     locale_language = get_locale().language
     locale_country = get_locale().country
     if opts.debug:


### PR DESCRIPTION
Python 3.11 deprecates the API locale.getdefaultlocale() with a pending removal in Python 3.13 (I).
Python 3.12 moves this pending removal to Python 3.15 (II). 
Deprecation warnings in Python 3.12:
datetime: datetime.datetime’s utcnow() and utcfromtimestamp() are deprecated and will be removed in a future version. Instead, use timezone-aware objects to represent datetimes in UTC: respectively, call now() and fromtimestamp() with the tz parameter set to datetime.UTC. (Contributed by Paul Ganssle in gh-103857.) See (II).

References:
(I)  https://docs.python.org/3/whatsnew/3.11.html#deprecated
(II) https://docs.python.org/3/whatsnew/3.12.html#deprecated



##### Checklist
- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

Fixes #819