### PR TITLE
DBus screensaver always report being awake

### DIFF
--- a/mythtv/libs/libmythui/platforms/mythscreensaverdbus.cpp
+++ b/mythtv/libs/libmythui/platforms/mythscreensaverdbus.cpp
@@ -83,7 +83,6 @@ class ScreenSaverDBusPrivate
                 QList<QVariant> replylist = msg.arguments();
                 const QVariant& reply = replylist.first();
                 m_cookie = reply.toUInt();
-                m_inhibited = true;
                 LOG(VB_GENERAL, LOG_INFO, LOC +
                     QString("Successfully inhibited screensaver via %1. cookie %2. nom nom")
                     .arg(m_serviceUsed).arg(m_cookie));
@@ -112,7 +111,6 @@ class ScreenSaverDBusPrivate
             if (m_cookie != 0) {
                 m_interface->call(QDBus::NoBlock, m_unInhibit , m_cookie);
                 m_cookie = 0;
-                m_inhibited = false;
                 LOG(VB_GENERAL, LOG_INFO, LOC + QString("Screensaver uninhibited via %1")
                     .arg(m_serviceUsed));
             }
@@ -122,7 +120,6 @@ class ScreenSaverDBusPrivate
     bool isValid() const { return m_interface ? m_interface->isValid() : false; };
 
   protected:
-    bool            m_inhibited  {false};
     uint32_t        m_cookie     {0};
     QDBusConnection *m_bus       {nullptr};
     QDBusInterface  *m_interface {nullptr};
@@ -189,6 +186,5 @@ void MythScreenSaverDBus::Reset()
 
 bool MythScreenSaverDBus::Asleep()
 {
-    return std::any_of(m_dbusPrivateInterfaces.cbegin(), m_dbusPrivateInterfaces.cend(),
-                       [](auto * interface){ return interface->m_inhibited; } );
+    return false;
 }


### PR DESCRIPTION
Always return false for the Asleep function of the DBus screensaver.
Remove the inhibite state bookkeeping because that is not used anymore.
The Asleep function is only relevant for the X11 screensaver.
The value of this function is used in mythinputdevicehandler.cpp to discard input events when the screen is powered off. This is only useful with the X11 screensaver; the DBus screensaver has the state "inhibited" and "not inhibited" but it does not say anything about the screen actually being saved or not.

Fixes #1064
