### PR TITLE
MythContext::Impl::FindDatabase(): read the database parameters after they have been changed

### DIFF
--- a/mythtv/libs/libmythbase/mythtranslation.h
+++ b/mythtv/libs/libmythbase/mythtranslation.h
@@ -30,6 +30,8 @@ class MBASE_PUBLIC MythTranslation
     static bool LanguageChanged(void);
 
   protected:
+    static void load_real(const QString &module_name);
+
     static class MythTranslationPrivate d;
 };
 

--- a/mythtv/libs/libmythui/langsettings.cpp
+++ b/mythtv/libs/libmythui/langsettings.cpp
@@ -212,7 +212,7 @@ void LanguageSelection::Save(void)
     }
 
     QString langCode = item->GetData().toString();
-    gCoreContext->SaveSettingOnHost("Language", langCode, nullptr);
+    gCoreContext->SaveSetting("Language", langCode);
 
     item = m_countryList->GetItemCurrent();
 
@@ -225,7 +225,7 @@ void LanguageSelection::Save(void)
     }
 
     QString countryCode = item->GetData().toString();
-    gCoreContext->SaveSettingOnHost("Country", countryCode, nullptr);
+    gCoreContext->SaveSetting("Country", countryCode);
 
     if (m_language != langCode)
         m_languageChanged = true;


### PR DESCRIPTION
This fixes bugs from e10ba67e29e5df144dfb5eb0a383c4460bff9c5a where the parameters read from config.xml (or the defaults if it doesn't exist) are always saved back to config.xml.

goto NoDBfound skipped over the initialization of the moved dbParams, so was copied to its two uses.

My testing showed `mythbackend` and `mythtv-setup` could create config.xml.  I do not have a setup for a remote frontend, so I could not get `mythfrontend` to create config.xml.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

