### PR TITLE
Close memory leak in getMythSortHelper

### DIFF
--- a/mythtv/libs/libmythbase/mythsorthelper.cpp
+++ b/mythtv/libs/libmythbase/mythsorthelper.cpp
@@ -130,8 +130,7 @@ static std::shared_ptr<MythSortHelper> singleton = nullptr;
 std::shared_ptr<MythSortHelper> getMythSortHelper(void)
 {
     if (singleton == nullptr)
-        // coverity[resource_leak]
-        singleton = std::make_shared<MythSortHelper>(new MythSortHelper());
+        singleton = std::make_shared<MythSortHelper>();
     return singleton;
 }
 


### PR DESCRIPTION
The usage of **std::make_shared<>** was improper. The whole point of this template is to automatically allocate memory and invoke the constructor. By eliminating an unnecessary 'new' call in this code, we remove the memory leak. In addition, we simplify the invocation by removing the unnecessary constructor call. **std::make_shared<>** only requires the constructor arguments. Proper template usage makes it safer, faster, and less leaky.

Resolves #1106

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

