### PR TITLE
remove unnecessary references to QtScript

### DIFF
--- a/mythtv/libs/libmyth/libmyth.pro
+++ b/mythtv/libs/libmyth/libmyth.pro
@@ -1,7 +1,6 @@
 include ( ../../settings.pro )
 
 QT += network xml sql widgets
-using_qtscript: QT += script
 android: QT += androidextras
 
 TEMPLATE = lib

--- a/mythtv/libs/libmythupnp/httpserver.cpp
+++ b/mythtv/libs/libmythupnp/httpserver.cpp
@@ -24,9 +24,6 @@
 #endif
 
 // Qt headers
-#if CONFIG_QTSCRIPT
-#include <QScriptEngine>
-#endif
 #include <QSslConfiguration>
 #include <QSslSocket>
 #include <QSslCipher>

--- a/mythtv/libs/libmythupnp/httpserver.h
+++ b/mythtv/libs/libmythupnp/httpserver.h
@@ -43,9 +43,6 @@
 #include "upnputil.h"
 
 class HttpWorkerThread;
-#if CONFIG_QTSCRIPT
-class QScriptEngine;
-#endif
 class HttpServer;
 #ifndef QT_NO_OPENSSL
 class QSslKey;

--- a/mythtv/programs/mythbackend/mediaserver.cpp
+++ b/mythtv/programs/mythbackend/mediaserver.cpp
@@ -13,9 +13,6 @@
 // Qt
 #include <QNetworkInterface>
 #include <QNetworkProxy>
-#if CONFIG_QTSCRIPT
-#include <QScriptEngine>
-#endif
 
 // MythTV
 #if CONFIG_LIBDNS_SD

--- a/mythtv/programs/mythexternrecorder/CMakeLists.txt
+++ b/mythtv/programs/mythexternrecorder/CMakeLists.txt
@@ -11,9 +11,6 @@ add_executable(
 target_include_directories(mythexternrecorder PRIVATE .)
 
 target_link_libraries(mythexternrecorder PUBLIC myth mythbase mythtv)
-if(TARGET Qt${QT_VERSION_MAJOR}::Script)
-  target_link_libraries(mythexternrecorder PUBLIC Qt${QT_VERSION_MAJOR}::Script)
-endif()
 
 install(TARGETS mythexternrecorder RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/mythtv/programs/mythexternrecorder/mythexternrecorder.pro
+++ b/mythtv/programs/mythexternrecorder/mythexternrecorder.pro
@@ -3,7 +3,6 @@ include (../../version.pro)
 include ( ../programs-libs.pro )
 
 QT += network xml sql core
-using_qtscript: QT += script
 
 TEMPLATE = app
 CONFIG += thread

--- a/mythtv/programs/mythfilerecorder/CMakeLists.txt
+++ b/mythtv/programs/mythfilerecorder/CMakeLists.txt
@@ -6,8 +6,5 @@ add_executable(
 target_include_directories(mythfilerecorder PRIVATE .)
 
 target_link_libraries(mythfilerecorder PUBLIC myth mythbase mythtv)
-if(TARGET Qt${QT_VERSION_MAJOR}::Script)
-  target_link_libraries(mythfilerecorder PUBLIC Qt${QT_VERSION_MAJOR}::Script)
-endif()
 
 install(TARGETS mythfilerecorder RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/mythtv/programs/mythfilerecorder/mythfilerecorder.pro
+++ b/mythtv/programs/mythfilerecorder/mythfilerecorder.pro
@@ -3,7 +3,6 @@ include (../../version.pro)
 include ( ../programs-libs.pro )
 
 QT += network xml sql widgets
-using_qtscript: QT += script
 
 TEMPLATE = app
 CONFIG += thread


### PR DESCRIPTION
mythbackend.pro still needs using_qtscript: QT += script due to transitive includes from libmythupnp/htmlserver.h

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

