### PR TITLE
libmythmetadata/imagemetadata: remove Qt 5.4.1 specific code

### DIFF
--- a/mythtv/libs/libmythmetadata/imagemetadata.cpp
+++ b/mythtv/libs/libmythmetadata/imagemetadata.cpp
@@ -33,7 +33,7 @@ int Orientation::Transform(int transform)
  * \brief Determines orientation required for an image
  * \return Exif orientation code to apply after the image has been loaded.
  */
-int Orientation::GetCurrent()
+int Orientation::GetCurrent() const
 {
     return m_current;
 }

--- a/mythtv/libs/libmythmetadata/imagemetadata.cpp
+++ b/mythtv/libs/libmythmetadata/imagemetadata.cpp
@@ -29,73 +29,12 @@ int Orientation::Transform(int transform)
     return Composite();
 }
 
-
-/*!
-   \brief Initialises conversion matrix for Qt 5.4.1
-   \return Matrix of orientation codes such that:
-    Qt 5.4.1 orientation = matrix(file orientation, current orientation)
- */
-Orientation::Matrix Orientation::InitOrientationMatrix()
-{
-    Orientation::Matrix matrix;
-
-    if (krunningQt541)
-    {
-        // Each row/string defines codes for a single file orientation
-        // Each col/value defines applicable code for corresponding current orientation
-        // As current orientation is applicable to raw camera image, these codes
-        // define the current orientation relative to 1/Normal (as Qt 5.4.1 has already
-        // applied the file orientation)
-        QStringList vals = QStringList()
-                << "0 1 2 3 4 5 6 7 8"
-                << "0 1 2 3 4 5 6 7 8"
-                << "0 2 1 4 3 8 7 6 5"
-                << "0 3 4 1 2 7 8 5 6"
-                << "0 4 3 2 1 6 5 8 7"
-                << "0 5 6 7 8 1 2 3 4"
-                << "0 8 7 6 5 2 1 4 3"
-                << "0 7 8 5 6 3 4 1 2"
-                << "0 6 5 8 7 4 3 2 1";
-
-        for (int row = 0; row < vals.size(); ++row)
-        {
-            QStringList rowVals = vals.at(row).split(' ');
-            for (int col = 0; col < rowVals.size(); ++col)
-                matrix[row][col] = rowVals.at(col).toInt();
-        }
-    }
-    return matrix;
-}
-
-const bool Orientation::krunningQt541 = (strcmp(qVersion(), "5.4.1") == 0);
-const Orientation::Matrix Orientation::kQt541_orientation =
-        Orientation::InitOrientationMatrix();
-
-
 /*!
  * \brief Determines orientation required for an image
- * \details Some Qt versions automatically apply file orientation when an image
- * is loaded. This compensates for that to ensure images are always orientated
-   correctly.
- * \param compensate Whether to compensate for Qt auto-rotation
  * \return Exif orientation code to apply after the image has been loaded.
  */
-int Orientation::GetCurrent(bool compensate)
+int Orientation::GetCurrent()
 {
-    // Qt 5.4.1 automatically applies the file orientation when loading images
-    // Ref: https://codereview.qt-project.org/#/c/111398/
-    // Ref: https://codereview.qt-project.org/#/c/110685/
-    // https://bugreports.qt.io/browse/QTBUG-37946
-    if (compensate && krunningQt541)
-    {
-        // Deduce orientation relative to 1/Normal from file & current orientations
-        int old = m_current;
-        m_current = kQt541_orientation.value(m_file).value(m_current);
-
-        LOG(VB_FILE, LOG_DEBUG, LOC +
-            QString("Adjusted orientation %1 to %2 for Qt 5.4.1")
-            .arg(old).arg(m_current));
-    }
     return m_current;
 }
 

--- a/mythtv/libs/libmythmetadata/imagemetadata.h
+++ b/mythtv/libs/libmythmetadata/imagemetadata.h
@@ -70,7 +70,7 @@ public:
     //! Encode original & current orientation to a single Db field
     int Composite() const { return (m_current * 10) + m_file; }
     int Transform(int transform);
-    int GetCurrent(bool compensate);
+    int GetCurrent();
     QString Description() const;
 
     static int FromRotation(const QString &degrees);
@@ -79,14 +79,6 @@ private:
     static QString AsText(int orientation);
 
     int Apply(int transform) const;
-
-    using Matrix = QHash<int, QHash<int, int> >;
-
-    //! True when using Qt 5.4.1 with its deviant orientation behaviour
-    static const bool krunningQt541;
-    //! Orientation conversions for proper display on Qt 5.4.1
-    static const Matrix kQt541_orientation;
-    static Matrix InitOrientationMatrix();
 
     //! The orientation to use: the file orientation with user transformations applied.
     int m_current;

--- a/mythtv/libs/libmythmetadata/imagemetadata.h
+++ b/mythtv/libs/libmythmetadata/imagemetadata.h
@@ -70,7 +70,7 @@ public:
     //! Encode original & current orientation to a single Db field
     int Composite() const { return (m_current * 10) + m_file; }
     int Transform(int transform);
-    int GetCurrent();
+    int GetCurrent() const;
     QString Description() const;
 
     static int FromRotation(const QString &degrees);

--- a/mythtv/libs/libmythmetadata/imagescanner.cpp
+++ b/mythtv/libs/libmythmetadata/imagescanner.cpp
@@ -487,7 +487,7 @@ void ImageScanThread<DBFS>::SyncFile(const QFileInfo &fileInfo, int devId,
                          im->m_comment, im->m_date, fileOrient);
 
         // Reset file orientation, retaining existing setting
-        int currentOrient = Orientation(dbIm->m_orientation).GetCurrent(false);
+        int currentOrient = Orientation(dbIm->m_orientation).GetCurrent();
         im->m_orientation = Orientation(currentOrient, fileOrient).Composite();
 
         // Remove it from removed list

--- a/mythtv/libs/libmythmetadata/imagethumbs.cpp
+++ b/mythtv/libs/libmythmetadata/imagethumbs.cpp
@@ -300,9 +300,7 @@ QString ThumbThread<DBFS>::CreateThumbnail(const ImagePtrK &im, int thumbPriorit
                 .arg(im->m_type).arg(imagePath);
     }
 
-    // Compensate for any Qt auto-orientation
-    int orientBy = Orientation(im->m_orientation)
-            .GetCurrent(im->m_type == kImageFile);
+    int orientBy = Orientation(im->m_orientation).GetCurrent();
 
     // Orientate now to optimise load/display time - no orientation
     // is required when displaying thumbnails

--- a/mythtv/programs/mythfrontend/galleryslide.cpp
+++ b/mythtv/programs/mythfrontend/galleryslide.cpp
@@ -415,9 +415,9 @@ bool Slide::LoadSlide(const ImagePtrK& im, int direction, bool notifyCompletion)
     }
     else
     {
-        // Load image, compensating for any Qt auto-orientation
+        // Load image
         SetFilename(im->m_url);
-        SetOrientation(Orientation(m_data->m_orientation).GetCurrent(true));
+        SetOrientation(Orientation(m_data->m_orientation).GetCurrent());
     }
 
     // Load in background


### PR DESCRIPTION
The current QT5_MIN_VERSION_STR is 5.15.2.

This was originally part of https://github.com/MythTV/mythtv/pull/671.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

