### PR TITLE
configure: no ant & java required if use system libbluray

### DIFF
--- a/mythtv/configure
+++ b/mythtv/configure
@@ -5223,7 +5223,7 @@ fi
 
 antbin=""
 java_code_version=""
-if enabled bdjava; then
+if enabled bdjava && ! enabled system_libbluray; then
     enabled x86_64 && java_arch=amd64
     enabled x86_32 && java_arch=i386
     enabled arm    && java_arch=arm


### PR DESCRIPTION
 * mythtv/external/libmythbluray/ won't be built
  * java is required at runtime only

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

