### PR TITLE
Stop memory use after free in SaveLastPlayPos

### DIFF
--- a/mythtv/libs/libmythtv/tv_play.h
+++ b/mythtv/libs/libmythtv/tv_play.h
@@ -25,6 +25,7 @@
 #include "libmythbase/mythdeque.h"
 #include "libmythbase/mythtimer.h"
 #include "libmythbase/referencecounter.h"
+#include "libmythbase/mthreadpool.h"
 
 #include "channelgroup.h"
 #include "channelinfo.h"
@@ -170,6 +171,7 @@ class MTV_PUBLIC TV : public TVPlaybackState, public MythTVMenuItemDisplayer, pu
     static int  ConfiguredTunerCards();
     static bool IsTunable(uint ChanId);
     void        ReloadKeys();
+    MThreadPool* GetPosThreadPool();
 
     bool IsSameProgram(const ProgramInfo* ProgInfo) const;
 
@@ -515,6 +517,7 @@ class MTV_PUBLIC TV : public TVPlaybackState, public MythTVMenuItemDisplayer, pu
     void RetrieveCast(const ProgramInfo& ProgInfo);
 
     MythMainWindow*   m_mainWindow { nullptr };
+    MThreadPool*      m_posThreadPool { nullptr };
 
     // Configuration variables from database
     QString           m_dbChannelFormat {"<num> <sign>"};
@@ -768,6 +771,22 @@ class MTV_PUBLIC TV : public TVPlaybackState, public MythTVMenuItemDisplayer, pu
 #else
     static inline const std::chrono::milliseconds kEndOfPlaybackFirstCheckTimer = 5s;
 #endif
+};
+
+class SavePositionThread : public QRunnable
+{
+    public:
+        SavePositionThread(ProgramInfo *progInfoPtr, uint64_t framesPos):
+            m_progInfo(progInfoPtr),
+            m_framesPlayed(framesPos)
+        {
+        }
+
+        void run() override; // QRunnable
+
+    private:
+        ProgramInfo *m_progInfo {nullptr};
+        uint64_t     m_framesPlayed {0};
 };
 
 #endif


### PR DESCRIPTION
**MConcurrent** was used to launch a separate thread to take on the task of saving the playback position. However, **MConcurrent** doesn't provide any way of tracking the progress of that operation. This update switches from using **MConcurrent** to using **MThreadPool**. This is a little more complicated, but it provides us the option to invoke **waitForDone()**. This is used to guarantee  completion of the saving playback position operation in **TV::~TV()** before the complete destruction of the TV instance. It eliminates the race condition between the threads, and stops the reference to memory which has already been freed.

Resolves: #1131

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

