### PR TITLE
Scheduler::UpdateManuals(): prevent scheduling recordings before the given start date

### DIFF
--- a/mythtv/programs/mythbackend/scheduler.cpp
+++ b/mythtv/programs/mythbackend/scheduler.cpp
@@ -3776,54 +3776,60 @@ void Scheduler::UpdateManuals(uint recordid)
     while (query.next())
         chanidlist.push_back(query.value(0).toUInt());
 
-    int progcount = 0;
-    int skipdays = 1;
-    bool weekday = false;
-    int daysoff = 0;
-    QDateTime lstartdt = startdt.toLocalTime();
+    std::vector<QDateTime> startList;
+    constexpr int weeksToSchedule = 2;
+    constexpr int daysInWeek = 7;
+    // use local date/time so the local time of the recording stays constant
+    // across daylight savings time changes and weekday/weekend detection works
+    // correctly
+    const QDate startDate = startdt.toLocalTime().date();
+    const QTime startTime = startdt.toLocalTime().time();
+    // don't schedule recordings before startDate
+    qint64 offset =
+        std::max(qint64{0}, startDate.daysTo(MythDate::current().toLocalTime().date()));
 
     switch (rectype)
     {
     case kSingleRecord:
     case kOverrideRecord:
     case kDontRecord:
-        progcount = 1;
-        skipdays = 1;
-        weekday = false;
-        daysoff = 0;
+        startList.push_back(startdt);
         break;
     case kDailyRecord:
-        progcount = 13;
-        skipdays = 1;
-        weekday = (lstartdt.date().dayOfWeek() < 6);
-        daysoff = lstartdt.date().daysTo(
-            MythDate::current().toLocalTime().date());
+        for (int i = 0; i < daysInWeek * weeksToSchedule; i++)
+        {
+            if (startDate.dayOfWeek() < 6 && startDate.addDays(offset + i).dayOfWeek() >= 6)
+            {
+                continue;
+            }
 #if QT_VERSION < QT_VERSION_CHECK(6,5,0)
-        startdt = QDateTime(lstartdt.date().addDays(daysoff),
-                            lstartdt.time(), Qt::LocalTime).toUTC();
+            startList.push_back(QDateTime(startDate.addDays(offset + i),
+                                          startTime, Qt::LocalTime).toUTC());
 #else
-        startdt = QDateTime(lstartdt.date().addDays(daysoff),
-                            lstartdt.time(),
-                            QTimeZone(QTimeZone::LocalTime)
-                            ).toUTC();
+            startList.push_back(QDateTime(startDate.addDays(offset + i),
+                                          startTime,
+                                          QTimeZone(QTimeZone::LocalTime)
+                                          ).toUTC()
+                                );
 #endif
+        }
         break;
     case kWeeklyRecord:
-        progcount = 2;
-        skipdays = 7;
-        weekday = false;
-        daysoff = lstartdt.date().daysTo(
-            MythDate::current().toLocalTime().date());
-        daysoff = (daysoff + 6) / 7 * 7;
+        // round offset up to a whole number of weeks
+        offset = (offset + daysInWeek - 1) / daysInWeek * daysInWeek;
+        for (int i = 0; i < daysInWeek * weeksToSchedule; i += daysInWeek)
+        {
 #if QT_VERSION < QT_VERSION_CHECK(6,5,0)
-        startdt = QDateTime(lstartdt.date().addDays(daysoff),
-                            lstartdt.time(), Qt::LocalTime).toUTC();
+            startList.push_back(QDateTime(startDate.addDays(offset + i),
+                                          startTime, Qt::LocalTime).toUTC());
 #else
-        startdt = QDateTime(lstartdt.date().addDays(daysoff),
-                            lstartdt.time(),
-                            QTimeZone(QTimeZone::LocalTime)
-                            ).toUTC();
+            startList.push_back(QDateTime(startDate.addDays(offset + i),
+                                          startTime,
+                                          QTimeZone(QTimeZone::LocalTime)
+                                          ).toUTC()
+                                );
 #endif
+        }
         break;
     default:
         LOG(VB_GENERAL, LOG_ERR,
@@ -3831,13 +3837,10 @@ void Scheduler::UpdateManuals(uint recordid)
         return;
     }
 
-    while (progcount--)
+    for (const QDateTime& start : startList)
     {
         for (uint id : chanidlist)
         {
-            if (weekday && startdt.toLocalTime().date().dayOfWeek() >= 6)
-                continue;
-
             query.prepare("REPLACE INTO program (chanid, starttime, endtime,"
                           " title, subtitle, description, manualid,"
                           " season, episode, inetref, originalairdate, generic) "
@@ -3845,8 +3848,8 @@ void Scheduler::UpdateManuals(uint recordid)
                           " :SUBTITLE, :DESCRIPTION, :RECORDID, "
                           " :SEASON, :EPISODE, :INETREF, :ORIGINALAIRDATE, 1)");
             query.bindValue(":CHANID", id);
-            query.bindValue(":STARTTIME", startdt);
-            query.bindValue(":ENDTIME", startdt.addSecs(duration));
+            query.bindValue(":STARTTIME", start);
+            query.bindValue(":ENDTIME", start.addSecs(duration));
             query.bindValue(":TITLE", title);
             query.bindValue(":SUBTITLE", subtitle);
             query.bindValue(":DESCRIPTION", description);
@@ -3861,17 +3864,6 @@ void Scheduler::UpdateManuals(uint recordid)
                 return;
             }
         }
-
-        daysoff += skipdays;
-#if QT_VERSION < QT_VERSION_CHECK(6,5,0)
-        startdt = QDateTime(lstartdt.date().addDays(daysoff),
-                            lstartdt.time(), Qt::LocalTime).toUTC();
-#else
-        startdt = QDateTime(lstartdt.date().addDays(daysoff),
-                            lstartdt.time(),
-                            QTimeZone(QTimeZone::LocalTime)
-                            ).toUTC();
-#endif
     }
 }
 


### PR DESCRIPTION
and rewrite the confusing code that calculated the start times.

I thought about adding something to prevent scheduling recordings in the past, but this function doesn’t have enough information to determine that.

`
if (MythDate::current().toLocalTime().time() > starttime) {
    offset++;
}
`
The above code would prevent scheduling recordings that should have already started.  However, the end time may still be in the future, so it should be scheduled in that case.  Unfortunately, the startdate, starttime, enddate, and endtime values do not account for starting/ending the recording early/late (8 hours in either direction from the start and end), so this cannot be determined from the information the function has.

Therefore, this function will continue to schedule recordings that may be entirely in the past.

---

This is a modified cherry-pick from https://github.com/MythTV/mythtv/pull/643 since it is independent of the main reason of that PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

