### PR TITLE
remove unused pidfile and logfile global variables

### DIFF
--- a/mythtv/libs/libmythbase/mythcommandlineparser.cpp
+++ b/mythtv/libs/libmythbase/mythcommandlineparser.cpp
@@ -1286,6 +1286,12 @@ MythCommandLineParser::MythCommandLineParser(QString appname)
 
 MythCommandLineParser::~MythCommandLineParser()
 {
+    QString pidfile = toString("pidfile");
+    if (!pidfile.isEmpty())
+    {
+        QFile::remove(pidfile);
+    }
+
     QMap<QString, CommandLineArg*>::iterator i;
 
     i = m_namedArgs.begin();

--- a/mythtv/programs/mythbackend/mythbackend_main_helpers.cpp
+++ b/mythtv/programs/mythbackend/mythbackend_main_helpers.cpp
@@ -82,7 +82,6 @@ static JobQueue               *gJobQueue        { nullptr };
 static MythSystemEventHandler *gSysEventHandler { nullptr };
 static MediaServer            *g_pUPnp          { nullptr };
 static MainServer             *mainServer       { nullptr };
-static QString gPidFile;
 
 bool setupTVs(bool ismaster, bool &error)
 {
@@ -321,12 +320,6 @@ void cleanup(void)
      delete gBackendContext;
      gBackendContext = nullptr;
 
-    if (!gPidFile.isEmpty())
-    {
-        QFile::remove(gPidFile);
-        gPidFile.clear();
-    }
-
     SignalHandler::Done();
 }
 
@@ -525,23 +518,6 @@ void print_warnings(const MythBackendCommandLineParser &cmdline)
 
 int run_backend(MythBackendCommandLineParser &cmdline)
 {
-    gPidFile = cmdline.toString("pidfile");
-    if (!gPidFile.isEmpty())
-    {
-        QFile file(gPidFile);
-        if (file.open(QIODevice::WriteOnly))
-        {
-            qint64 pid = QCoreApplication::applicationPid();
-            file.write(qPrintable(QString("%1\n").arg(pid)));
-            file.close();
-        }
-        else
-        {
-            LOG(VB_GENERAL, LOG_WARNING,
-                QString(LOC + "Cannot open pidfile named %1").arg(gPidFile));
-        }
-    }
-
     gBackendContext = new BackendContext();
 
     if (gCoreContext->IsDatabaseIgnored())

--- a/mythtv/programs/mythjobqueue/mythjobqueue.cpp
+++ b/mythtv/programs/mythjobqueue/mythjobqueue.cpp
@@ -41,19 +41,10 @@
 #define LOC_ERR  QString("MythJobQueue, Error: ")
 
 JobQueue *jobqueue = nullptr;
-QString   pidfile;
-QString   logfile;
-
 static void cleanup(void)
 {
     delete gContext;
     gContext = nullptr;
-
-    if (!pidfile.isEmpty())
-    {
-        unlink(pidfile.toLatin1().constData());
-        pidfile.clear();
-    }
 
     SignalHandler::Done();
 }

--- a/mythtv/programs/mythmediaserver/mythmediaserver.cpp
+++ b/mythtv/programs/mythmediaserver/mythmediaserver.cpp
@@ -44,19 +44,10 @@ static inline void ms_sd_notify(const char */*str*/) {};
 #define LOC_WARN QString("MythMediaServer, Warning: ")
 #define LOC_ERR  QString("MythMediaServer, Error: ")
 
-QString   pidfile;
-QString   logfile  = "";
-
 static void cleanup(void)
 {
     delete gContext;
     gContext = nullptr;
-
-    if (!pidfile.isEmpty())
-    {
-        unlink(pidfile.toLatin1().constData());
-        pidfile.clear();
-    }
 
     SignalHandler::Done();
 }

--- a/mythtv/programs/mythtv-setup/mythtv-setup.cpp
+++ b/mythtv/programs/mythtv-setup/mythtv-setup.cpp
@@ -56,7 +56,6 @@ ExitPrompter   *exitPrompt  = nullptr;
 StartPrompter  *startPrompt = nullptr;
 
 static MythThemedMenu *menu;
-static QString  logfile;
 
 static void cleanup()
 {


### PR DESCRIPTION
Also improve code creating and deleting the pidfile for mythbackend.

Expanded version of a commit from https://github.com/MythTV/mythtv/pull/671.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

