### PR TITLE
Move constants from libmyth/backendselect.h to libmythbase/configuration.h and libmythupnp/ssdp.h

### DIFF
--- a/mythtv/libs/libmyth/backendselect.cpp
+++ b/mythtv/libs/libmyth/backendselect.cpp
@@ -252,12 +252,12 @@ void BackendSelection::Cancel(void)
 void BackendSelection::Load(void)
 {
     SSDP::AddListener(this);
-    SSDP::Instance()->PerformSearch(kBackendURI);
+    SSDP::Instance()->PerformSearch(SSDP::kBackendURI);
 }
 
 void BackendSelection::Init(void)
 {
-    SSDPCacheEntries *pEntries = SSDPCache::Instance()->Find(kBackendURI);
+    SSDPCacheEntries *pEntries = SSDPCache::Instance()->Find(SSDP::kBackendURI);
     if (pEntries)
     {
         EntryMap ourMap;

--- a/mythtv/libs/libmyth/backendselect.cpp
+++ b/mythtv/libs/libmyth/backendselect.cpp
@@ -120,8 +120,8 @@ void BackendSelection::Accept(MythUIButtonListItem *item)
         {
             auto config = XmlConfiguration(m_configFilename);
             if (!m_pinCode.isEmpty())
-                config.SetValue(kDefaultPIN, m_pinCode);
-            config.SetValue(kDefaultUSN, m_usn);
+                config.SetValue(XmlConfiguration::kDefaultPIN, m_pinCode);
+            config.SetValue(XmlConfiguration::kDefaultUSN, m_usn);
             config.Save();
         }
         CloseWithDecision(kAcceptConfigure);

--- a/mythtv/libs/libmyth/backendselect.h
+++ b/mythtv/libs/libmyth/backendselect.h
@@ -14,11 +14,6 @@ class MythUIButton;
 
 class DatabaseParams;
 
-// TODO: The following do not belong here, but I cannot think of a better
-//       location at this moment in time
-// Some common UPnP search and XML value strings
-const QString kBackendURI = "urn:schemas-mythtv-org:device:MasterMediaServer:1";
-
 using ItemMap = QMap <QString, DeviceLocation*>;
 
 /**

--- a/mythtv/libs/libmyth/backendselect.h
+++ b/mythtv/libs/libmyth/backendselect.h
@@ -18,11 +18,6 @@ class DatabaseParams;
 //       location at this moment in time
 // Some common UPnP search and XML value strings
 const QString kBackendURI = "urn:schemas-mythtv-org:device:MasterMediaServer:1";
-const QString kDefaultDB  = "Database/";
-const QString kDefaultWOL = "WakeOnLAN/";
-const QString kDefaultMFE = "UPnP/MythFrontend/DefaultBackend/";
-const QString kDefaultPIN = kDefaultMFE + "SecurityPin";
-const QString kDefaultUSN = kDefaultMFE + "USN";
 
 using ItemMap = QMap <QString, DeviceLocation*>;
 

--- a/mythtv/libs/libmyth/mythcontext.cpp
+++ b/mythtv/libs/libmyth/mythcontext.cpp
@@ -570,18 +570,18 @@ bool MythContextPrivate::LoadDatabaseSettings(void)
     m_dbParams.LoadDefaults();
 
     m_dbParams.m_localHostName  = config.GetValue("LocalHostName", "");
-    m_dbParams.m_dbHostPing     = config.GetValue(kDefaultDB + "PingHost", true);
-    m_dbParams.m_dbHostName     = config.GetValue(kDefaultDB + "Host", "");
-    m_dbParams.m_dbUserName     = config.GetValue(kDefaultDB + "UserName", "");
-    m_dbParams.m_dbPassword     = config.GetValue(kDefaultDB + "Password", "");
-    m_dbParams.m_dbName         = config.GetValue(kDefaultDB + "DatabaseName", "");
-    m_dbParams.m_dbPort         = config.GetValue(kDefaultDB + "Port", 0);
+    m_dbParams.m_dbHostPing     = config.GetValue(XmlConfiguration::kDefaultDB + "PingHost", true);
+    m_dbParams.m_dbHostName     = config.GetValue(XmlConfiguration::kDefaultDB + "Host", "");
+    m_dbParams.m_dbUserName     = config.GetValue(XmlConfiguration::kDefaultDB + "UserName", "");
+    m_dbParams.m_dbPassword     = config.GetValue(XmlConfiguration::kDefaultDB + "Password", "");
+    m_dbParams.m_dbName         = config.GetValue(XmlConfiguration::kDefaultDB + "DatabaseName", "");
+    m_dbParams.m_dbPort         = config.GetValue(XmlConfiguration::kDefaultDB + "Port", 0);
 
-    m_dbParams.m_wolEnabled     = config.GetValue(kDefaultWOL + "Enabled", false);
+    m_dbParams.m_wolEnabled     = config.GetValue(XmlConfiguration::kDefaultWOL + "Enabled", false);
     m_dbParams.m_wolReconnect   =
-        config.GetDuration<std::chrono::seconds>(kDefaultWOL + "SQLReconnectWaitTime", 0s);
-    m_dbParams.m_wolRetry       = config.GetValue(kDefaultWOL + "SQLConnectRetry", 5);
-    m_dbParams.m_wolCommand     = config.GetValue(kDefaultWOL + "Command", "");
+        config.GetDuration<std::chrono::seconds>(XmlConfiguration::kDefaultWOL + "SQLReconnectWaitTime", 0s);
+    m_dbParams.m_wolRetry       = config.GetValue(XmlConfiguration::kDefaultWOL + "SQLConnectRetry", 5);
+    m_dbParams.m_wolCommand     = config.GetValue(XmlConfiguration::kDefaultWOL + "Command", "");
 
     bool ok = m_dbParams.IsValid(XmlConfiguration::kDefaultFilename);
 
@@ -673,7 +673,7 @@ bool MythContextPrivate::SaveDatabaseParams(
 
         config.SetValue("LocalHostName", params.m_localHostName);
 
-        config.SetValue(kDefaultDB + "PingHost", params.m_dbHostPing);
+        config.SetValue(XmlConfiguration::kDefaultDB + "PingHost", params.m_dbHostPing);
 
         // If dbHostName is an IPV6 address with scope,
         // remove the scope. Unescaped % signs are an
@@ -685,17 +685,17 @@ bool MythContextPrivate::SaveDatabaseParams(
             addr.setScopeId(QString());
             dbHostName = addr.toString();
         }
-        config.SetValue(kDefaultDB + "Host",     dbHostName);
-        config.SetValue(kDefaultDB + "UserName", params.m_dbUserName);
-        config.SetValue(kDefaultDB + "Password", params.m_dbPassword);
-        config.SetValue(kDefaultDB + "DatabaseName", params.m_dbName);
-        config.SetValue(kDefaultDB + "Port",     params.m_dbPort);
+        config.SetValue(XmlConfiguration::kDefaultDB + "Host",     dbHostName);
+        config.SetValue(XmlConfiguration::kDefaultDB + "UserName", params.m_dbUserName);
+        config.SetValue(XmlConfiguration::kDefaultDB + "Password", params.m_dbPassword);
+        config.SetValue(XmlConfiguration::kDefaultDB + "DatabaseName", params.m_dbName);
+        config.SetValue(XmlConfiguration::kDefaultDB + "Port",     params.m_dbPort);
 
-        config.SetValue(kDefaultWOL + "Enabled", params.m_wolEnabled);
+        config.SetValue(XmlConfiguration::kDefaultWOL + "Enabled", params.m_wolEnabled);
         config.SetDuration(
-            kDefaultWOL + "SQLReconnectWaitTime", params.m_wolReconnect);
-        config.SetValue(kDefaultWOL + "SQLConnectRetry", params.m_wolRetry);
-        config.SetValue(kDefaultWOL + "Command", params.m_wolCommand);
+            XmlConfiguration::kDefaultWOL + "SQLReconnectWaitTime", params.m_wolReconnect);
+        config.SetValue(XmlConfiguration::kDefaultWOL + "SQLConnectRetry", params.m_wolRetry);
+        config.SetValue(XmlConfiguration::kDefaultWOL + "Command", params.m_wolCommand);
 
         // actually save the file
         success = config.Save();
@@ -1268,8 +1268,8 @@ bool MythContextPrivate::DefaultUPnP(QString& Error)
     QString usn;
     {
         auto config = XmlConfiguration(); // read-only
-        pin = config.GetValue(kDefaultPIN, QString(""));
-        usn = config.GetValue(kDefaultUSN, QString(""));
+        pin = config.GetValue(XmlConfiguration::kDefaultPIN, QString(""));
+        usn = config.GetValue(XmlConfiguration::kDefaultUSN, QString(""));
     }
 
     if (usn.isEmpty())

--- a/mythtv/libs/libmyth/mythcontext.cpp
+++ b/mythtv/libs/libmyth/mythcontext.cpp
@@ -1194,7 +1194,7 @@ int MythContextPrivate::UPnPautoconf(const std::chrono::milliseconds milliSecond
     LOG(VB_GENERAL, LOG_INFO, QString("UPNP Search %1 secs")
         .arg(seconds.count()));
 
-    SSDP::Instance()->PerformSearch(kBackendURI, seconds);
+    SSDP::Instance()->PerformSearch(SSDP::kBackendURI, seconds);
 
     // Search for a total of 'milliSeconds' ms, sending new search packet
     // about every 250 ms until less than one second remains.
@@ -1209,12 +1209,12 @@ int MythContextPrivate::UPnPautoconf(const std::chrono::milliseconds milliSecond
             auto ttlSeconds = duration_cast<std::chrono::seconds>(ttl);
             LOG(VB_GENERAL, LOG_INFO, QString("UPNP Search %1 secs")
                 .arg(ttlSeconds.count()));
-            SSDP::Instance()->PerformSearch(kBackendURI, ttlSeconds);
+            SSDP::Instance()->PerformSearch(SSDP::kBackendURI, ttlSeconds);
             searchTime.start();
         }
     }
 
-    SSDPCacheEntries *backends = SSDP::Find(kBackendURI);
+    SSDPCacheEntries *backends = SSDP::Find(SSDP::kBackendURI);
 
     if (!backends)
     {
@@ -1288,7 +1288,7 @@ bool MythContextPrivate::DefaultUPnP(QString& Error)
     auto timeout_s = duration_cast<std::chrono::seconds>(timeout_ms);
     LOG(VB_GENERAL, LOG_INFO, loc + QString("UPNP Search up to %1 secs")
         .arg(timeout_s.count()));
-    SSDP::Instance()->PerformSearch(kBackendURI, timeout_s);
+    SSDP::Instance()->PerformSearch(SSDP::kBackendURI, timeout_s);
 
     // ----------------------------------------------------------------------
     // We need to give the server time to respond...
@@ -1301,7 +1301,7 @@ bool MythContextPrivate::DefaultUPnP(QString& Error)
     searchTime.start();
     while (totalTime.elapsed() < timeout_ms)
     {
-        devicelocation = SSDP::Find(kBackendURI, usn);
+        devicelocation = SSDP::Find(SSDP::kBackendURI, usn);
         if (devicelocation)
             break;
 
@@ -1313,7 +1313,7 @@ bool MythContextPrivate::DefaultUPnP(QString& Error)
             auto ttlSeconds = duration_cast<std::chrono::seconds>(ttl);
             LOG(VB_GENERAL, LOG_INFO, loc + QString("UPNP Search up to %1 secs")
                 .arg(ttlSeconds.count()));
-            SSDP::Instance()->PerformSearch(kBackendURI, ttlSeconds);
+            SSDP::Instance()->PerformSearch(SSDP::kBackendURI, ttlSeconds);
             searchTime.start();
         }
     }

--- a/mythtv/libs/libmythbase/configuration.h
+++ b/mythtv/libs/libmythbase/configuration.h
@@ -54,6 +54,12 @@ class MBASE_PUBLIC XmlConfiguration
 
     static constexpr auto kDefaultFilename = "config.xml";
 
+    static inline const QString kDefaultDB  {"Database/"};
+    static inline const QString kDefaultWOL {"WakeOnLAN/"};
+    static inline const QString kDefaultMFE {"UPnP/MythFrontend/DefaultBackend/"};
+    static inline const QString kDefaultPIN {kDefaultMFE + "SecurityPin"};
+    static inline const QString kDefaultUSN {kDefaultMFE + "USN"};
+
     XmlConfiguration() { Load(); }
     explicit XmlConfiguration(QString fileName)
         : m_fileName(std::move(fileName))

--- a/mythtv/libs/libmythupnp/ssdp.h
+++ b/mythtv/libs/libmythupnp/ssdp.h
@@ -110,6 +110,8 @@ class UPNP_PUBLIC SSDP : public MThread
  
     public:
 
+        static inline const QString kBackendURI = "urn:schemas-mythtv-org:device:MasterMediaServer:1";
+
         static SSDP* Instance();
         static void Shutdown();
 


### PR DESCRIPTION
This was originally part of https://github.com/MythTV/mythtv/pull/671.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

