### PR TITLE
Python: Respect `fold` attribute provided by `datetime.tzinfo`

### DIFF
--- a/mythtv/bindings/python/MythTV/utility/dt.py
+++ b/mythtv/bindings/python/MythTV/utility/dt.py
@@ -343,11 +343,12 @@ class datetime( _pydatetime ):
         return cls._utctz
 
     @classmethod
-    def fromDatetime(cls, dt, tzinfo=None):
+    def fromDatetime(cls, dt, tzinfo=None, fold=None):
         if tzinfo is None:
             tzinfo = dt.tzinfo
+            fold = dt.fold
         return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute,
-                   dt.second, dt.microsecond, tzinfo)
+                   dt.second, dt.microsecond, tzinfo, fold)
 
 # override existing classmethods to enforce use of timezone
     @classmethod
@@ -506,7 +507,7 @@ class datetime( _pydatetime ):
         raise TypeError("time data '%s' does not match supported formats"%t)
 
     def __new__(cls, year, month, day, hour=None, minute=None, second=None,
-                      microsecond=None, tzinfo=None):
+                      microsecond=None, tzinfo=None, fold=None):
 
         if tzinfo is None:
             kwargs = {'tzinfo':cls.localTZ()}
@@ -520,6 +521,8 @@ class datetime( _pydatetime ):
             kwargs['second'] = second
         if microsecond is not None:
             kwargs['microsecond'] = microsecond
+        if fold is not None:
+            kwargs['fold'] = fold
         return _pydatetime.__new__(cls, year, month, day, **kwargs)
 
     def mythformat(self):


### PR DESCRIPTION
Python3.13 takes the `fold` attribute into account when crating various `MythTV.datetime` objects. This attribute is used to disambiguate `datetime` objects during transition from daylight saving time to standard time, where the local time stamp occurs twice.

Found in the changelog of python 3.13:
gh-89039: When replace() method is called on a subclass of datetime, date or time, properly call derived constructor. Previously, only the base class’s constructor was called.
Also, make sure to pass non-zero fold values when creating subclasses in various methods. Previously, fold was silently ignored.

Refs: MythTV.#1083


- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

