### PR TITLE
Remove unncessary caption template that creates div on web app recordings page.

### DIFF
--- a/mythtv/html/backend/src/app/dashboard/recordings/recordings.component.html
+++ b/mythtv/html/backend/src/app/dashboard/recordings/recordings.component.html
@@ -46,8 +46,6 @@
             dataKey="Recording.RecordedId" (onRowSelect)="onSelectChange()" (onRowUnselect)="onSelectChange()"
             sortField="Title" [virtualScroll]="true" scrollHeight="flex" [scrollable]="true" (onSort)="refresh()">
 
-            <ng-template pTemplate="caption">
-            </ng-template>
             <ng-template pTemplate="header">
                 <tr>
                     <!-- Column Headings. -->


### PR DESCRIPTION
- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

In making some changes to the web app I noticed a div that was creating an unnecessary visual artifact on the recordings page. See image where I've highlighted it with a red mark. I can't see a reason for this template, so I'm suggesting it is removed.

Of course, the web app will need a rebuild after applying this pull request.

<img width="603" alt="Screenshot 2025-05-11 at 13 23 22" src="https://github.com/user-attachments/assets/337d99c2-f3ae-4dc1-9dc5-780049e612f1" />

