### PR TITLE
fix CMake name for test_bitreader

### DIFF
--- a/mythtv/libs/libmythtv/test/test_bitreader/CMakeLists.txt
+++ b/mythtv/libs/libmythtv/test/test_bitreader/CMakeLists.txt
@@ -10,4 +10,4 @@ target_include_directories(test_bitreader PRIVATE . ../..)
 
 target_link_libraries(test_bitreader PUBLIC mythtv Qt${QT_VERSION_MAJOR}::Test)
 
-add_test(NAME AVCInfo COMMAND test_bitreader)
+add_test(NAME BitReader COMMAND test_bitreader)


### PR DESCRIPTION
@linuxdude42 You didn't adjust it when copying from a different test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

