### PR TITLE
Close memory leak in MythDisplayX11::GetEDID

### DIFF
--- a/mythtv/libs/libmythui/platforms/mythdisplayx11.cpp
+++ b/mythtv/libs/libmythui/platforms/mythdisplayx11.cpp
@@ -319,6 +319,10 @@ void MythDisplayX11::GetEDID(MythXDisplay *mDisplay)
         {
             if (actualtype == XA_INTEGER && actualformat == 8)
                 m_edid = MythEDID(reinterpret_cast<const char*>(data), static_cast<int>(nitems));
+            if (data)
+            {
+                XFree(data);
+            }
         }
         break;
     }


### PR DESCRIPTION
A call to XRRGetOutputProperty() allocates memory and assigns it to the 'prop' argument. In mythdisplayx11.cpp, the 'data' variable is
passed in as the 'prop' argument, so we need to free the memory which gets assigned to 'data'.

Resolves #1105

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

