### PR TITLE
Close memory leak in SignalHandler

### DIFF
--- a/mythtv/libs/libmythbase/signalhandling.cpp
+++ b/mythtv/libs/libmythbase/signalhandling.cpp
@@ -122,6 +122,9 @@ SignalHandler::~SignalHandler()
     }
 
     m_sigMap.clear();
+
+    delete [] m_sigStack;
+    m_sigStack = nullptr;
 #endif
 }
 


### PR DESCRIPTION
This modification of the **SignalHandler** destructor adds the missing delete of memory allocated for the **m_sigStack** array.

Resolves #1112

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

