### PR TITLE
Close file leak in PulseAudio output handler

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutputpulse.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputpulse.cpp
@@ -76,6 +76,8 @@ AudioOutputSettings* AudioOutputPulseAudio::GetOutputSettings(bool /*digital*/)
     {
         pa_threaded_mainloop_unlock(m_mainloop);
         pa_threaded_mainloop_stop(m_mainloop);
+        pa_threaded_mainloop_free(m_mainloop);
+        m_mainloop = nullptr;
         delete m_aoSettings;
         return nullptr;
     }
@@ -118,6 +120,7 @@ AudioOutputSettings* AudioOutputPulseAudio::GetOutputSettings(bool /*digital*/)
     pa_context_unref(m_pcontext);
     m_pcontext = nullptr;
     pa_threaded_mainloop_stop(m_mainloop);
+    pa_threaded_mainloop_free(m_mainloop);
     m_mainloop = nullptr;
 
     return m_aoSettings;
@@ -180,6 +183,8 @@ bool AudioOutputPulseAudio::OpenDevice()
     {
         pa_threaded_mainloop_unlock(m_mainloop);
         pa_threaded_mainloop_stop(m_mainloop);
+        pa_threaded_mainloop_free(m_mainloop);
+        m_mainloop = nullptr;
         return false;
     }
 
@@ -187,6 +192,8 @@ bool AudioOutputPulseAudio::OpenDevice()
     {
         pa_threaded_mainloop_unlock(m_mainloop);
         pa_threaded_mainloop_stop(m_mainloop);
+        pa_threaded_mainloop_free(m_mainloop);
+        m_mainloop = nullptr;
         return false;
     }
 
@@ -219,6 +226,7 @@ void AudioOutputPulseAudio::CloseDevice()
     {
         pa_threaded_mainloop_unlock(m_mainloop);
         pa_threaded_mainloop_stop(m_mainloop);
+        pa_threaded_mainloop_free(m_mainloop);
         m_mainloop = nullptr;
     }
 }


### PR DESCRIPTION
According to the PulseAudio Destruction documentation,

"When the PulseAudio connection has been terminated, the thread must be stopped and the resources freed. Stopping the thread is done using
pa_threaded_mainloop_stop(), which must be called
without the lock (see below) held. When that
function returns, the thread is stopped and
the pa_threaded_mainloop object can be freed using pa_threaded_mainloop_free()."

The code in audiooutputpulse.cpp called
pa_threaded_mainloop_stop(), but never called
pa_threaded_mainloop_free(). That missing call is
what frees up allocated resources like FIFO files.

The missing calls to pa_threaded_mainloop_free() have been added in this modification.

Resolves: #1095

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ ] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [ ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

