### PR TITLE
fix compilation of zmserver.cpp on macOS

### DIFF
--- a/mythplugins/mythzoneminder/mythzmserver/zmserver.cpp
+++ b/mythplugins/mythzoneminder/mythzmserver/zmserver.cpp
@@ -43,7 +43,7 @@
 #  endif // !__CYGWIN__
 #endif
 
-#ifdef __APPLE__
+#ifndef MSG_NOSIGNAL
 static constexpr int MSG_NOSIGNAL { 0 };  // Apple also has SO_NOSIGPIPE?
 #endif
 


### PR DESCRIPTION
MSG_NOSIGNAL is defined in the GitHub Actions builders.

Make the condition agnostic to OS, which is how FFmpeg does it.

@linuxdude42 This should fix the GitHub Actions for macOS 13 and 14 since you re-enabled building zmserver https://github.com/MythTV/mythtv/commit/8f7766d62c6a3eb3630392b2ebf419d276d8fe40.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

