### PR TITLE
cmake: fix macOS notarization typo

### DIFF
--- a/platform/darwin/notarizeFiles.zsh
+++ b/platform/darwin/notarizeFiles.zsh
@@ -65,7 +65,7 @@ case $STATUS in
       returnCode=0
     ;;
   *)
-    echo '\033[0;31m'"----- ${NOTA_FILE} Notarization Failud or Timeout"'\033[m'
+    echo '\033[0;31m'"----- ${NOTA_FILE} Notarization Failed or Timeout"'\033[m'
     echo $notaOutput
     returnCode=1
 esac


### PR DESCRIPTION
Fix a typo

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

