### PR TITLE
Close memory leak in GetDisplayID

### DIFF
--- a/mythtv/libs/libmythui/platforms/mythnvcontrol.cpp
+++ b/mythtv/libs/libmythui/platforms/mythnvcontrol.cpp
@@ -217,5 +217,7 @@ int MythNVControl::GetDisplayID() const
             .arg((size - 4) / 4));
     }
 
-    return static_cast<int>(data[1]);
+    int dispId = static_cast<int>(data[1]);
+    free(data);
+    return dispId;
 }


### PR DESCRIPTION
According to the Nvidia header file, when invoking XNVCTRLQueryTargetBinaryData(), it is the caller's responsibility to free the data when done.

This modification adds the step of freeing the
memory allocated for 'data'.

Resolves: #1102

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

