### PR TITLE
fix ANSI/CTA-708 DTV Closed Captions decoding

### DIFF
--- a/mythtv/libs/libmythtv/captions/cc708decoder.h
+++ b/mythtv/libs/libmythtv/captions/cc708decoder.h
@@ -13,14 +13,12 @@
 using cc708_seen_flags = std::array<bool,64>;
 using cc708_seen_times = std::array<SystemTime,64>;
 
-#ifndef __CC_CALLBACKS_H__
 /** EIA-708-A closed caption packet */
 struct CaptionPacket
 {
-    std::array<unsigned char,128+16> data;
-    int size;
+    std::array<uint8_t,128+16> data {0};
+    int size {0};
 };
-#endif
 
 class CC708Reader;
 
@@ -31,7 +29,6 @@ class CC708Decoder
    ~CC708Decoder() = default;
 
     void decode_cc_data(uint cc_type, uint data1, uint data2);
-    void decode_cc_null(void);
 
     /// \return Services seen in last few seconds as specified.
     void services(std::chrono::seconds seconds, cc708_seen_flags & seen) const;

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -2774,8 +2774,6 @@ void AvFormatDecoder::DecodeCCx08(const uint8_t *buf, uint buf_size)
 
         if (!cc_valid)
         {
-            if (cc_type >= 0x2)
-                m_ccd708->decode_cc_null();
             continue;
         }
 


### PR DESCRIPTION
ANSI/CTA-708-E S-2023 page 14 footnote 4:
"The presence of padding should not be interpreted as terminating the CCP." The fix from f8312c35f01980be8d10a048cc23220f11864211 is incorrect.

Instead, check if the CCP is full after adding data and parse immediately.

caption_channel_packet::packet_data_size is 127 for packet_size_code = 0, which parse_cc_packet() will still incorrectly skip.

The addition of m_partialPacket.size > 0 prevents data from being added to a packet before a header has been added.  size will remain 0 until a header is added and total_packet_size is never 0, so parse_cc_packet() will not be called until a header has been added.

Fixes https://github.com/MythTV/mythtv/issues/1117

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

