### PR TITLE
move generate_file_url() from libmythmetadata to libmythbase

### DIFF
--- a/mythplugins/mytharchive/mytharchive/videoselector.cpp
+++ b/mythplugins/mytharchive/mytharchive/videoselector.cpp
@@ -12,7 +12,7 @@
 #include <libmythbase/mythdb.h>
 #include <libmythbase/remotefile.h>
 #include <libmythbase/stringutil.h>
-#include <libmythmetadata/videoutils.h>
+#include <libmythbase/storagegroup.h>
 #include <libmythui/mythdialogbox.h>
 #include <libmythui/mythmainwindow.h>
 #include <libmythui/mythuibutton.h>
@@ -451,7 +451,7 @@ std::vector<VideoInfo *> *VideoSelector::getVideoListFromDB(void)
                 if (info->filename.isEmpty())
                 {
                     // file must not be local or doesn't exist
-                    info->filename = generate_file_url("Videos", host, filename);
+                    info->filename = StorageGroup::generate_file_url("Videos", host, filename);
                 }
             }
 

--- a/mythplugins/mythnetvision/mythnetvision/netbase.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/netbase.cpp
@@ -5,8 +5,8 @@
 #include <libmythbase/mythdirs.h>
 #include <libmythbase/remotefile.h>
 #include <libmythbase/remoteutil.h>
+#include <libmythbase/storagegroup.h>
 #include <libmythmetadata/metadataimagedownload.h>
-#include <libmythmetadata/videoutils.h>
 #include <libmythui/mythdialogbox.h>
 #include <libmythui/mythmainwindow.h>
 #include <libmythui/mythprogressdialog.h>
@@ -287,7 +287,7 @@ void NetBase::DoDownloadAndPlay()
     QString baseFilename = GetDownloadFilename(item->GetTitle(),
                                                item->GetMediaURL());
 
-    QString finalFilename = generate_file_url("Default",
+    QString finalFilename = StorageGroup::generate_file_url("Default",
                                               gCoreContext->GetMasterHostName(),
                                               baseFilename);
 

--- a/mythtv/libs/libmythbase/storagegroup.cpp
+++ b/mythtv/libs/libmythbase/storagegroup.cpp
@@ -892,4 +892,13 @@ QString StorageGroup::GetGroupToUse(
     return tmpGroup;
 }
 
+QString StorageGroup::generate_file_url(const QString &storage_group,
+                                        const QString &host,
+                                        const QString &path)
+{
+    return MythCoreContext::GenMythURL(host, gCoreContext->GetBackendServerPort(host),
+        path, StorageGroup::GetGroupToUse(host, storage_group));
+
+}
+
 /* vim: set expandtab tabstop=4 shiftwidth=4: */

--- a/mythtv/libs/libmythbase/storagegroup.h
+++ b/mythtv/libs/libmythbase/storagegroup.h
@@ -52,6 +52,9 @@ class MBASE_PUBLIC StorageGroup
     static void ClearGroupToUseCache(void);
     static QString GetGroupToUse(
         const QString &host, const QString &sgroup);
+    static QString generate_file_url(const QString &storage_group,
+                                     const QString &host,
+                                     const QString &path);
 
   private:
     static void    StaticInit(void);

--- a/mythtv/libs/libmythmetadata/metadatafactory.cpp
+++ b/mythtv/libs/libmythmetadata/metadatafactory.cpp
@@ -16,6 +16,7 @@
 #include "libmythbase/mythlogging.h"
 #include "libmythbase/programinfo.h"
 #include "libmythbase/remoteutil.h"
+#include "libmythbase/storagegroup.h"
 #include "libmythtv/recordingrule.h"
 
 // libmythmetadata
@@ -184,7 +185,7 @@ void MetadataFactory::Lookup(VideoMetadata *metadata, bool automatic,
     lookup->SetSeason(metadata->GetSeason());
     lookup->SetEpisode(metadata->GetEpisode());
     lookup->SetInetref(metadata->GetInetRef());
-    lookup->SetFilename(generate_file_url("Videos", metadata->GetHost(),
+    lookup->SetFilename(StorageGroup::generate_file_url("Videos", metadata->GetHost(),
                                       metadata->GetFilename()));
 
     if (m_lookupthread->isRunning())

--- a/mythtv/libs/libmythmetadata/videometadata.cpp
+++ b/mythtv/libs/libmythmetadata/videometadata.cpp
@@ -443,7 +443,7 @@ bool VideoMetadataImp::DeleteFile()
 
     if (!m_host.isEmpty())
     {
-        QString url = generate_file_url("Videos", m_host, m_filename);
+        QString url = StorageGroup::generate_file_url("Videos", m_host, m_filename);
         isremoved = RemoteFile::DeleteFile(url);
     }
     else
@@ -890,7 +890,7 @@ void VideoMetadataImp::GetImageMap(InfoMap &imageMap) const
         && !GetCoverFile().isEmpty()
         && !IsDefaultCoverFile(GetCoverFile()))
     {
-        coverfile = generate_file_url(QStringLiteral(u"Coverart"), GetHost(),
+        coverfile = StorageGroup::generate_file_url(QStringLiteral(u"Coverart"), GetHost(),
                                       GetCoverFile());
     }
     else
@@ -905,7 +905,7 @@ void VideoMetadataImp::GetImageMap(InfoMap &imageMap) const
     if (IsHostSet() && !GetScreenshot().startsWith(u'/')
         && !GetScreenshot().isEmpty())
     {
-        screenshotfile = generate_file_url(QStringLiteral(u"Screenshots"),
+        screenshotfile = StorageGroup::generate_file_url(QStringLiteral(u"Screenshots"),
                                            GetHost(), GetScreenshot());
     }
     else
@@ -920,7 +920,7 @@ void VideoMetadataImp::GetImageMap(InfoMap &imageMap) const
     if (IsHostSet() && !GetBanner().startsWith(u'/')
         && !GetBanner().isEmpty())
     {
-        bannerfile = generate_file_url(QStringLiteral(u"Banners"), GetHost(),
+        bannerfile = StorageGroup::generate_file_url(QStringLiteral(u"Banners"), GetHost(),
                                        GetBanner());
     }
     else
@@ -935,7 +935,7 @@ void VideoMetadataImp::GetImageMap(InfoMap &imageMap) const
     if (IsHostSet() && !GetFanart().startsWith('/')
         && !GetFanart().isEmpty())
     {
-        fanartfile = generate_file_url(QStringLiteral(u"Fanart"), GetHost(),
+        fanartfile = StorageGroup::generate_file_url(QStringLiteral(u"Fanart"), GetHost(),
                                        GetFanart());
     }
     else
@@ -964,7 +964,7 @@ QString VideoMetadataImp::GetImage(const QString& name) const
             && !coverfile.startsWith(u'/')
             && !coverfile.isEmpty()
             && !IsDefaultCoverFile(coverfile))
-            return generate_file_url(QStringLiteral(u"Coverart"), GetHost(),
+            return StorageGroup::generate_file_url(QStringLiteral(u"Coverart"), GetHost(),
                                      coverfile);
         return coverfile;
     }
@@ -975,7 +975,7 @@ QString VideoMetadataImp::GetImage(const QString& name) const
         QString screenshot = GetScreenshot();
         if (IsHostSet() && !screenshot.startsWith(u'/')
             && !screenshot.isEmpty())
-            return generate_file_url(QStringLiteral(u"Screenshots"),
+            return StorageGroup::generate_file_url(QStringLiteral(u"Screenshots"),
                                      GetHost(), screenshot);
         return screenshot;
     }
@@ -986,7 +986,7 @@ QString VideoMetadataImp::GetImage(const QString& name) const
         QString bannerfile = GetBanner();
         if (IsHostSet() && !bannerfile.startsWith(u'/')
             && !bannerfile.isEmpty())
-            return generate_file_url(QStringLiteral(u"Banners"), GetHost(),
+            return StorageGroup::generate_file_url(QStringLiteral(u"Banners"), GetHost(),
                                      bannerfile);
         return bannerfile;
     }
@@ -997,7 +997,7 @@ QString VideoMetadataImp::GetImage(const QString& name) const
         QString fanartfile = GetFanart();
         if (IsHostSet() && !fanartfile.startsWith('/')
             && !fanartfile.isEmpty())
-            return generate_file_url(QStringLiteral(u"Fanart"), GetHost(),
+            return StorageGroup::generate_file_url(QStringLiteral(u"Fanart"), GetHost(),
                                      fanartfile);
         return fanartfile;
     }
@@ -1129,7 +1129,7 @@ QString VideoMetadata::VideoFileHash(const QString &file_name,
         return FileHash(fullname);
     }
 
-    QString url = generate_file_url("Videos", host, file_name);
+    QString url = StorageGroup::generate_file_url("Videos", host, file_name);
 
     return RemoteFile::GetFileHash(url);
 }

--- a/mythtv/libs/libmythmetadata/videoscan.cpp
+++ b/mythtv/libs/libmythmetadata/videoscan.cpp
@@ -7,7 +7,7 @@
 #include <utility>
 
 // mythtv
-#include "libmyth/mythcontext.h"
+#include "libmythbase/mythcorecontext.h"
 #include "libmythbase/mythdate.h"
 #include "libmythbase/mythevent.h"
 #include "libmythbase/mythlogging.h"

--- a/mythtv/libs/libmythmetadata/videoutils.h
+++ b/mythtv/libs/libmythmetadata/videoutils.h
@@ -58,18 +58,4 @@ META_PUBLIC QString WatchedToState(bool watched);
 META_PUBLIC VideoContentType ContentTypeFromString(const QString &type);
 META_PUBLIC QString ContentTypeToString(VideoContentType type);
 
-// this needs to be an inline and pull in the storage group and context
-// headers since it this used in dbcheck.cpp.
-#include <libmythbase/storagegroup.h>
-#include <libmythbase/mythcorecontext.h>
-inline QString generate_file_url(
-    const QString &storage_group, const QString &host, const QString &path)
-{
-    uint port = gCoreContext->GetBackendServerPort(host);
-
-    return MythCoreContext::GenMythURL(host, port, path,
-                                    StorageGroup::GetGroupToUse(host, storage_group));
-
-}
-
 #endif // VIDEOUTILS_H_

--- a/mythtv/libs/libmythtv/metadataimagehelper.cpp
+++ b/mythtv/libs/libmythtv/metadataimagehelper.cpp
@@ -1,24 +1,11 @@
-
 #include "metadataimagehelper.h"
 
 #include <QUrl>
 
-#include "libmythbase/mythcorecontext.h"
+#include "libmythbase/mythdb.h"
 #include "libmythbase/mythdbcon.h"
 #include "libmythbase/mythdirs.h"
 #include "libmythbase/storagegroup.h"
-
-// a helper functions that is used only in this file
-namespace {
-    QString generate_myth_url(const QString &storage_group, const QString &host,
-                              const QString &path)
-    {
-        uint port = gCoreContext->GetBackendServerPort(host);
-
-        return MythCoreContext::GenMythURL(host, port, path,
-                                        StorageGroup::GetGroupToUse(host, storage_group));
-    }
-}
 
 ArtworkMap GetArtwork(const QString& inetref,
                       uint season,
@@ -70,21 +57,21 @@ ArtworkMap GetArtwork(const QString& inetref,
         if (!coverart.isEmpty())
         {
             ArtworkInfo coverartinfo;
-            coverartinfo.url = generate_myth_url("Coverart", host, coverart);
+            coverartinfo.url = StorageGroup::generate_file_url("Coverart", host, coverart);
             map.insert(kArtworkCoverart, coverartinfo);
         }
 
         if (!fanart.isEmpty())
         {
             ArtworkInfo fanartinfo;
-            fanartinfo.url = generate_myth_url("Fanart", host, fanart);
+            fanartinfo.url = StorageGroup::generate_file_url("Fanart", host, fanart);
             map.insert(kArtworkFanart, fanartinfo);
         }
 
         if (!banner.isEmpty())
         {
             ArtworkInfo bannerinfo;
-            bannerinfo.url = generate_myth_url("Banners", host, banner);
+            bannerinfo.url = StorageGroup::generate_file_url("Banners", host, banner);
             map.insert(kArtworkBanner, bannerinfo);
         }
     }
@@ -105,21 +92,21 @@ bool SetArtwork(const QString &inetref,
     if (!coverart.isEmpty())
     {
         ArtworkInfo coverartinfo;
-        coverartinfo.url = generate_myth_url("Coverart", host, coverart);
+        coverartinfo.url = StorageGroup::generate_file_url("Coverart", host, coverart);
         map.insert(kArtworkCoverart, coverartinfo);
     }
 
     if (!fanart.isEmpty())
     {
         ArtworkInfo fanartinfo;
-        fanartinfo.url = generate_myth_url("Fanart", host, fanart);
+        fanartinfo.url = StorageGroup::generate_file_url("Fanart", host, fanart);
         map.insert(kArtworkFanart, fanartinfo);
     }
 
     if (!banner.isEmpty())
     {
         ArtworkInfo bannerinfo;
-        bannerinfo.url = generate_myth_url("Banners", host, banner);
+        bannerinfo.url = StorageGroup::generate_file_url("Banners", host, banner);
         map.insert(kArtworkBanner, bannerinfo);
     }
 

--- a/mythtv/libs/libmythtv/videodbcheck.cpp
+++ b/mythtv/libs/libmythtv/videodbcheck.cpp
@@ -12,7 +12,7 @@
 #include "libmythbase/mythlogging.h"
 #include "libmythbase/mythmiscutil.h"
 #include "libmythbase/remotefile.h"
-#include "libmythmetadata/videoutils.h"
+#include "libmythbase/storagegroup.h"
 
 #include "videodbcheck.h"
 
@@ -58,7 +58,7 @@ static void UpdateHashes(void)
 
             if (!host.isEmpty())
             {
-                QString url = generate_file_url("Videos", host, filename);
+                QString url = StorageGroup::generate_file_url("Videos", host, filename);
                 hash =  RemoteFile::GetFileHash(url);
             }
             else

--- a/mythtv/programs/mythfrontend/editvideometadata.cpp
+++ b/mythtv/programs/mythfrontend/editvideometadata.cpp
@@ -9,6 +9,7 @@
 #include "libmyth/mythcontext.h"
 #include "libmythbase/mythdirs.h"
 #include "libmythbase/remoteutil.h"
+#include "libmythbase/storagegroup.h"
 #include "libmythbase/stringutil.h"
 #include "libmythmetadata/dbaccess.h"
 #include "libmythmetadata/globals.h"
@@ -431,7 +432,7 @@ void EditMetadataDialog::fillWidgets()
             !m_workingMetadata->GetCoverFile().isEmpty() &&
             !m_workingMetadata->GetCoverFile().startsWith("/"))
         {
-            m_coverart->SetFilename(generate_file_url("Coverart",
+            m_coverart->SetFilename(StorageGroup::generate_file_url("Coverart",
                                   m_workingMetadata->GetHost(),
                                   m_workingMetadata->GetCoverFile()));
         }
@@ -449,7 +450,7 @@ void EditMetadataDialog::fillWidgets()
             !m_workingMetadata->GetScreenshot().isEmpty() &&
             !m_workingMetadata->GetScreenshot().startsWith("/"))
         {
-            m_screenshot->SetFilename(generate_file_url("Screenshots",
+            m_screenshot->SetFilename(StorageGroup::generate_file_url("Screenshots",
                                   m_workingMetadata->GetHost(),
                                   m_workingMetadata->GetScreenshot()));
         }
@@ -467,7 +468,7 @@ void EditMetadataDialog::fillWidgets()
             !m_workingMetadata->GetBanner().isEmpty() &&
             !m_workingMetadata->GetBanner().startsWith("/"))
         {
-            m_banner->SetFilename(generate_file_url("Banners",
+            m_banner->SetFilename(StorageGroup::generate_file_url("Banners",
                                   m_workingMetadata->GetHost(),
                                   m_workingMetadata->GetBanner()));
         }
@@ -485,7 +486,7 @@ void EditMetadataDialog::fillWidgets()
             !m_workingMetadata->GetFanart().isEmpty() &&
             !m_workingMetadata->GetFanart().startsWith("/"))
         {
-            m_fanart->SetFilename(generate_file_url("Fanart",
+            m_fanart->SetFilename(StorageGroup::generate_file_url("Fanart",
                                   m_workingMetadata->GetHost(),
                                   m_workingMetadata->GetFanart()));
         }
@@ -635,7 +636,7 @@ void EditMetadataDialog::FindCoverArt()
 {
     if (!m_workingMetadata->GetHost().isEmpty())
     {
-        QString url = generate_file_url("Coverart",
+        QString url = StorageGroup::generate_file_url("Coverart",
                       m_workingMetadata->GetHost(),
                       "");
         FindImagePopup(url, "", *this, CEID_COVERARTFILE);
@@ -814,7 +815,7 @@ void EditMetadataDialog::FindBanner()
 {
     if (!m_workingMetadata->GetHost().isEmpty())
     {
-        QString url = generate_file_url("Banners",
+        QString url = StorageGroup::generate_file_url("Banners",
                       m_workingMetadata->GetHost(),
                       "");
         FindImagePopup(url, "", *this, CEID_BANNERFILE);
@@ -861,7 +862,7 @@ void EditMetadataDialog::FindFanart()
 {
     if (!m_workingMetadata->GetHost().isEmpty())
     {
-        QString url = generate_file_url("Fanart",
+        QString url = StorageGroup::generate_file_url("Fanart",
                       m_workingMetadata->GetHost(),
                       "");
         FindImagePopup(url, "", *this, CEID_FANARTFILE);
@@ -908,7 +909,7 @@ void EditMetadataDialog::FindScreenshot()
 {
     if (!m_workingMetadata->GetHost().isEmpty())
     {
-        QString url = generate_file_url("Screenshots",
+        QString url = StorageGroup::generate_file_url("Screenshots",
                       m_workingMetadata->GetHost(),
                       "");
         FindImagePopup(url, "", *this, CEID_SCREENSHOTFILE);
@@ -956,7 +957,7 @@ void EditMetadataDialog::FindTrailer()
 {
     if (!m_workingMetadata->GetHost().isEmpty())
     {
-        QString url = generate_file_url("Trailers",
+        QString url = StorageGroup::generate_file_url("Trailers",
                       m_workingMetadata->GetHost(),
                       "");
         FindVideoFilePopup(url, "", *this, CEID_TRAILERFILE);

--- a/mythtv/programs/mythfrontend/scheduleeditor.cpp
+++ b/mythtv/programs/mythfrontend/scheduleeditor.cpp
@@ -14,7 +14,6 @@
 #include "libmythbase/storagegroup.h"
 #include "libmythmetadata/mythuiimageresults.h"
 #include "libmythmetadata/mythuimetadataresults.h"
-#include "libmythmetadata/videoutils.h"
 #include "libmythtv/cardutil.h"
 #include "libmythtv/metadataimagehelper.h"
 #include "libmythtv/playgroup.h"
@@ -1440,7 +1439,7 @@ void MetadataOptions::SelectLocalFanart()
     if (!CanSetArtwork())
         return;
 
-    QString url = generate_file_url("Fanart",
+    QString url = StorageGroup::generate_file_url("Fanart",
                   gCoreContext->GetMasterHostName(),
                   "");
     FindImagePopup(url,"",*this, "fanart");
@@ -1451,7 +1450,7 @@ void MetadataOptions::SelectLocalCoverart()
     if (!CanSetArtwork())
         return;
 
-    QString url = generate_file_url("Coverart",
+    QString url = StorageGroup::generate_file_url("Coverart",
                   gCoreContext->GetMasterHostName(),
                   "");
     FindImagePopup(url,"",*this, "coverart");
@@ -1462,7 +1461,7 @@ void MetadataOptions::SelectLocalBanner()
     if (!CanSetArtwork())
         return;
 
-    QString url = generate_file_url("Banners",
+    QString url = StorageGroup::generate_file_url("Banners",
                   gCoreContext->GetMasterHostName(),
                   "");
     FindImagePopup(url,"",*this, "banner");

--- a/mythtv/programs/mythfrontend/services/frontend.cpp
+++ b/mythtv/programs/mythfrontend/services/frontend.cpp
@@ -12,9 +12,9 @@
 #include "libmythbase/mythevent.h"
 #include "libmythbase/mythlogging.h"
 #include "libmythbase/mythversion.h"
+#include "libmythbase/storagegroup.h"
 #include "libmythmetadata/videometadata.h"
 #include "libmythmetadata/videometadatalistmanager.h"
-#include "libmythmetadata/videoutils.h"
 #include "libmythtv/recordinginfo.h"
 #include "libmythtv/tv_actions.h"        // for ACTION_JUMPCHAPTER, etc
 #include "libmythtv/tv_play.h"
@@ -228,7 +228,7 @@ bool Frontend::PlayVideo(const QString &Id, bool UseBookmark)
         return false;
     }
 
-    QString mrl = generate_file_url("Videos", metadata->GetHost(),
+    QString mrl = StorageGroup::generate_file_url("Videos", metadata->GetHost(),
                                     metadata->GetFilename());
     LOG(VB_GENERAL, LOG_INFO, LOC +
         QString("PlayVideo, id: %1 usebookmark: %2 url: '%3'")

--- a/mythtv/programs/mythfrontend/services/mythfrontendservice.cpp
+++ b/mythtv/programs/mythfrontend/services/mythfrontendservice.cpp
@@ -12,8 +12,8 @@
 #include "libmythbase/mythcorecontext.h"
 #include "libmythbase/mythlogging.h"
 #include "libmythbase/mythversion.h"
+#include "libmythbase/storagegroup.h"
 #include "libmythmetadata/videometadatalistmanager.h"
-#include "libmythmetadata/videoutils.h"
 #include "libmythtv/recordinginfo.h"
 #include "libmythtv/tv_actions.h"
 #include "libmythtv/tv_play.h"
@@ -346,7 +346,7 @@ bool MythFrontendService::PlayVideo(const QString& Id, bool UseBookmark)
         return false;
     }
 
-    QString mrl = generate_file_url("Videos", metadata->GetHost(), metadata->GetFilename());
+    QString mrl = StorageGroup::generate_file_url("Videos", metadata->GetHost(), metadata->GetFilename());
     LOG(VB_GENERAL, LOG_INFO, LOC + QString("PlayVideo ID: %1 UseBookmark: %2 URL: '%3'")
         .arg(id).arg(UseBookmark).arg(mrl));
 

--- a/mythtv/programs/mythfrontend/setupwizard_video.cpp
+++ b/mythtv/programs/mythfrontend/setupwizard_video.cpp
@@ -9,7 +9,7 @@
 #include "libmythbase/mythdirs.h"
 #include "libmythbase/remotefile.h"
 #include "libmythbase/remoteutil.h"
-#include "libmythmetadata/videoutils.h"
+#include "libmythbase/storagegroup.h"
 #include "libmythui/mythprogressdialog.h"
 
 // MythFrontend
@@ -154,7 +154,7 @@ bool VideoSetupWizard::keyPressEvent(QKeyEvent *event)
 
 void VideoSetupWizard::testSDVideo(void)
 {
-    QString sdtestfile = generate_file_url("Temp",
+    QString sdtestfile = StorageGroup::generate_file_url("Temp",
                               gCoreContext->GetMasterHostName(),
                               VIDEO_SAMPLE_SD_FILENAME);
     QString desiredpbp =
@@ -177,7 +177,7 @@ void VideoSetupWizard::testSDVideo(void)
 
 void VideoSetupWizard::testHDVideo(void)
 {
-    QString hdtestfile = generate_file_url("Temp",
+    QString hdtestfile = StorageGroup::generate_file_url("Temp",
                               gCoreContext->GetMasterHostName(),
                               VIDEO_SAMPLE_HD_FILENAME);
     QString desiredpbp =

--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -462,7 +462,7 @@ namespace
                 && !metadata->GetCoverFile().isEmpty()
                 && !IsDefaultCoverFile(metadata->GetCoverFile()))
             {
-                coverfile = generate_file_url("Coverart", metadata->GetHost(),
+                coverfile = StorageGroup::generate_file_url("Coverart", metadata->GetHost(),
                         metadata->GetCoverFile());
             }
             else
@@ -479,7 +479,7 @@ namespace
             if (metadata->IsHostSet() && !metadata->GetScreenshot().startsWith("/")
                 && !metadata->GetScreenshot().isEmpty())
             {
-                screenshotfile = generate_file_url("Screenshots",
+                screenshotfile = StorageGroup::generate_file_url("Screenshots",
                         metadata->GetHost(), metadata->GetScreenshot());
             }
             else
@@ -496,7 +496,7 @@ namespace
             if (metadata->IsHostSet() && !metadata->GetBanner().startsWith("/")
                 && !metadata->GetBanner().isEmpty())
             {
-                bannerfile = generate_file_url("Banners", metadata->GetHost(),
+                bannerfile = StorageGroup::generate_file_url("Banners", metadata->GetHost(),
                         metadata->GetBanner());
             }
             else
@@ -513,7 +513,7 @@ namespace
             if (metadata->IsHostSet() && !metadata->GetFanart().startsWith("/")
                 && !metadata->GetFanart().isEmpty())
             {
-                fanartfile = generate_file_url("Fanart", metadata->GetHost(),
+                fanartfile = StorageGroup::generate_file_url("Fanart", metadata->GetHost(),
                         metadata->GetFanart());
             }
             else
@@ -1458,7 +1458,7 @@ QString VideoDialog::RemoteImageCheck(const QString& host, const QString& filena
             }
 
             if ((!list.isEmpty()) && (list.at(0) == fname))
-                result = generate_file_url("Videos", host, filename);
+                result = StorageGroup::generate_file_url("Videos", host, filename);
 
             if (!result.isEmpty())
             {
@@ -1625,7 +1625,7 @@ QString VideoDialog::GetCoverImage(MythGenericTree *node)
                                 if (!metadata->GetHost().isEmpty() &&
                                     !metadata->GetCoverFile().startsWith("/"))
                                 {
-                                    QString test_file = generate_file_url("Coverart",
+                                    QString test_file = StorageGroup::generate_file_url("Coverart",
                                                 metadata->GetHost(), metadata->GetCoverFile());
                                     if (!test_file.endsWith("/") && !test_file.isEmpty() &&
                                         !IsDefaultCoverFile(test_file))
@@ -1658,7 +1658,7 @@ QString VideoDialog::GetCoverImage(MythGenericTree *node)
                 }
                 else
                 {
-                    icon_file = generate_file_url("Videos", host, fList.at(0));
+                    icon_file = StorageGroup::generate_file_url("Videos", host, fList.at(0));
                 }
             }
         }
@@ -1685,7 +1685,7 @@ QString VideoDialog::GetCoverImage(MythGenericTree *node)
                 !metadata->GetCoverFile().startsWith("/") &&
                 !IsDefaultCoverFile(metadata->GetCoverFile()))
             {
-                icon_file = generate_file_url("Coverart", metadata->GetHost(),
+                icon_file = StorageGroup::generate_file_url("Coverart", metadata->GetHost(),
                         metadata->GetCoverFile());
             }
             else
@@ -1744,7 +1744,7 @@ QString VideoDialog::GetFirstImage(MythGenericTree *node, const QString& type,
                     if (type == "Coverart" && !host.isEmpty() &&
                         !metadata->GetCoverFile().startsWith("/"))
                     {
-                        test_file = generate_file_url("Coverart",
+                        test_file = StorageGroup::generate_file_url("Coverart",
                                     host, metadata->GetCoverFile());
                     }
                     else if (type == "Coverart")
@@ -1763,7 +1763,7 @@ QString VideoDialog::GetFirstImage(MythGenericTree *node, const QString& type,
                     if (type == "Fanart" && !host.isEmpty() &&
                         !metadata->GetFanart().startsWith("/"))
                     {
-                        test_file = generate_file_url("Fanart",
+                        test_file = StorageGroup::generate_file_url("Fanart",
                                     host, metadata->GetFanart());
                     }
                     else if (type == "Fanart")
@@ -1782,7 +1782,7 @@ QString VideoDialog::GetFirstImage(MythGenericTree *node, const QString& type,
                     if (type == "Banners" && !host.isEmpty() &&
                         !metadata->GetBanner().startsWith("/"))
                     {
-                        test_file = generate_file_url("Banners",
+                        test_file = StorageGroup::generate_file_url("Banners",
                                     host, metadata->GetBanner());
                     }
                     else if (type == "Banners")
@@ -1801,7 +1801,7 @@ QString VideoDialog::GetFirstImage(MythGenericTree *node, const QString& type,
                     if (type == "Screenshots" && !host.isEmpty() &&
                         !metadata->GetScreenshot().startsWith("/"))
                     {
-                        test_file = generate_file_url("Screenshots",
+                        test_file = StorageGroup::generate_file_url("Screenshots",
                                     host, metadata->GetScreenshot());
                     }
                     else if (type == "Screenshots")
@@ -1865,7 +1865,7 @@ QString VideoDialog::GetScreenshot(MythGenericTree *node)
                     !metadata->GetScreenshot().startsWith("/") &&
                     !metadata->GetScreenshot().isEmpty())
             {
-                icon_file = generate_file_url("Screenshots", metadata->GetHost(),
+                icon_file = StorageGroup::generate_file_url("Screenshots", metadata->GetHost(),
                         metadata->GetScreenshot());
             }
             else
@@ -1901,7 +1901,7 @@ QString VideoDialog::GetBanner(MythGenericTree *node)
                !metadata->GetBanner().startsWith("/") &&
                !metadata->GetBanner().isEmpty())
         {
-            icon_file = generate_file_url("Banners", metadata->GetHost(),
+            icon_file = StorageGroup::generate_file_url("Banners", metadata->GetHost(),
                     metadata->GetBanner());
         }
         else
@@ -1936,7 +1936,7 @@ QString VideoDialog::GetFanart(MythGenericTree *node)
                 !metadata->GetFanart().startsWith("/") &&
                 !metadata->GetFanart().isEmpty())
         {
-            icon_file = generate_file_url("Fanart", metadata->GetHost(),
+            icon_file = StorageGroup::generate_file_url("Fanart", metadata->GetHost(),
                     metadata->GetFanart());
         }
         else
@@ -3232,7 +3232,7 @@ void VideoDialog::playTrailer()
 
     if (metadata->IsHostSet() && !metadata->GetTrailer().startsWith("/"))
     {
-        url = generate_file_url("Trailers", metadata->GetHost(),
+        url = StorageGroup::generate_file_url("Trailers", metadata->GetHost(),
                         metadata->GetTrailer());
     }
     else

--- a/mythtv/programs/mythfrontend/videoplayercommand.cpp
+++ b/mythtv/programs/mythfrontend/videoplayercommand.cpp
@@ -7,9 +7,9 @@
 #include "libmythbase/mythmiscutil.h"
 #include "libmythbase/mythsystemlegacy.h"
 #include "libmythbase/remoteutil.h"
+#include "libmythbase/storagegroup.h"
 #include "libmythmetadata/dbaccess.h"
 #include "libmythmetadata/videometadata.h"
-#include "libmythmetadata/videoutils.h"
 #include "libmythui/mythmainwindow.h"
 
 // MythFrontend
@@ -209,7 +209,7 @@ class VideoPlayerCommandPrivate
 
             if (item->IsHostSet())
             {
-                filename = generate_file_url("Videos", item->GetHost(),
+                filename = StorageGroup::generate_file_url("Videos", item->GetHost(),
                         item->GetFilename());
             }
             else
@@ -242,7 +242,7 @@ class VideoPlayerCommandPrivate
 
             if (item->IsHostSet())
             {
-                filename = generate_file_url("Videos", item->GetHost(),
+                filename = StorageGroup::generate_file_url("Videos", item->GetHost(),
                         item->GetFilename());
             }
             else


### PR DESCRIPTION
This breaks the dependency of libmythtv on libmythmetadata.

This was originally part of https://github.com/MythTV/mythtv/pull/671

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

