### PR TITLE
Close memory leaks in PulseAudio output handler

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutputpulse.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputpulse.cpp
@@ -266,15 +266,18 @@ void AudioOutputPulseAudio::CloseDevice()
 
     if (m_pcontext)
     {
-        pa_operation *op = pa_context_drain(m_pcontext, ContextDrainCallback, m_mainloop);
-        if (op)
+        if (m_mainloop)
         {
-            // Wait for the asynchronous draining to complete
-            while (pa_operation_get_state(op) == PA_OPERATION_RUNNING)
+            pa_operation *op = pa_context_drain(m_pcontext, ContextDrainCallback, m_mainloop);
+            if (op)
             {
-                pa_threaded_mainloop_wait(m_mainloop);
+                // Wait for the asynchronous draining to complete
+                while (pa_operation_get_state(op) == PA_OPERATION_RUNNING)
+                {
+                    pa_threaded_mainloop_wait(m_mainloop);
+                }
+                pa_operation_unref(op);
             }
-            pa_operation_unref(op);
         }
         pa_context_disconnect(m_pcontext);
         pa_context_unref(m_pcontext);

--- a/mythtv/libs/libmyth/audio/audiooutputpulse.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputpulse.cpp
@@ -52,6 +52,16 @@ AudioOutputPulseAudio::~AudioOutputPulseAudio()
         pa_context_unref(m_pcontext);
         m_pcontext = nullptr;
     }
+    if (m_ctproplist)
+    {
+        pa_proplist_free(m_ctproplist);
+        m_ctproplist = nullptr;
+    }
+    if (m_stproplist)
+    {
+        pa_proplist_free(m_stproplist);
+        m_stproplist = nullptr;
+    }
 }
 
 AudioOutputSettings* AudioOutputPulseAudio::GetOutputSettings(bool /*digital*/)
@@ -78,6 +88,16 @@ AudioOutputSettings* AudioOutputPulseAudio::GetOutputSettings(bool /*digital*/)
         pa_threaded_mainloop_stop(m_mainloop);
         pa_threaded_mainloop_free(m_mainloop);
         m_mainloop = nullptr;
+        if (m_ctproplist)
+        {
+            pa_proplist_free(m_ctproplist);
+            m_ctproplist = nullptr;
+        }
+        if (m_stproplist)
+        {
+            pa_proplist_free(m_stproplist);
+            m_stproplist = nullptr;
+        }
         delete m_aoSettings;
         return nullptr;
     }
@@ -122,6 +142,16 @@ AudioOutputSettings* AudioOutputPulseAudio::GetOutputSettings(bool /*digital*/)
     pa_threaded_mainloop_stop(m_mainloop);
     pa_threaded_mainloop_free(m_mainloop);
     m_mainloop = nullptr;
+    if (m_ctproplist)
+    {
+        pa_proplist_free(m_ctproplist);
+        m_ctproplist = nullptr;
+    }
+    if (m_stproplist)
+    {
+        pa_proplist_free(m_stproplist);
+        m_stproplist = nullptr;
+    }
 
     return m_aoSettings;
 }
@@ -185,6 +215,16 @@ bool AudioOutputPulseAudio::OpenDevice()
         pa_threaded_mainloop_stop(m_mainloop);
         pa_threaded_mainloop_free(m_mainloop);
         m_mainloop = nullptr;
+        if (m_ctproplist)
+        {
+            pa_proplist_free(m_ctproplist);
+            m_ctproplist = nullptr;
+        }
+        if (m_stproplist)
+        {
+            pa_proplist_free(m_stproplist);
+            m_stproplist = nullptr;
+        }
         return false;
     }
 
@@ -194,6 +234,16 @@ bool AudioOutputPulseAudio::OpenDevice()
         pa_threaded_mainloop_stop(m_mainloop);
         pa_threaded_mainloop_free(m_mainloop);
         m_mainloop = nullptr;
+        if (m_ctproplist)
+        {
+            pa_proplist_free(m_ctproplist);
+            m_ctproplist = nullptr;
+        }
+        if (m_stproplist)
+        {
+            pa_proplist_free(m_stproplist);
+            m_stproplist = nullptr;
+        }
         return false;
     }
 
@@ -216,9 +266,16 @@ void AudioOutputPulseAudio::CloseDevice()
 
     if (m_pcontext)
     {
-        pa_context_drain(m_pcontext, nullptr, nullptr);
-        pa_context_disconnect(m_pcontext);
-        pa_context_unref(m_pcontext);
+        pa_operation *op;
+        if ((op = pa_context_drain(m_pcontext, ContextDrainCallback, nullptr)))
+        {
+            pa_operation_unref(op);
+        }
+        else
+        {
+            pa_context_disconnect(m_pcontext);
+            pa_context_unref(m_pcontext);
+        }
         m_pcontext = nullptr;
     }
 
@@ -228,6 +285,17 @@ void AudioOutputPulseAudio::CloseDevice()
         pa_threaded_mainloop_stop(m_mainloop);
         pa_threaded_mainloop_free(m_mainloop);
         m_mainloop = nullptr;
+    }
+
+    if (m_ctproplist)
+    {
+        pa_proplist_free(m_ctproplist);
+        m_ctproplist = nullptr;
+    }
+    if (m_stproplist)
+    {
+        pa_proplist_free(m_stproplist);
+        m_stproplist = nullptr;
     }
 }
 
@@ -415,21 +483,23 @@ bool AudioOutputPulseAudio::ContextConnect(void)
         m_pcontext = nullptr;
         return false;
     }
-    pa_proplist *proplist = pa_proplist_new();
-    if (!proplist)
+    m_ctproplist = pa_proplist_new();
+    if (!m_ctproplist)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + fn_log_tag + QString("failed to create new proplist"));
         return false;
     }
-    pa_proplist_sets(proplist, PA_PROP_APPLICATION_NAME, "MythTV");
-    pa_proplist_sets(proplist, PA_PROP_APPLICATION_ICON_NAME, "mythtv");
-    pa_proplist_sets(proplist, PA_PROP_MEDIA_ROLE, "video");
+    pa_proplist_sets(m_ctproplist, PA_PROP_APPLICATION_NAME, "MythTV");
+    pa_proplist_sets(m_ctproplist, PA_PROP_APPLICATION_ICON_NAME, "mythtv");
+    pa_proplist_sets(m_ctproplist, PA_PROP_MEDIA_ROLE, "video");
     m_pcontext =
         pa_context_new_with_proplist(pa_threaded_mainloop_get_api(m_mainloop),
-                                     "MythTV", proplist);
+                                     "MythTV", m_ctproplist);
     if (!m_pcontext)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + fn_log_tag + "failed to acquire new context");
+        pa_proplist_free(m_ctproplist);
+        m_ctproplist = nullptr;
         return false;
     }
     pa_context_set_state_callback(m_pcontext, ContextStateCallback, this);
@@ -443,6 +513,8 @@ bool AudioOutputPulseAudio::ContextConnect(void)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + fn_log_tag + QString("context connect failed: %1")
                              .arg(pa_strerror(pa_context_errno(m_pcontext))));
+        pa_proplist_free(m_ctproplist);
+        m_ctproplist = nullptr;
         return false;
     }
     bool connected = false;
@@ -461,6 +533,8 @@ bool AudioOutputPulseAudio::ContextConnect(void)
                 LOG(VB_GENERAL, LOG_ERR, LOC + fn_log_tag +
                         QString("context connection failed or terminated: %1")
                         .arg(pa_strerror(pa_context_errno(m_pcontext))));
+                pa_proplist_free(m_ctproplist);
+                m_ctproplist = nullptr;
                 return false;
 
             default:
@@ -507,19 +581,21 @@ QString AudioOutputPulseAudio::ChooseHost(void)
 bool AudioOutputPulseAudio::ConnectPlaybackStream(void)
 {
     QString fn_log_tag = "ConnectPlaybackStream, ";
-    pa_proplist *proplist = pa_proplist_new();
-    if (!proplist)
+    m_stproplist = pa_proplist_new();
+    if (!m_stproplist)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + fn_log_tag + QString("failed to create new proplist"));
         return false;
     }
-    pa_proplist_sets(proplist, PA_PROP_MEDIA_ROLE, "video");
+    pa_proplist_sets(m_stproplist, PA_PROP_MEDIA_ROLE, "video");
     m_pstream =
         pa_stream_new_with_proplist(m_pcontext, "MythTV playback", &m_sampleSpec,
-                                    &m_channelMap, proplist);
+                                    &m_channelMap, m_stproplist);
     if (!m_pstream)
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + "failed to create new playback stream");
+        pa_proplist_free(m_stproplist);
+        m_stproplist = nullptr;
         return false;
     }
     pa_stream_set_state_callback(m_pstream, StreamStateCallback, this);
@@ -567,6 +643,8 @@ bool AudioOutputPulseAudio::ConnectPlaybackStream(void)
             case PA_CONTEXT_TERMINATED:
                 LOG(VB_GENERAL, LOG_ERR, LOC + QString("context is stuffed, %1")
                             .arg(pa_strerror(pa_context_errno(m_pcontext))));
+                pa_proplist_free(m_stproplist);
+                m_stproplist = nullptr;
                 failed = true;
                 break;
             default:
@@ -580,6 +658,8 @@ bool AudioOutputPulseAudio::ConnectPlaybackStream(void)
                         LOG(VB_GENERAL, LOG_ERR, LOC + QString("stream failed or was terminated, "
                                         "context state %1, stream state %2")
                                     .arg(cstate).arg(sstate));
+                        pa_proplist_free(m_stproplist);
+                        m_stproplist = nullptr;
                         failed = true;
                         break;
                     default:
@@ -609,6 +689,12 @@ void AudioOutputPulseAudio::FlushStream(const char *caller)
         pa_operation_unref(op);
     else
         LOG(VB_GENERAL, LOG_ERR, LOC + fn_log_tag + "stream flush operation failed ");
+}
+
+void AudioOutputPulseAudio::ContextDrainCallback(pa_context *c, void */*arg*/)
+{
+    pa_context_disconnect(c);
+    pa_context_unref(c);
 }
 
 void AudioOutputPulseAudio::ContextStateCallback(pa_context *c, void *arg)

--- a/mythtv/libs/libmyth/audio/audiooutputpulse.h
+++ b/mythtv/libs/libmyth/audio/audiooutputpulse.h
@@ -48,6 +48,7 @@ class AudioOutputPulseAudio : public AudioOutputBase
     bool ConnectPlaybackStream(void);
     void FlushStream(const char *caller);
 
+    static void ContextDrainCallback(pa_context *c, void *arg);
     static void ContextStateCallback(pa_context *c, void *arg);
     static void StreamStateCallback(pa_stream *s, void *arg);
     static void OpCompletionCallback(pa_context *c, int ok, void *arg);
@@ -58,6 +59,8 @@ class AudioOutputPulseAudio : public AudioOutputBase
     static void SinkInfoCallback(pa_context *c, const pa_sink_info *info,
                                  int eol, void *arg);
 
+    pa_proplist            *m_ctproplist {nullptr};
+    pa_proplist            *m_stproplist {nullptr};
     pa_context             *m_pcontext   {nullptr};
     pa_stream              *m_pstream    {nullptr};
     pa_threaded_mainloop   *m_mainloop   {nullptr};


### PR DESCRIPTION
The original code allocated memory with calls to **pa_proplist_new()**, and stored those addresses in a local variable, _proplist_. The corresponding memory was never released. The same local variable was used in two different methods, **ContextConnect()** and **ConnectPlaybackStream()**.

We need to keep track of these memory pointers separately, so 2 new members have been added to the AudioOutputPulseAudio class:
```
        pa_proplist *m_ctproplist
        pa_proplist *m_stproplist
```
When memory is allocated for Context or Stream, the updated code stores the _pa_proplist *_ value in _m_ctproplist_ or _m_stproplist_. Later on, when it's time to release memory, these class members are used in calls to **pa_proplist_free()**.

A separate memory leak was identified in the call to **pa_context_drain()**. This routine allocates memory which it needs for an asynchronous callback.  The original code passed _nullptr_ as the callback function pointer, but this causes the leak. The code has been updated to add a callback function, **ContextDrainCallback()**. A loop has been added to wait for the callback to be invoked before destroying the reference to the **pa_context_drain()** operation.

After applying these modifications, all of the memory leaks associated with audiooutputpulse.cpp by '**valgrind**' have been eliminated.

Resolves #1100 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

