### PR TITLE
Prevent deadlock in MThreadPool

### DIFF
--- a/mythtv/libs/libmythbase/mthreadpool.cpp
+++ b/mythtv/libs/libmythbase/mthreadpool.cpp
@@ -123,7 +123,9 @@ class MPoolThread : public MThread
                 loggingRegisterThread(m_runnableName);
 
             bool autodelete = m_runnable->autoDelete();
+            locker.unlock();
             m_runnable->run();
+            locker.relock();
             if (autodelete)
                 delete m_runnable;
             if (m_reserved)

--- a/mythtv/libs/libmythbase/mthreadpool.cpp
+++ b/mythtv/libs/libmythbase/mthreadpool.cpp
@@ -127,7 +127,11 @@ class MPoolThread : public MThread
             if (autodelete)
                 delete m_runnable;
             if (m_reserved)
+            {
+                locker.unlock();
                 m_pool.ReleaseThread();
+                locker.relock();
+            }
             m_reserved = false;
             m_runnable = nullptr;
 

--- a/mythtv/libs/libmythbase/mthreadpool.cpp
+++ b/mythtv/libs/libmythbase/mthreadpool.cpp
@@ -112,8 +112,6 @@ class MPoolThread : public MThread
     {
         RunProlog();
 
-        MythTimer t;
-        t.start();
         QMutexLocker locker(&m_lock);
         if (m_doRun && m_runnable == nullptr)
         {
@@ -139,8 +137,6 @@ class MPoolThread : public MThread
             GetMythDB()->GetDBManager()->PurgeIdleConnections(false);
             qApp->processEvents();
             qApp->sendPostedEvents(nullptr, QEvent::DeferredDelete);
-
-            t.start();
 
             if (m_doRun)
             {

--- a/mythtv/libs/libmythupnp/httpserver.cpp
+++ b/mythtv/libs/libmythupnp/httpserver.cpp
@@ -17,6 +17,7 @@
 
 // ANSI C headers
 #include <cmath>
+#include <thread>
 
 // POSIX headers
 #ifndef _WIN32
@@ -38,6 +39,7 @@
 #include "libmythbase/mythcorecontext.h"
 #include "libmythbase/mythdirs.h"
 #include "libmythbase/mythlogging.h"
+#include "libmythbase/mythtimer.h"
 #include "libmythbase/mythversion.h"
 
 #include "upnputil.h"
@@ -473,11 +475,12 @@ void HttpWorker::run(void)
     LOG(VB_HTTP, LOG_DEBUG,
         QString("HttpWorker::run() socket=%1 -- begin").arg(m_socket));
 
-    bool                    bTimeout   = false;
     bool                    bKeepAlive = true;
     HTTPRequest            *pRequest   = nullptr;
     QTcpSocket             *pSocket    = nullptr;
     bool                    bEncrypted = false;
+    MythTimer attempt_time;
+    static constexpr std::chrono::milliseconds k_poll_interval {1ms};
 
     if (m_connectionType == kSSLServer)
     {
@@ -489,7 +492,12 @@ void HttpWorker::run(void)
         {
             pSslSocket->setSslConfiguration(m_sslConfig);
             pSslSocket->startServerEncryption();
-            if (pSslSocket->waitForEncrypted(5000))
+            attempt_time.start();
+            while (m_httpServer.IsRunning() && attempt_time.elapsed() < 5s && !pSslSocket->isEncrypted())
+            {
+                pSslSocket->waitForEncrypted(k_poll_interval.count());
+            }
+            if (pSslSocket->isEncrypted())
             {
                 LOG(VB_HTTP, LOG_INFO, "SSL Handshake occurred, connection encrypted");
                 LOG(VB_HTTP, LOG_INFO, QString("Using %1 cipher").arg(pSslSocket->sessionCipher().name()));
@@ -541,16 +549,19 @@ void HttpWorker::run(void)
             // new clients from connecting - Default at time of writing was
             // 5 seconds for initial connection, then up to 10 seconds of idle
             // time between each subsequent request on the same connection
-            bTimeout = !(pSocket->waitForReadyRead(m_socketTimeout.count()));
+            attempt_time.start();
+            while (m_httpServer.IsRunning() && pSocket->isValid()
+                   && pSocket->state() == QAbstractSocket::ConnectedState
+                   && pSocket->bytesAvailable() <= 0
+                   && attempt_time.elapsed() < m_socketTimeout
+                   )
+            {
+                pSocket->waitForReadyRead(k_poll_interval.count());
+            }
 
-            if (bTimeout) // Either client closed the socket or we timed out waiting for new data
+            if (!m_httpServer.IsRunning() || pSocket->bytesAvailable() <= 0)
                 break;
 
-            int64_t nBytes = pSocket->bytesAvailable();
-            if (!m_httpServer.IsRunning())
-                break;
-
-            if ( nBytes > 0)
             {
                 // ----------------------------------------------------------
                 // See if this is a valid request
@@ -618,10 +629,6 @@ void HttpWorker::run(void)
                     bKeepAlive = false;
                 }
             }
-            else
-            {
-                bKeepAlive = false;
-            }
         }
     }
     catch(...)
@@ -643,17 +650,21 @@ void HttpWorker::run(void)
 
     std::chrono::milliseconds writeTimeout = 5s;
     // Make sure any data in the buffer is flushed before the socket is closed
+    if (pSocket->bytesToWrite() > 0)
+    {
+        LOG(VB_HTTP, LOG_DEBUG,
+            QString("HttpWorker(%1): Waiting for %2 bytes to be written before closing the connection.")
+                .arg(m_socket).arg(pSocket->bytesToWrite())
+            );
+    }
+    attempt_time.start();
     while (m_httpServer.IsRunning() &&
            pSocket->isValid() &&
            pSocket->state() == QAbstractSocket::ConnectedState &&
-           pSocket->bytesToWrite() > 0)
+           pSocket->bytesToWrite() > 0 &&
+           attempt_time.elapsed() < writeTimeout
+           )
     {
-        LOG(VB_HTTP, LOG_DEBUG, QString("HttpWorker(%1): "
-                                        "Waiting for %2 bytes to be written "
-                                        "before closing the connection.")
-                                            .arg(m_socket)
-                                            .arg(pSocket->bytesToWrite()));
-
         // If the client stops reading for longer than 'writeTimeout' then
         // stop waiting for them. We can't afford to leave the socket
         // connected indefinately, it could be used by another client.
@@ -662,15 +673,7 @@ void HttpWorker::run(void)
         // streaming. We should create a new server extension or adjust the
         // timeout according to the User-Agent, instead of increasing the
         // standard timeout. However we should ALWAYS have a timeout.
-        if (!pSocket->waitForBytesWritten(writeTimeout.count()))
-        {
-            LOG(VB_GENERAL, LOG_WARNING, QString("HttpWorker(%1): "
-                                         "Timed out waiting to write bytes to "
-                                         "the socket, waited %2 seconds")
-                                            .arg(m_socket)
-                                            .arg(writeTimeout.count() / 1000));
-            break;
-        }
+        pSocket->waitForBytesWritten(k_poll_interval.count());
     }
 
     if (pSocket->bytesToWrite() > 0)

--- a/mythtv/libs/libmythupnp/httpserver.cpp
+++ b/mythtv/libs/libmythupnp/httpserver.cpp
@@ -470,10 +470,8 @@ HttpWorker::HttpWorker(HttpServer &httpServer, qintptr sock,
 
 void HttpWorker::run(void)
 {
-#if 0
     LOG(VB_HTTP, LOG_DEBUG,
         QString("HttpWorker::run() socket=%1 -- begin").arg(m_socket));
-#endif
 
     bool                    bTimeout   = false;
     bool                    bKeepAlive = true;
@@ -694,9 +692,7 @@ void HttpWorker::run(void)
     delete pSocket;
     pSocket = nullptr;
 
-#if 0
-    LOG(VB_HTTP, LOG_DEBUG, "HttpWorkerThread::run() -- end");
-#endif
+    LOG(VB_HTTP, LOG_DEBUG, QString("HttpWorker::run() socket=%1 -- end").arg(m_socket));
 }
 
 


### PR DESCRIPTION
@bennettpeter This resolves the shutdown issue mentioned in https://github.com/MythTV/mythtv/pull/1044

The deadlock can be triggered in mythfrontend by using http://localhost:6551/MythFE/GetRemote and then exiting within 10 seconds.

For a version with additional logging I used to diagnose this, see https://github.com/ulmus-scott/mythtv/tree/upnp_shutdown_log

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

