### PR TITLE
Close memory leak in loglevelAdd()

### DIFF
--- a/mythtv/libs/libmythbase/logging.cpp
+++ b/mythtv/libs/libmythbase/logging.cpp
@@ -688,6 +688,10 @@ void logStop(void)
     {
         logThread->stop();
         logThread->wait();
+        qDeleteAll(verboseMap);  // delete VerboseDef memory in map values
+        verboseMap.clear();
+        qDeleteAll(loglevelMap); // delete LoglevelDef memory in map values
+        loglevelMap.clear();
         delete logThread;
         logThread = nullptr;
     }
@@ -843,7 +847,9 @@ void verboseInit(void)
 {
     QMutexLocker locker(&verboseMapMutex);
     QMutexLocker locker2(&loglevelMapMutex);
+    qDeleteAll(verboseMap);  // delete VerboseDef memory in map values
     verboseMap.clear();
+    qDeleteAll(loglevelMap); // delete LoglevelDef memory in map values
     loglevelMap.clear();
 
     // This looks funky, so I'll put some explanation here.  The verbosedefs.h


### PR DESCRIPTION
The verboseMap and loglevelMap entities are of type QMap. When the values inserted into a QMap are from allocated memory, the recommended way to clean up, is to invoke
```
  qDeleteAll( map ); // delete all values in map
  map.clear(); // remove map references to values
```
In verboseAdd(), new VerboseDef is invoked.
In loglevelAdd(), new LoglevelDef is invoked.

To properly clean up without a memory leak, in logStop() and verboseInit() we need to call qDeleteAll() and clear().

Resolves #1104

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

