### PR TITLE
Fix Blu-ray crashes

### DIFF
--- a/mythtv/libs/libmythtv/Bluray/mythbddecoder.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbddecoder.cpp
@@ -68,7 +68,6 @@ void MythBDDecoder::StreamChangeCheck(void)
         QMutexLocker locker(&m_trackLock);
         Reset(true, false, false);
         CloseCodecs();
-        FindStreamInfo();
         ScanStreams(false);
         m_streamsChanged=false;
     }

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -126,8 +126,6 @@ static constexpr int16_t kMaxVideoQueueSize = 220;
 static constexpr ssize_t kMaxVideoQueueSize = 220;
 #endif
 
-static bool silence_ffmpeg_logging = false;
-
 static QSize get_video_dim(const AVCodecContext &ctx)
 {
     return {ctx.width >> ctx.lowres, ctx.height >> ctx.lowres};
@@ -265,9 +263,6 @@ static bool StreamHasRequiredParameters(AVCodecContext *Context, AVStream *Strea
 
 static void myth_av_log(void *ptr, int level, const char* fmt, va_list vl)
 {
-    if (silence_ffmpeg_logging)
-        return;
-
     if (VERBOSE_LEVEL_NONE())
         return;
 

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -879,21 +879,6 @@ extern "C"
     }
 }
 
-int AvFormatDecoder::FindStreamInfo(void)
-{
-    m_avCodecLock.lock();
-    int retval = avformat_find_stream_info(m_ic, nullptr);
-    m_avCodecLock.unlock();
-    silence_ffmpeg_logging = false;
-    // ffmpeg 3.0 is returning -1 code when there is a channel
-    // change or some encoding error just after the start
-    // of the file, but is has found the correct stream info
-    // Set rc to 0 so that playing can continue.
-    if (retval == -1)
-        retval = 0;
-    return retval;
-}
-
 /**
  *  OpenFile opens a ringbuffer for playback.
  *
@@ -1042,7 +1027,9 @@ int AvFormatDecoder::OpenFile(MythMediaBuffer *Buffer, bool novideo,
         m_ic->max_analyze_duration = 60LL * AV_TIME_BASE;
 
         m_avfRingBuffer->SetInInit(m_livetv);
-        err = FindStreamInfo();
+        m_avCodecLock.lock();
+        err = avformat_find_stream_info(m_ic, nullptr);
+        m_avCodecLock.unlock();
         if (err < 0)
         {
             LOG(VB_GENERAL, LOG_ERR, LOC + QString("Could not find codec parameters for '%1'").arg(filename));

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.h
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.h
@@ -120,7 +120,6 @@ class AvFormatDecoder : public DecoderBase
     int SetTrack(uint Type, int TrackNo) override;
 
     int ScanStreams(bool novideo);
-    int FindStreamInfo(void);
 
     int  GetNumChapters() override; // DecoderBase
     void GetChapterTimes(QList<std::chrono::seconds> &times) override; // DecoderBase


### PR DESCRIPTION
call avformat_find_stream_info() only once

It frees FFStream::info, which will cause a segmentation fault on a second call
since info will be NULL.

silence_ffmpeg_logging is never set and -1 is not an AVERROR code (depends on
the values used by errno.h), so those can be removed.

Closes https://github.com/MythTV/mythtv/issues/1035.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

