### PR TITLE
have CTest print test output on failure

### DIFF
--- a/mythtv/CMakeLists.txt
+++ b/mythtv/CMakeLists.txt
@@ -87,6 +87,7 @@ endif()
 #
 include(CMakePushCheckState)
 include(CTest)
+list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 include(CheckTypeSize)
 include(GNUInstallDirs)
 

--- a/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.cpp
+++ b/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.cpp
@@ -9,10 +9,6 @@ extern "C" {
 #include "libmythbase/mythrandom.h"
 #include "libmythtv/mythframe.h"
 
-void TestCopyFrames::initTestCase(void)
-{
-}
-
 void TestCopyFrames::TestInvalidFrames()
 {
     MythVideoFrame dummy;

--- a/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.h
+++ b/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.h
@@ -25,7 +25,6 @@ class TestCopyFrames : public QObject
     Q_OBJECT
 
   private slots:
-    void initTestCase();
     static void TestInvalidFrames();
     static void TestInvalidFormats();
     static void TestInvalidSizes();


### PR DESCRIPTION
This should show exactly what failed in the GitHub Actions for builds using CMake.
