### PR TITLE
Fix New, Delete type mismatch

### DIFF
--- a/mythtv/libs/libmythui/opengl/mythrenderopengl.h
+++ b/mythtv/libs/libmythui/opengl/mythrenderopengl.h
@@ -57,7 +57,7 @@ class MUI_PUBLIC MythGLTexture
   public:
     explicit MythGLTexture(QOpenGLTexture *Texture);
     explicit MythGLTexture(GLuint Texture);
-   ~MythGLTexture() = default;
+    virtual ~MythGLTexture() = default;
 
     unsigned char  *m_data                    { nullptr };
     int             m_bufferSize              { 0 } ;


### PR DESCRIPTION
At the allocation point a **MythVideoTextureOpenGL** class was created. At the deletion point, a **MythGLTexture** was released. MythGLTexture is a base class for **MythVideoTextureOpenGL**.

If you intend to delete a derived class object through a base class pointer, the base class must have a virtual destructor. This ensures that the correct destructor for the derived class is called when the object is deleted.

This modification stipulates the destructor for **MythGLTexture** to be virtual. This ensures that the type upon deletion matches the type upon creation.

Resolves #1121

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

