### PR TITLE
GitHub: macOS Fix broken azure-cli python3.12 link

### DIFF
--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -355,6 +355,7 @@ jobs:
           brew unlink python3
           brew deps python3 | xargs brew remove --ignore-dependencies
           brew list | grep python@|xargs brew remove --force --ignore-dependencies
+          brew remove azure-cli
           echo "re-install requested python"
           brew update
           brew install --force --overwrite python3


### PR DESCRIPTION
  On macOS Ventura, the azure-cli homebrew formula has not correctly
  been updated to use python3.13 causing a brew link error when
  updating the underlying homebrew formula.  Since its not needed
  remove the azure-cli package.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ ] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

