### PR TITLE
Correct array deallocation with alignment

### DIFF
--- a/mythtv/libs/libmyth/audio/audiooutputbase.cpp
+++ b/mythtv/libs/libmyth/audio/audiooutputbase.cpp
@@ -1736,8 +1736,8 @@ void AudioOutputBase::OutputAudioLoop(void)
 
     }
 
-    delete[] zeros;
-    delete[] fragment;
+    ::operator delete[] (zeros, std::align_val_t(16));
+    ::operator delete[] (fragment, std::align_val_t(16));
     LOG(VB_AUDIO, LOG_INFO, LOC + "OutputAudioLoop: Stop Event");
     OutputEvent e(OutputEvent::kStopped);
     dispatch(e);

--- a/mythtv/programs/mythfrontend/audiogeneralsettings.cpp
+++ b/mythtv/programs/mythfrontend/audiogeneralsettings.cpp
@@ -767,7 +767,7 @@ void AudioTestThread::run()
         }
         m_audioOutput->Pause(true);
 
-        delete[] frames;
+        ::operator delete[] (frames, std::align_val_t(16));
     }
     RunEpilog();
 }


### PR DESCRIPTION
The deletion of 3 arrays, which were allocated with **std::align_val_t()** to specify a non-default alignment, have been updated to use the proper deletion alignment.

Resolves #1122

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

