### PR TITLE
Github: fix broken macOS 13 python

### DIFF
--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -348,21 +348,23 @@ jobs:
           key: ${{ matrix.os.desc }}-${{ matrix.compiler.desc }}-build-core-ccache-${{ github.sha }}
           restore-keys: ${{ matrix.os.desc }}-${{ matrix.compiler.desc }}-build-core-ccache
 
-      - name: Update Homebrew Environment
-        run: |
-          brew update && brew upgrade
-          PKGMGR_PREFIX=$(brew --prefix)
-          echo "PKGMGR_PREFIX=$PKGMGR_PREFIX" >> $GITHUB_ENV
-
       - name: Fix Python install on Ventura
         run: |
           echo "Force remove currently installed python"
           brew unlink python
           brew unlink python3
-          brew remove --force --ignore-dependencies python3
+          brew deps python3 | xargs brew remove --ignore-dependencies
+          brew list | grep python@|xargs brew remove --force --ignore-dependencies
           echo "re-install requested python"
+          brew update
           brew install --force --overwrite python3
         if: matrix.os.runner == 'macOS-13'
+
+      - name: Update Homebrew Environment
+        run: |
+          brew update && brew upgrade
+          PKGMGR_PREFIX=$(brew --prefix)
+          echo "PKGMGR_PREFIX=$PKGMGR_PREFIX" >> $GITHUB_ENV
 
       - name: Install Ansible and missing Python necessities
         run: |


### PR DESCRIPTION
  Github and homebrew occasionally get out of sync with the python
  package.  Fix this by brute force uninstalling python and its
  dependents, updating homebrew, then reinstalling python.  Necessary
  dependents should get reinstalled by ansible.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

