### PR TITLE
The translation of "Don't Record" should be "Don't Record".

### DIFF
--- a/mythtv/html/assets/i18n/en_CA.json
+++ b/mythtv/html/assets/i18n/en_CA.json
@@ -444,7 +444,7 @@
             "Conflict": "Conflict",
             "CurrentRecording": "Current Recording",
             "Default": "Default",
-            "DontRecord": "Dont Record",
+            "DontRecord": "Don't Record",
             "EarlierShowing": "Earlier Showing",
             "Failed": "Failed",
             "Failing": "Failing",

--- a/mythtv/html/assets/i18n/en_GB.json
+++ b/mythtv/html/assets/i18n/en_GB.json
@@ -444,7 +444,7 @@
             "Conflict": "Conflict",
             "CurrentRecording": "Current Recording",
             "Default": "Default",
-            "DontRecord": "Dont Record",
+            "DontRecord": "Don't Record",
             "EarlierShowing": "Earlier Showing",
             "Failed": "Failed",
             "Failing": "Failing",

--- a/mythtv/html/assets/i18n/en_US.json
+++ b/mythtv/html/assets/i18n/en_US.json
@@ -444,7 +444,7 @@
             "Conflict": "Conflict",
             "CurrentRecording": "Current Recording",
             "Default": "Default",
-            "DontRecord": "Dont Record",
+            "DontRecord": "Don't Record",
             "EarlierShowing": "Earlier Showing",
             "Failed": "Failed",
             "Failing": "Failing",


### PR DESCRIPTION
I noticed that one of the English translations is incorrect for Don't Record.
It is missing an apostrophe.

- [X] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [X] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [X] code compiles successfully without errors
- [X] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [X] documentation added/updated/removed where necessary
- [X] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

