### PR TITLE
github: Add missing cmake test and migrate macOS to cmake/qt6 based builds

### DIFF
--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -309,24 +309,18 @@ jobs:
             qt_version: 'qt6'
             database_version: 'mariadb'
             extrapkgs: ''
-            configureopts: '--disable-firewire  --enable-libmp3lame --enable-libvpx  --enable-libxvid --enable-libx264 --enable-libx265 --enable-bdjava'
-            linkerflags: '-Wl,-ld_classic'
           - desc: 'macOS 14 (Sonoma) arm64'
             runner: 'macOS-14'
             arch: 'arm64'
             qt_version: 'qt6'
             database_version: 'mariadb'
             extrapkgs: ''
-            configureopts: '--disable-firewire  --enable-libmp3lame --enable-libvpx  --enable-libxvid --enable-libx264 --enable-libx265 --enable-bdjava'
-            linkerflags: '-Wl,-ld_classic'
           - desc: 'macOS 15 (Sequoia) arm64'
             runner: 'macOS-15'
             arch: 'arm64'
             qt_version: 'qt6'
             database_version: 'mariadb'
             extrapkgs: ''
-            configureopts: '--disable-firewire  --enable-libmp3lame --enable-libvpx  --enable-libxvid --enable-libx264 --enable-libx265 --enable-bdjava'
-            linkerflags: '-Wl,-ld_classic'
 
         compiler:
           - desc: 'clang'
@@ -339,15 +333,12 @@ jobs:
 
     env:
       TZ: Etc/UTC
-      MYTHTV_CONFIG_PREFIX: "${{ github.workspace }}/build/install"
-      MYTHTV_CONFIG_EXTRA: "--cc=${{ matrix.compiler.cc }} --cxx=${{ matrix.compiler.cxx }} --compile-type=release --enable-debug=0 --disable-debug"
-      MYTHPLUGINS_EXTRA: "--disable-mytharchive --disable-mythnetvision --disable-mythzoneminder --disable-mythzmserver"
       CCACHE_DIR: $HOME/.ccache
       CCACHE_COMPRESS: true
       CCACHE_MAXSIZE: 250M
-      CONFIGURE_CMD: "./configure"
-      MAKE_CMD: 'make'
-      ANSIBLE_EXTRA: ''
+      CONFIGURE_CMD: 'cmake --preset ${{ matrix.os.qt_version }} -G Ninja -DCMAKE_BUILD_TYPE=Release'
+      MAKE_CMD: 'cmake --build build-${{ matrix.os.qt_version }}'
+      TEST_CMD: 'cmake --build build-${{ matrix.os.qt_version }} -t MythTV-tests'
 
     steps:
       - name: Checkout ccache
@@ -390,10 +381,6 @@ jobs:
 
       - name: Setup build envinomental variables
         run: |
-          echo "C_INCLUDE_PATH=${PKGMGR_PREFIX}/include" >> $GITHUB_ENV
-          echo "CPLUS_INCLUDE_PATH=${PKGMGR_PREFIX}/include" >> $GITHUB_ENV
-          echo "LDFLAGS=-L${PKGMGR_PREFIX}/lib ${{ matrix.os.linkerflags }}" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=${PKGMGR_PREFIX}/lib" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=${PKGMGR_PREFIX}/lib/pkgconfig" >> $GITHUB_ENV
           echo "QMAKE_CMD=${PKGMGR_PREFIX}/opt/${{ matrix.os.qt_version }}/bin/qmake" >> $GITHUB_ENV
 
@@ -430,7 +417,7 @@ jobs:
         run: ln -s $PKGMGR_PREFIX/opt/libhdhomerun/lib/libhdhomerun.dylib $PKGMGR_PREFIX/opt/libhdhomerun/lib/libhdhomerun_arm64.dylib
         if: matrix.os.arch == 'arm64'
 
-      - name: Fix the HDHomeRun library on ARM64
+      - name: Fix the HDHomeRun library on x86_64
         run: ln -s $PKGMGR_PREFIX/opt/libhdhomerun/lib/libhdhomerun.dylib $PKGMGR_PREFIX/opt/libhdhomerun/lib/libhdhomerun_x64.dylib
         if: matrix.os.arch == 'x86_64'
 
@@ -443,32 +430,16 @@ jobs:
         run: ccache -s
 
       - name: Configure core
-        working-directory: mythtv/mythtv
-        run: ${CONFIGURE_CMD} --prefix=${MYTHTV_CONFIG_PREFIX} ${MYTHTV_CONFIG_EXTRA} --qmake=${QMAKE_CMD} --python=${PYTHON_CMD} ${{ matrix.os.configureopts }}
+        working-directory: mythtv
+        run: ${CONFIGURE_CMD} -B build-${{ matrix.os.qt_version }} -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/install
 
       - name: Make core
-        working-directory: mythtv/mythtv
-        run: ${MAKE_CMD} -j4 all_no_test
-
-      - name: Install core
-        working-directory: mythtv/mythtv
-        run: ${MAKE_CMD} -j1 install
+        working-directory: mythtv
+        run: ${MAKE_CMD}
 
       - name: Test core
-        working-directory: mythtv/mythtv
-        run: ${MAKE_CMD} -j1 tests
-
-      - name: Configure plugins
-        working-directory: mythtv/mythplugins
-        run: ${CONFIGURE_CMD} --prefix=${MYTHTV_CONFIG_PREFIX} ${MYTHPLUGINS_EXTRA}
-
-      - name: Make plugins
-        working-directory: mythtv/mythplugins
-        run: ${MAKE_CMD} -j4
-
-      - name: Install plugins
-        working-directory: mythtv/mythplugins
-        run: ${MAKE_CMD} -j1 install
+        working-directory: mythtv
+        run: ${TEST_CMD}
 
       - name: ccache statistics [post]
         run: ccache -s

--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -195,7 +195,7 @@ jobs:
             core_configure_cmd: 'cmake --preset qt5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/install'
             core_build_cmd: 'cmake --build build-qt5'
             core_install_cmd: ''
-            core_test_cmd: ''
+            core_test_cmd: 'cmake --build build-qt5 -t MythTV-tests'
             plugins_working_subdirectory: ''
             plugins_configure_cmd: ''
             plugins_build_cmd: ''

--- a/cmake/SourceVersion.cmake
+++ b/cmake/SourceVersion.cmake
@@ -109,7 +109,7 @@ function(mythtv_find_source_version version version_major branch)
 
   # Next if git is installed, ask it for the version and branch info. This will
   # succeed if the compile is running from a git tree and fail otherwise.
-  if(NOT versionString AND GIT_EXECUTABLE)
+  if(NOT versionString AND DEFINED GIT_EXECUTABLE)
     message(STATUS "Checking for version info from git")
 
     # Version
@@ -156,7 +156,7 @@ function(mythtv_find_source_version version version_major branch)
   if(NOT versionString)
     set(filename "${mythtv_source_dir}/EXPORTED_VERSION")
     message(STATUS "Checking for version info in ${filename}")
-    source_version_from_file(${filename} versionString branchName)
+    source_version_from_file(${filename} versionString tempBranchName)
 
     # Fix up version
     if(versionString AND NOT versionString MATCHES "^v[0-9]")
@@ -167,7 +167,6 @@ function(mythtv_find_source_version version version_major branch)
         set(versionString "${prefix}-${versionString}")
       endif()
     endif()
-
     clean_branch_information(branchName)
     if(versionString)
       message(STATUS "  version:${versionString} branch:${branchName}")
@@ -179,9 +178,17 @@ function(mythtv_find_source_version version version_major branch)
     set(filename "${mythtv_source_dir}/SRC_VERSION")
     message(STATUS "Checking for version info in ${filename}")
     if(EXISTS ${filename})
-      source_version_from_file(${filename} versionString branchName)
+      source_version_from_file(${filename} versionString tempBranchName)
       message(STATUS "  version:${versionString}")
     endif()
+  endif()
+
+  # Prevent the source_version_from_file from stomping on any branch
+  # name discovered by git previously with NULL.
+  # This case is known to occur on a fork where the data used in
+  # git describe is stripped from the fork/branch.
+  if(tempBranchName)
+    set(branchName ${tempBranchName})
   endif()
 
   # All the options for retrieving data have been tried. Validate the format of


### PR DESCRIPTION
This PR attempts to fix a cmake issue where branches / forks may not have any describe data.  It additionally adds missing tests to the linux cmake test builds and migrates the macOS workflow to cmake/qt6.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

