### PR TITLE
Close StandardSetting memory leaks using destructors

### DIFF
--- a/mythtv/libs/libmythtv/channelsettings.cpp
+++ b/mythtv/libs/libmythtv/channelsettings.cpp
@@ -104,9 +104,14 @@ class Name : public MythUITextEditSetting
 {
   public:
     explicit Name(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "name"))
+        MythUITextEditSetting(new ChannelDBStorage(this, id, "name"))
     {
         setLabel(QCoreApplication::translate("(Common)", "Channel Name"));
+    }
+
+    ~Name()
+    {
+        delete GetStorage();
     }
 };
 
@@ -114,11 +119,16 @@ class Channum : public MythUITextEditSetting
 {
   public:
     explicit Channum(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "channum"))
+        MythUITextEditSetting(new ChannelDBStorage(this, id, "channum"))
     {
         setLabel(QCoreApplication::translate("(Common)", "Channel Number"));
         setHelpText(QCoreApplication::translate("(Common)",
         "This is the number by which the channel is known to MythTV."));
+    }
+
+    ~Channum()
+    {
+        delete GetStorage();
     }
 };
 
@@ -126,7 +136,7 @@ class Source : public MythUIComboBoxSetting
 {
   public:
     Source(const ChannelID &id, uint _default_sourceid) :
-        MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "sourceid")),
+        MythUIComboBoxSetting(new ChannelDBStorage(this, id, "sourceid")),
         m_defaultSourceId(_default_sourceid)
     {
         setLabel(QCoreApplication::translate("(Common)", "Video Source"));
@@ -134,6 +144,11 @@ class Source : public MythUIComboBoxSetting
         "It is NOT a good idea to change this value as it only changes "
         "the sourceid in table channel but not in dtv_multiplex. "
         "The sourceid in dtv_multiplex cannot and should not be changed."));
+    }
+
+    ~Source()
+    {
+        delete GetStorage();
     }
 
     void Load(void) override // StandardSetting
@@ -185,14 +200,19 @@ class Callsign : public MythUITextEditSetting
 {
   public:
     explicit Callsign(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "callsign"))
+        MythUITextEditSetting(new ChannelDBStorage(this, id, "callsign"))
     {
         setLabel(QCoreApplication::translate("(Common)", "Callsign"));
+    }
+
+    ~Callsign()
+    {
+        delete GetStorage();
     }
 };
 
 ChannelTVFormat::ChannelTVFormat(const ChannelID &id) :
-    MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "tvformat"))
+    MythUIComboBoxSetting(new ChannelDBStorage(this, id, "tvformat"))
 {
     setLabel(QCoreApplication::translate("(ChannelSettings)", "TV Format"));
     setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -204,6 +224,11 @@ ChannelTVFormat::ChannelTVFormat(const ChannelID &id) :
     QStringList list = GetFormats();
     for (const QString& format : std::as_const(list))
         addSelection(format);
+}
+
+ChannelTVFormat::~ChannelTVFormat()
+{
+    delete GetStorage();
 }
 
 QStringList ChannelTVFormat::GetFormats(void)
@@ -232,7 +257,7 @@ class TimeOffset : public MythUISpinBoxSetting
 {
   public:
     explicit TimeOffset(const ChannelID &id) :
-        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "tmoffset"),
+        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "tmoffset"),
                              -1440, 1440, 1)
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)",
@@ -243,13 +268,18 @@ class TimeOffset : public MythUISpinBoxSetting
             "import.  This can be used when the listings for a particular "
             "channel are in a different time zone."));
     }
+
+    ~TimeOffset()
+    {
+        delete GetStorage();
+    }
 };
 
 class Priority : public MythUISpinBoxSetting
 {
   public:
     explicit Priority(const ChannelID &id) :
-        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "recpriority"),
+        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "recpriority"),
                              -99, 99, 1)
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Priority"));
@@ -260,13 +290,18 @@ class Priority : public MythUISpinBoxSetting
             "if you want this to be a preferred channel, a negative one to "
             "depreciate this channel."));
     }
+
+    ~Priority()
+    {
+        delete GetStorage();
+    }
 };
 
 class Icon : public MythUITextEditSetting
 {
   public:
     explicit Icon(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "icon"))
+        MythUITextEditSetting(new ChannelDBStorage(this, id, "icon"))
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Icon"));
 
@@ -274,13 +309,18 @@ class Icon : public MythUITextEditSetting
             "Image file to use as the icon for this channel on various MythTV "
             "displays."));
     }
+
+    ~Icon()
+    {
+        delete GetStorage();
+    }
 };
 
 class VideoFilters : public MythUITextEditSetting
 {
   public:
     explicit VideoFilters(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "videofilters"))
+        MythUITextEditSetting(new ChannelDBStorage(this, id, "videofilters"))
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Video filters"));
@@ -290,6 +330,11 @@ class VideoFilters : public MythUITextEditSetting
             "with hardware encoding cards."));
 
     }
+
+    ~VideoFilters()
+    {
+        delete GetStorage();
+    }
 };
 
 
@@ -297,7 +342,7 @@ class OutputFilters : public MythUITextEditSetting
 {
   public:
     explicit OutputFilters(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "outputfilters"))
+        MythUITextEditSetting(new ChannelDBStorage(this, id, "outputfilters"))
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                     "Playback filters"));
@@ -306,13 +351,18 @@ class OutputFilters : public MythUITextEditSetting
             "Filters to be used when recordings from this channel are viewed. "
             "Start with a plus to append to the global playback filters."));
     }
+
+    ~OutputFilters()
+    {
+        delete GetStorage();
+    }
 };
 
 class XmltvID : public MythUIComboBoxSetting
 {
   public:
     XmltvID(const ChannelID &id, QString _sourceName) :
-        MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "xmltvid"), true),
+        MythUIComboBoxSetting(new ChannelDBStorage(this, id, "xmltvid"), true),
         m_sourceName(std::move(_sourceName))
     {
         setLabel(QCoreApplication::translate("(Common)", "XMLTV ID"));
@@ -322,6 +372,11 @@ class XmltvID : public MythUIComboBoxSetting
             "between a channel in your line-up and a channel in their "
             "database. Normally this is set automatically when "
             "'mythfilldatabase' is run."));
+    }
+
+    ~XmltvID()
+    {
+        delete GetStorage();
     }
 
     void Load(void) override // StandardSetting
@@ -370,7 +425,7 @@ class ServiceID : public MythUISpinBoxSetting
 {
   public:
     explicit ServiceID(const ChannelID &id)
-        : MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "serviceid"),
+        : MythUISpinBoxSetting(new ChannelDBStorage(this, id, "serviceid"),
                                -1, UINT16_MAX, 1, 1, "NULL")
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Service ID"));
@@ -378,6 +433,11 @@ class ServiceID : public MythUISpinBoxSetting
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
                 "Service ID (Program Number) of desired channel within the transport stream. "
                 "If there is only one channel, then setting this to anything will still find it."));
+    }
+
+    ~ServiceID()
+    {
+        delete GetStorage();
     }
 
     void Load(void) override // StandardSetting
@@ -426,7 +486,7 @@ class CommMethod : public MythUIComboBoxSetting
 {
   public:
     explicit CommMethod(const ChannelID &id) :
-       MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "commmethod"))
+       MythUIComboBoxSetting(new ChannelDBStorage(this, id, "commmethod"))
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Commercial Detection Method"));
@@ -443,13 +503,18 @@ class CommMethod : public MythUIComboBoxSetting
         for (int pref : tmp)
             addSelection(SkipTypeToString(pref), QString::number(pref));
     }
+
+    ~CommMethod()
+    {
+        delete GetStorage();
+    }
 };
 
 class Visible : public MythUIComboBoxSetting
 {
   public:
     explicit Visible(const ChannelID &id) :
-        MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "visible"))
+        MythUIComboBoxSetting(new ChannelDBStorage(this, id, "visible"))
     {
         setValue(kChannelVisible);
 
@@ -470,13 +535,18 @@ class Visible : public MythUIComboBoxSetting
         addSelection(QCoreApplication::translate("(Common)", "Never Visible"),
                      QString::number(kChannelNeverVisible));
     }
+
+    ~Visible()
+    {
+        delete GetStorage();
+    }
 };
 
 class OnAirGuide : public MythUICheckBoxSetting
 {
   public:
     explicit OnAirGuide(const ChannelID &id) :
-        MythUICheckBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "useonairguide"))
+        MythUICheckBoxSetting(new ChannelDBStorage(this, id, "useonairguide"))
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Use on air guide"));
@@ -484,6 +554,11 @@ class OnAirGuide : public MythUICheckBoxSetting
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
             "If enabled, guide information for this channel will be updated "
             "using 'Over-the-Air' program listings."));
+    }
+
+    ~OnAirGuide()
+    {
+        delete GetStorage();
     }
 };
 
@@ -494,13 +569,18 @@ class ChannelURL : public MythUITextEditSetting
 {
   public:
     explicit ChannelURL(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<IPTVChannelDBStorage>(this, id, "url"))
+        MythUITextEditSetting(new IPTVChannelDBStorage(this, id, "url"))
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)", "URL"));
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
             "URL for streaming of this channel. Used by the IPTV "
             "capture card and obtained with an \"M3U Import\" or "
             "with a \"HDHomeRun Channel Import\" loading of an XML file."));
+    }
+
+    ~ChannelURL()
+    {
+        delete GetStorage();
     }
 };
 
@@ -512,7 +592,7 @@ class Freqid : public MythUITextEditSetting
 {
   public:
     explicit Freqid(const ChannelID &id) :
-        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "freqid"))
+        MythUITextEditSetting(new ChannelDBStorage(this, id, "freqid"))
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Freq/Channel"));
@@ -522,13 +602,18 @@ class Freqid : public MythUITextEditSetting
             "frequency (in kHz) or a valid channel "
             "number that will be understood by your tuners."));
     }
+
+    ~Freqid()
+    {
+        delete GetStorage();
+    }
 };
 
 class Finetune : public MythUISpinBoxSetting
 {
   public:
     explicit Finetune(const ChannelID& id)
-        : MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "finetune"),
+        : MythUISpinBoxSetting(new ChannelDBStorage(this, id, "finetune"),
                                -300, 300, 1)
     {
         setLabel(QCoreApplication::translate("(ChannelSettings)",
@@ -540,16 +625,26 @@ class Finetune : public MythUISpinBoxSetting
 
         setValue("0");
     }
+
+    ~Finetune()
+    {
+        delete GetStorage();
+    }
 };
 
 class Contrast : public MythUISpinBoxSetting
 {
   public:
     explicit Contrast(const ChannelID &id) :
-        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "contrast"),
+        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "contrast"),
                              0, 65535, 655)
     {
         setLabel(QCoreApplication::translate("(Common)", "Contrast"));
+    }
+
+    ~Contrast()
+    {
+        delete GetStorage();
     }
 };
 
@@ -557,10 +652,15 @@ class Brightness : public MythUISpinBoxSetting
 {
   public:
     explicit Brightness(const ChannelID &id) :
-        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "brightness"),
+        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "brightness"),
                              0, 65535, 655)
     {
         setLabel(QCoreApplication::translate("(Common)", "Brightness"));
+    }
+
+    ~Brightness()
+    {
+        delete GetStorage();
     }
 };
 
@@ -568,10 +668,15 @@ class Colour : public MythUISpinBoxSetting
 {
   public:
     explicit Colour(const ChannelID &id) :
-        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "colour"),
+        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "colour"),
                              0, 65535, 655)
     {
         setLabel(QCoreApplication::translate("(Common)", "Color"));
+    }
+
+    ~Colour()
+    {
+        delete GetStorage();
     }
 };
 
@@ -579,10 +684,15 @@ class Hue : public MythUISpinBoxSetting
 {
   public:
     explicit Hue(const ChannelID &id) :
-        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "hue"),
+        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "hue"),
                              0, 65535, 655)
     {
         setLabel(QCoreApplication::translate("(Common)", "Hue"));
+    }
+
+    ~Hue()
+    {
+        delete GetStorage();
     }
 };
 

--- a/mythtv/libs/libmythtv/channelsettings.cpp
+++ b/mythtv/libs/libmythtv/channelsettings.cpp
@@ -104,9 +104,8 @@ class Name : public MythUITextEditSetting
 {
   public:
     explicit Name(const ChannelID &id) :
-        MythUITextEditSetting(new ChannelDBStorage(this, id, "name"))
+        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "name"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Channel Name"));
     }
 };
@@ -115,9 +114,8 @@ class Channum : public MythUITextEditSetting
 {
   public:
     explicit Channum(const ChannelID &id) :
-        MythUITextEditSetting(new ChannelDBStorage(this, id, "channum"))
+        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "channum"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Channel Number"));
         setHelpText(QCoreApplication::translate("(Common)",
         "This is the number by which the channel is known to MythTV."));
@@ -128,10 +126,9 @@ class Source : public MythUIComboBoxSetting
 {
   public:
     Source(const ChannelID &id, uint _default_sourceid) :
-        MythUIComboBoxSetting(new ChannelDBStorage(this, id, "sourceid")),
+        MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "sourceid")),
         m_defaultSourceId(_default_sourceid)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Video Source"));
         setHelpText(QCoreApplication::translate("(Common)",
         "It is NOT a good idea to change this value as it only changes "
@@ -188,17 +185,15 @@ class Callsign : public MythUITextEditSetting
 {
   public:
     explicit Callsign(const ChannelID &id) :
-        MythUITextEditSetting(new ChannelDBStorage(this, id, "callsign"))
+        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "callsign"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Callsign"));
     }
 };
 
 ChannelTVFormat::ChannelTVFormat(const ChannelID &id) :
-    MythUIComboBoxSetting(new ChannelDBStorage(this, id, "tvformat"))
+    MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "tvformat"))
 {
-    m_newdStorage = true;
     setLabel(QCoreApplication::translate("(ChannelSettings)", "TV Format"));
     setHelpText(QCoreApplication::translate("(ChannelSettings)",
         "If this channel uses a format other than TV Format in the General "
@@ -237,10 +232,9 @@ class TimeOffset : public MythUISpinBoxSetting
 {
   public:
     explicit TimeOffset(const ChannelID &id) :
-        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "tmoffset"),
+        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "tmoffset"),
                              -1440, 1440, 1)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "DataDirect Time Offset"));
 
@@ -255,10 +249,9 @@ class Priority : public MythUISpinBoxSetting
 {
   public:
     explicit Priority(const ChannelID &id) :
-        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "recpriority"),
+        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "recpriority"),
                              -99, 99, 1)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Priority"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -273,9 +266,8 @@ class Icon : public MythUITextEditSetting
 {
   public:
     explicit Icon(const ChannelID &id) :
-        MythUITextEditSetting(new ChannelDBStorage(this, id, "icon"))
+        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "icon"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Icon"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -288,9 +280,8 @@ class VideoFilters : public MythUITextEditSetting
 {
   public:
     explicit VideoFilters(const ChannelID &id) :
-        MythUITextEditSetting(new ChannelDBStorage(this, id, "videofilters"))
+        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "videofilters"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Video filters"));
 
@@ -306,9 +297,8 @@ class OutputFilters : public MythUITextEditSetting
 {
   public:
     explicit OutputFilters(const ChannelID &id) :
-        MythUITextEditSetting(new ChannelDBStorage(this, id, "outputfilters"))
+        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "outputfilters"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                     "Playback filters"));
 
@@ -322,10 +312,9 @@ class XmltvID : public MythUIComboBoxSetting
 {
   public:
     XmltvID(const ChannelID &id, QString _sourceName) :
-        MythUIComboBoxSetting(new ChannelDBStorage(this, id, "xmltvid"), true),
+        MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "xmltvid"), true),
         m_sourceName(std::move(_sourceName))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "XMLTV ID"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -381,10 +370,9 @@ class ServiceID : public MythUISpinBoxSetting
 {
   public:
     explicit ServiceID(const ChannelID &id)
-        : MythUISpinBoxSetting(new ChannelDBStorage(this, id, "serviceid"),
+        : MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "serviceid"),
                                -1, UINT16_MAX, 1, 1, "NULL")
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Service ID"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -438,9 +426,8 @@ class CommMethod : public MythUIComboBoxSetting
 {
   public:
     explicit CommMethod(const ChannelID &id) :
-       MythUIComboBoxSetting(new ChannelDBStorage(this, id, "commmethod"))
+       MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "commmethod"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Commercial Detection Method"));
 
@@ -462,9 +449,8 @@ class Visible : public MythUIComboBoxSetting
 {
   public:
     explicit Visible(const ChannelID &id) :
-        MythUIComboBoxSetting(new ChannelDBStorage(this, id, "visible"))
+        MythUIComboBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "visible"))
     {
-        m_newdStorage = true;
         setValue(kChannelVisible);
 
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Visible"));
@@ -490,9 +476,8 @@ class OnAirGuide : public MythUICheckBoxSetting
 {
   public:
     explicit OnAirGuide(const ChannelID &id) :
-        MythUICheckBoxSetting(new ChannelDBStorage(this, id, "useonairguide"))
+        MythUICheckBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "useonairguide"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Use on air guide"));
 
@@ -509,9 +494,8 @@ class ChannelURL : public MythUITextEditSetting
 {
   public:
     explicit ChannelURL(const ChannelID &id) :
-        MythUITextEditSetting(new IPTVChannelDBStorage(this, id, "url"))
+        MythUITextEditSetting(std::make_shared<IPTVChannelDBStorage>(this, id, "url"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "URL"));
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
             "URL for streaming of this channel. Used by the IPTV "
@@ -528,9 +512,8 @@ class Freqid : public MythUITextEditSetting
 {
   public:
     explicit Freqid(const ChannelID &id) :
-        MythUITextEditSetting(new ChannelDBStorage(this, id, "freqid"))
+        MythUITextEditSetting(std::make_shared<ChannelDBStorage>(this, id, "freqid"))
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Freq/Channel"));
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -545,10 +528,9 @@ class Finetune : public MythUISpinBoxSetting
 {
   public:
     explicit Finetune(const ChannelID& id)
-        : MythUISpinBoxSetting(new ChannelDBStorage(this, id, "finetune"),
+        : MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "finetune"),
                                -300, 300, 1)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Finetune (kHz)"));
 
@@ -564,10 +546,9 @@ class Contrast : public MythUISpinBoxSetting
 {
   public:
     explicit Contrast(const ChannelID &id) :
-        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "contrast"),
+        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "contrast"),
                              0, 65535, 655)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Contrast"));
     }
 };
@@ -576,10 +557,9 @@ class Brightness : public MythUISpinBoxSetting
 {
   public:
     explicit Brightness(const ChannelID &id) :
-        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "brightness"),
+        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "brightness"),
                              0, 65535, 655)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Brightness"));
     }
 };
@@ -588,10 +568,9 @@ class Colour : public MythUISpinBoxSetting
 {
   public:
     explicit Colour(const ChannelID &id) :
-        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "colour"),
+        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "colour"),
                              0, 65535, 655)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Color"));
     }
 };
@@ -600,10 +579,9 @@ class Hue : public MythUISpinBoxSetting
 {
   public:
     explicit Hue(const ChannelID &id) :
-        MythUISpinBoxSetting(new ChannelDBStorage(this, id, "hue"),
+        MythUISpinBoxSetting(std::make_shared<ChannelDBStorage>(this, id, "hue"),
                              0, 65535, 655)
     {
-        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Hue"));
     }
 };

--- a/mythtv/libs/libmythtv/channelsettings.cpp
+++ b/mythtv/libs/libmythtv/channelsettings.cpp
@@ -106,6 +106,7 @@ class Name : public MythUITextEditSetting
     explicit Name(const ChannelID &id) :
         MythUITextEditSetting(new ChannelDBStorage(this, id, "name"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Channel Name"));
     }
 };
@@ -116,6 +117,7 @@ class Channum : public MythUITextEditSetting
     explicit Channum(const ChannelID &id) :
         MythUITextEditSetting(new ChannelDBStorage(this, id, "channum"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Channel Number"));
         setHelpText(QCoreApplication::translate("(Common)",
         "This is the number by which the channel is known to MythTV."));
@@ -129,6 +131,7 @@ class Source : public MythUIComboBoxSetting
         MythUIComboBoxSetting(new ChannelDBStorage(this, id, "sourceid")),
         m_defaultSourceId(_default_sourceid)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Video Source"));
         setHelpText(QCoreApplication::translate("(Common)",
         "It is NOT a good idea to change this value as it only changes "
@@ -187,6 +190,7 @@ class Callsign : public MythUITextEditSetting
     explicit Callsign(const ChannelID &id) :
         MythUITextEditSetting(new ChannelDBStorage(this, id, "callsign"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Callsign"));
     }
 };
@@ -194,6 +198,7 @@ class Callsign : public MythUITextEditSetting
 ChannelTVFormat::ChannelTVFormat(const ChannelID &id) :
     MythUIComboBoxSetting(new ChannelDBStorage(this, id, "tvformat"))
 {
+    m_newdStorage = true;
     setLabel(QCoreApplication::translate("(ChannelSettings)", "TV Format"));
     setHelpText(QCoreApplication::translate("(ChannelSettings)",
         "If this channel uses a format other than TV Format in the General "
@@ -235,6 +240,7 @@ class TimeOffset : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new ChannelDBStorage(this, id, "tmoffset"),
                              -1440, 1440, 1)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "DataDirect Time Offset"));
 
@@ -252,6 +258,7 @@ class Priority : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new ChannelDBStorage(this, id, "recpriority"),
                              -99, 99, 1)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Priority"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -268,6 +275,7 @@ class Icon : public MythUITextEditSetting
     explicit Icon(const ChannelID &id) :
         MythUITextEditSetting(new ChannelDBStorage(this, id, "icon"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Icon"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -282,6 +290,7 @@ class VideoFilters : public MythUITextEditSetting
     explicit VideoFilters(const ChannelID &id) :
         MythUITextEditSetting(new ChannelDBStorage(this, id, "videofilters"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Video filters"));
 
@@ -299,6 +308,7 @@ class OutputFilters : public MythUITextEditSetting
     explicit OutputFilters(const ChannelID &id) :
         MythUITextEditSetting(new ChannelDBStorage(this, id, "outputfilters"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                     "Playback filters"));
 
@@ -315,6 +325,7 @@ class XmltvID : public MythUIComboBoxSetting
         MythUIComboBoxSetting(new ChannelDBStorage(this, id, "xmltvid"), true),
         m_sourceName(std::move(_sourceName))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "XMLTV ID"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -373,6 +384,7 @@ class ServiceID : public MythUISpinBoxSetting
         : MythUISpinBoxSetting(new ChannelDBStorage(this, id, "serviceid"),
                                -1, UINT16_MAX, 1, 1, "NULL")
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Service ID"));
 
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -428,6 +440,7 @@ class CommMethod : public MythUIComboBoxSetting
     explicit CommMethod(const ChannelID &id) :
        MythUIComboBoxSetting(new ChannelDBStorage(this, id, "commmethod"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Commercial Detection Method"));
 
@@ -451,6 +464,7 @@ class Visible : public MythUIComboBoxSetting
     explicit Visible(const ChannelID &id) :
         MythUIComboBoxSetting(new ChannelDBStorage(this, id, "visible"))
     {
+        m_newdStorage = true;
         setValue(kChannelVisible);
 
         setLabel(QCoreApplication::translate("(ChannelSettings)", "Visible"));
@@ -478,6 +492,7 @@ class OnAirGuide : public MythUICheckBoxSetting
     explicit OnAirGuide(const ChannelID &id) :
         MythUICheckBoxSetting(new ChannelDBStorage(this, id, "useonairguide"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Use on air guide"));
 
@@ -496,6 +511,7 @@ class ChannelURL : public MythUITextEditSetting
     explicit ChannelURL(const ChannelID &id) :
         MythUITextEditSetting(new IPTVChannelDBStorage(this, id, "url"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)", "URL"));
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
             "URL for streaming of this channel. Used by the IPTV "
@@ -514,6 +530,7 @@ class Freqid : public MythUITextEditSetting
     explicit Freqid(const ChannelID &id) :
         MythUITextEditSetting(new ChannelDBStorage(this, id, "freqid"))
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Freq/Channel"));
         setHelpText(QCoreApplication::translate("(ChannelSettings)",
@@ -531,6 +548,7 @@ class Finetune : public MythUISpinBoxSetting
         : MythUISpinBoxSetting(new ChannelDBStorage(this, id, "finetune"),
                                -300, 300, 1)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(ChannelSettings)",
                                              "Finetune (kHz)"));
 
@@ -549,6 +567,7 @@ class Contrast : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new ChannelDBStorage(this, id, "contrast"),
                              0, 65535, 655)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Contrast"));
     }
 };
@@ -560,6 +579,7 @@ class Brightness : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new ChannelDBStorage(this, id, "brightness"),
                              0, 65535, 655)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Brightness"));
     }
 };
@@ -571,6 +591,7 @@ class Colour : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new ChannelDBStorage(this, id, "colour"),
                              0, 65535, 655)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Color"));
     }
 };
@@ -582,6 +603,7 @@ class Hue : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new ChannelDBStorage(this, id, "hue"),
                              0, 65535, 655)
     {
+        m_newdStorage = true;
         setLabel(QCoreApplication::translate("(Common)", "Hue"));
     }
 };

--- a/mythtv/libs/libmythtv/channelsettings.h
+++ b/mythtv/libs/libmythtv/channelsettings.h
@@ -153,6 +153,7 @@ class MTV_PUBLIC ChannelTVFormat :
 {
   public:
     explicit ChannelTVFormat(const ChannelID &id);
+    ~ChannelTVFormat();
 
     static QStringList GetFormats(void);
 };

--- a/mythtv/libs/libmythtv/playgroup.cpp
+++ b/mythtv/libs/libmythtv/playgroup.cpp
@@ -37,7 +37,7 @@ class TitleMatch : public MythUITextEditSetting
 {
   public:
     explicit TitleMatch(const PlayGroupConfig& _parent):
-        MythUITextEditSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "titlematch"))
+        MythUITextEditSetting(new PlayGroupDBStorage(this, _parent, "titlematch"))
     {
         setLabel(PlayGroupConfig::tr("Title match (regex)"));
         setHelpText(PlayGroupConfig::tr("Automatically set new recording rules "
@@ -47,13 +47,18 @@ class TitleMatch : public MythUITextEditSetting
                                          "match any title in which \"News\" or "
                                          "\"CNN\" appears."));
     };
+
+    ~TitleMatch()
+    {
+        delete GetStorage();
+    }
 };
 
 class SkipAhead : public MythUISpinBoxSetting
 {
   public:
     explicit SkipAhead(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "skipahead"),
+        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "skipahead"),
                              0, 600, 5, 1, PlayGroupConfig::tr("(default)"))
 
     {
@@ -61,26 +66,36 @@ class SkipAhead : public MythUISpinBoxSetting
         setHelpText(PlayGroupConfig::tr("How many seconds to skip forward on "
                                         "a fast forward."));
     };
+
+    ~SkipAhead()
+    {
+        delete GetStorage();
+    }
 };
 
 class SkipBack : public MythUISpinBoxSetting
 {
   public:
     explicit SkipBack(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "skipback"),
+        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "skipback"),
                              0, 600, 5, 1, PlayGroupConfig::tr("(default)"))
     {
         setLabel(PlayGroupConfig::tr("Skip back (seconds)"));
         setHelpText(PlayGroupConfig::tr("How many seconds to skip backward on "
                                         "a rewind."));
     };
+
+    ~SkipBack()
+    {
+        delete GetStorage();
+    }
 };
 
 class JumpMinutes : public MythUISpinBoxSetting
 {
   public:
     explicit JumpMinutes(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "jump"),
+        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "jump"),
                              0, 30, 10, 1, PlayGroupConfig::tr("(default)"))
     {
         setLabel(PlayGroupConfig::tr("Jump amount (minutes)"));
@@ -88,13 +103,18 @@ class JumpMinutes : public MythUISpinBoxSetting
                                         "backward when the jump keys are "
                                         "pressed."));
     };
+
+    ~JumpMinutes()
+    {
+        delete GetStorage();
+    }
 };
 
 class TimeStretch : public MythUISpinBoxSetting
 {
   public:
     explicit TimeStretch(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "timestretch"),
+        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "timestretch"),
                              50, 200, 5, 1)
     {
         setValue(100);
@@ -104,6 +124,11 @@ class TimeStretch : public MythUISpinBoxSetting
                                         "for half speed and 200 for double "
                                         "speed."));
     };
+
+    ~TimeStretch()
+    {
+        delete GetStorage();
+    }
 
     void Load(void) override // StandardSetting
     {

--- a/mythtv/libs/libmythtv/playgroup.cpp
+++ b/mythtv/libs/libmythtv/playgroup.cpp
@@ -37,9 +37,8 @@ class TitleMatch : public MythUITextEditSetting
 {
   public:
     explicit TitleMatch(const PlayGroupConfig& _parent):
-        MythUITextEditSetting(new PlayGroupDBStorage(this, _parent, "titlematch"))
+        MythUITextEditSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "titlematch"))
     {
-        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Title match (regex)"));
         setHelpText(PlayGroupConfig::tr("Automatically set new recording rules "
                                          "to use this group if the title "
@@ -54,11 +53,10 @@ class SkipAhead : public MythUISpinBoxSetting
 {
   public:
     explicit SkipAhead(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "skipahead"),
+        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "skipahead"),
                              0, 600, 5, 1, PlayGroupConfig::tr("(default)"))
 
     {
-        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Skip ahead (seconds)"));
         setHelpText(PlayGroupConfig::tr("How many seconds to skip forward on "
                                         "a fast forward."));
@@ -69,10 +67,9 @@ class SkipBack : public MythUISpinBoxSetting
 {
   public:
     explicit SkipBack(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "skipback"),
+        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "skipback"),
                              0, 600, 5, 1, PlayGroupConfig::tr("(default)"))
     {
-        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Skip back (seconds)"));
         setHelpText(PlayGroupConfig::tr("How many seconds to skip backward on "
                                         "a rewind."));
@@ -83,10 +80,9 @@ class JumpMinutes : public MythUISpinBoxSetting
 {
   public:
     explicit JumpMinutes(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "jump"),
+        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "jump"),
                              0, 30, 10, 1, PlayGroupConfig::tr("(default)"))
     {
-        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Jump amount (minutes)"));
         setHelpText(PlayGroupConfig::tr("How many minutes to jump forward or "
                                         "backward when the jump keys are "
@@ -98,10 +94,9 @@ class TimeStretch : public MythUISpinBoxSetting
 {
   public:
     explicit TimeStretch(const PlayGroupConfig& _parent):
-        MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "timestretch"),
+        MythUISpinBoxSetting(std::make_shared<PlayGroupDBStorage>(this, _parent, "timestretch"),
                              50, 200, 5, 1)
     {
-        m_newdStorage = true;
         setValue(100);
         setLabel(PlayGroupConfig::tr("Time stretch (speed x 100)"));
         setHelpText(PlayGroupConfig::tr("Initial playback speed with adjusted "

--- a/mythtv/libs/libmythtv/playgroup.cpp
+++ b/mythtv/libs/libmythtv/playgroup.cpp
@@ -39,6 +39,7 @@ class TitleMatch : public MythUITextEditSetting
     explicit TitleMatch(const PlayGroupConfig& _parent):
         MythUITextEditSetting(new PlayGroupDBStorage(this, _parent, "titlematch"))
     {
+        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Title match (regex)"));
         setHelpText(PlayGroupConfig::tr("Automatically set new recording rules "
                                          "to use this group if the title "
@@ -57,6 +58,7 @@ class SkipAhead : public MythUISpinBoxSetting
                              0, 600, 5, 1, PlayGroupConfig::tr("(default)"))
 
     {
+        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Skip ahead (seconds)"));
         setHelpText(PlayGroupConfig::tr("How many seconds to skip forward on "
                                         "a fast forward."));
@@ -70,6 +72,7 @@ class SkipBack : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "skipback"),
                              0, 600, 5, 1, PlayGroupConfig::tr("(default)"))
     {
+        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Skip back (seconds)"));
         setHelpText(PlayGroupConfig::tr("How many seconds to skip backward on "
                                         "a rewind."));
@@ -83,6 +86,7 @@ class JumpMinutes : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "jump"),
                              0, 30, 10, 1, PlayGroupConfig::tr("(default)"))
     {
+        m_newdStorage = true;
         setLabel(PlayGroupConfig::tr("Jump amount (minutes)"));
         setHelpText(PlayGroupConfig::tr("How many minutes to jump forward or "
                                         "backward when the jump keys are "
@@ -97,6 +101,7 @@ class TimeStretch : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new PlayGroupDBStorage(this, _parent, "timestretch"),
                              50, 200, 5, 1)
     {
+        m_newdStorage = true;
         setValue(100);
         setLabel(PlayGroupConfig::tr("Time stretch (speed x 100)"));
         setHelpText(PlayGroupConfig::tr("Initial playback speed with adjusted "

--- a/mythtv/libs/libmythtv/profilegroup.h
+++ b/mythtv/libs/libmythtv/profilegroup.h
@@ -45,9 +45,8 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit Is_default(const ProfileGroup &parent) :
-            StandardSetting(new ProfileGroupStorage(this, parent, "is_default"))
+            StandardSetting(std::make_shared<ProfileGroupStorage>(this, parent, "is_default"))
         {
-            m_newdStorage = true;
             setVisible(false);
         }
 
@@ -59,9 +58,8 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit Name(const ProfileGroup &parent) :
-            MythUITextEditSetting(new ProfileGroupStorage(this, parent, "name"))
+            MythUITextEditSetting(std::make_shared<ProfileGroupStorage>(this, parent, "name"))
         {
-            m_newdStorage = true;
             setLabel(QObject::tr("Profile Group Name"));
         }
     };
@@ -70,10 +68,9 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit HostName(const ProfileGroup &parent) :
-            MythUIComboBoxSetting(new ProfileGroupStorage(this, parent,
+            MythUIComboBoxSetting(std::make_shared<ProfileGroupStorage>(this, parent,
                                                           "hostname"))
         {
-            m_newdStorage = true;
             setLabel(QObject::tr("Hostname"));
         }
         void fillSelections();
@@ -83,10 +80,9 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit CardInfo(const ProfileGroup &parent) :
-            MythUIComboBoxSetting(new ProfileGroupStorage(this, parent,
+            MythUIComboBoxSetting(std::make_shared<ProfileGroupStorage>(this, parent,
                                                           "cardtype"))
         {
-            m_newdStorage = true;
             setLabel(QObject::tr("Card-Type"));
         }
     };

--- a/mythtv/libs/libmythtv/profilegroup.h
+++ b/mythtv/libs/libmythtv/profilegroup.h
@@ -45,9 +45,14 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit Is_default(const ProfileGroup &parent) :
-            StandardSetting(std::make_shared<ProfileGroupStorage>(this, parent, "is_default"))
+            StandardSetting(new ProfileGroupStorage(this, parent, "is_default"))
         {
             setVisible(false);
+        }
+
+        ~Is_default()
+        {
+            delete GetStorage();
         }
 
         void edit(MythScreenType * /*screen*/) override { } // StandardSetting
@@ -58,9 +63,14 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit Name(const ProfileGroup &parent) :
-            MythUITextEditSetting(std::make_shared<ProfileGroupStorage>(this, parent, "name"))
+            MythUITextEditSetting(new ProfileGroupStorage(this, parent, "name"))
         {
             setLabel(QObject::tr("Profile Group Name"));
+        }
+
+        ~Name()
+        {
+            delete GetStorage();
         }
     };
 
@@ -68,10 +78,15 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit HostName(const ProfileGroup &parent) :
-            MythUIComboBoxSetting(std::make_shared<ProfileGroupStorage>(this, parent,
+            MythUIComboBoxSetting(new ProfileGroupStorage(this, parent,
                                                           "hostname"))
         {
             setLabel(QObject::tr("Hostname"));
+        }
+
+        ~HostName()
+        {
+            delete GetStorage();
         }
         void fillSelections();
     };
@@ -80,10 +95,15 @@ class ProfileGroup : public GroupSetting
     {
       public:
         explicit CardInfo(const ProfileGroup &parent) :
-            MythUIComboBoxSetting(std::make_shared<ProfileGroupStorage>(this, parent,
+            MythUIComboBoxSetting(new ProfileGroupStorage(this, parent,
                                                           "cardtype"))
         {
             setLabel(QObject::tr("Card-Type"));
+        }
+
+        ~CardInfo()
+        {
+            delete GetStorage();
         }
     };
 

--- a/mythtv/libs/libmythtv/profilegroup.h
+++ b/mythtv/libs/libmythtv/profilegroup.h
@@ -47,6 +47,7 @@ class ProfileGroup : public GroupSetting
         explicit Is_default(const ProfileGroup &parent) :
             StandardSetting(new ProfileGroupStorage(this, parent, "is_default"))
         {
+            m_newdStorage = true;
             setVisible(false);
         }
 
@@ -60,6 +61,7 @@ class ProfileGroup : public GroupSetting
         explicit Name(const ProfileGroup &parent) :
             MythUITextEditSetting(new ProfileGroupStorage(this, parent, "name"))
         {
+            m_newdStorage = true;
             setLabel(QObject::tr("Profile Group Name"));
         }
     };
@@ -71,6 +73,7 @@ class ProfileGroup : public GroupSetting
             MythUIComboBoxSetting(new ProfileGroupStorage(this, parent,
                                                           "hostname"))
         {
+            m_newdStorage = true;
             setLabel(QObject::tr("Hostname"));
         }
         void fillSelections();
@@ -83,6 +86,7 @@ class ProfileGroup : public GroupSetting
             MythUIComboBoxSetting(new ProfileGroupStorage(this, parent,
                                                           "cardtype"))
         {
+            m_newdStorage = true;
             setLabel(QObject::tr("Card-Type"));
         }
     };

--- a/mythtv/libs/libmythtv/recordingprofile.h
+++ b/mythtv/libs/libmythtv/recordingprofile.h
@@ -55,9 +55,8 @@ class MTV_PUBLIC RecordingProfile : public GroupSetting
       public:
         explicit Name(const RecordingProfile &parent):
             MythUITextEditSetting(
-                new RecordingProfileStorage(this, parent, "name"))
+                std::make_shared<RecordingProfileStorage>(this, parent, "name"))
         {
-            m_newdStorage = true;
             setReadOnly(true);
             setLabel(QObject::tr("Profile name"));
             setName("name");

--- a/mythtv/libs/libmythtv/recordingprofile.h
+++ b/mythtv/libs/libmythtv/recordingprofile.h
@@ -57,6 +57,7 @@ class MTV_PUBLIC RecordingProfile : public GroupSetting
             MythUITextEditSetting(
                 new RecordingProfileStorage(this, parent, "name"))
         {
+            m_newdStorage = true;
             setReadOnly(true);
             setLabel(QObject::tr("Profile name"));
             setName("name");

--- a/mythtv/libs/libmythtv/recordingprofile.h
+++ b/mythtv/libs/libmythtv/recordingprofile.h
@@ -55,11 +55,16 @@ class MTV_PUBLIC RecordingProfile : public GroupSetting
       public:
         explicit Name(const RecordingProfile &parent):
             MythUITextEditSetting(
-                std::make_shared<RecordingProfileStorage>(this, parent, "name"))
+                new RecordingProfileStorage(this, parent, "name"))
         {
             setReadOnly(true);
             setLabel(QObject::tr("Profile name"));
             setName("name");
+        }
+
+        ~Name()
+        {
+            delete GetStorage();
         }
 
       // -=>TODO: Qt4 can't have nested classes with slots/signals

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -172,7 +172,7 @@ class InstanceCount : public MythUISpinBoxSetting
 {
   public:
     explicit InstanceCount(const CardInput &parent) :
-        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "reclimit"),
+        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "reclimit"),
                              1, 10, 1)
     {
         setLabel(QObject::tr("Max recordings"));
@@ -186,13 +186,18 @@ class InstanceCount : public MythUISpinBoxSetting
                 "program on a single channel."
                 ));
     };
+
+    ~InstanceCount()
+    {
+        delete GetStorage();
+    }
 };
 
 class SchedGroup : public MythUICheckBoxSetting
 {
   public:
     explicit SchedGroup(const CardInput &parent) :
-        MythUICheckBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "schedgroup"))
+        MythUICheckBoxSetting(new CardInputDBStorage(this, parent, "schedgroup"))
     {
         setLabel(QObject::tr("Schedule as group"));
         setValue(true);
@@ -205,6 +210,11 @@ class SchedGroup : public MythUICheckBoxSetting
                 "load."
                 ));
     };
+
+    ~SchedGroup()
+    {
+        delete GetStorage();
+    }
 };
 
 QString VideoSourceDBStorage::GetWhereClause(MSqlBindings &bindings) const
@@ -261,12 +271,17 @@ class XMLTVGrabber : public MythUIComboBoxSetting
 {
   public:
     explicit XMLTVGrabber(const VideoSource &parent) :
-        MythUIComboBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent,
+        MythUIComboBoxSetting(new VideoSourceDBStorage(this, parent,
                                                        "xmltvgrabber")),
         m_parent(parent)
     {
         setLabel(QObject::tr("Listings grabber"));
     };
+
+    ~XMLTVGrabber()
+    {
+        delete GetStorage();
+    }
 
     void Load(void) override // StandardSetting
     {
@@ -393,9 +408,14 @@ class CaptureCardSpinBoxSetting : public MythUISpinBoxSetting
                               std::chrono::milliseconds max_val,
                               std::chrono::milliseconds step,
                               const QString &setting) :
-        MythUISpinBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent, setting),
+        MythUISpinBoxSetting(new CaptureCardDBStorage(this, parent, setting),
                              min_val.count(), max_val.count(), step.count())
     {
+    }
+
+    ~CaptureCardSpinBoxSetting()
+    {
+        delete GetStorage();
     }
     // Handles integer milliseconds (compiler converts seconds to milliseconds)
     void setValueMs (std::chrono::milliseconds newValue)
@@ -411,8 +431,13 @@ class CaptureCardTextEditSetting : public MythUITextEditSetting
   public:
     CaptureCardTextEditSetting(const CaptureCard &parent,
                                const QString &setting) :
-        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, setting))
+        MythUITextEditSetting(new CaptureCardDBStorage(this, parent, setting))
     {
+    }
+
+    ~CaptureCardTextEditSetting()
+    {
+        delete GetStorage();
     }
 };
 
@@ -420,7 +445,7 @@ class ScanFrequencyStart : public MythUITextEditSetting
 {
   public:
     explicit ScanFrequencyStart(const VideoSource &parent) :
-        MythUITextEditSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "scanfrequency"))
+        MythUITextEditSetting(new VideoSourceDBStorage(this, parent, "scanfrequency"))
     {
        setLabel(QObject::tr("Scan Frequency"));
        setHelpText(QObject::tr("The frequency to start scanning this video source. "
@@ -428,13 +453,18 @@ class ScanFrequencyStart : public MythUITextEditSetting
                                "Frequency value in Hz for DVB-T/T2/C, in kHz for DVB-S/S2. "
                                "Leave at 0 if not known. "));
     };
+
+    ~ScanFrequencyStart()
+    {
+        delete GetStorage();
+    }
 };
 
 class DVBNetID : public MythUISpinBoxSetting
 {
   public:
     DVBNetID(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "dvb_nit_id"),
+        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "dvb_nit_id"),
                              min_val, 0xffff, 1)
     {
        setLabel(QObject::tr("Network ID"));
@@ -445,13 +475,18 @@ class DVBNetID : public MythUISpinBoxSetting
                                "enter it here. Leave it at -1 otherwise."));
        setValue(value);
     };
+
+    ~DVBNetID()
+    {
+        delete GetStorage();
+    }
 };
 
 class BouquetID : public MythUISpinBoxSetting
 {
   public:
     BouquetID(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "bouquet_id"),
+        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "bouquet_id"),
                              min_val, 0xffff, 1)
     {
        setLabel(QObject::tr("Bouquet ID"));
@@ -462,13 +497,18 @@ class BouquetID : public MythUISpinBoxSetting
                                "See the MythTV Wiki https://www.mythtv.org/wiki/DVB_UK."));
        setValue(value);
     };
+
+    ~BouquetID()
+    {
+        delete GetStorage();
+    }
 };
 
 class RegionID : public MythUISpinBoxSetting
 {
   public:
     RegionID(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "region_id"),
+        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "region_id"),
                              min_val, 100, 1)
     {
        setLabel(QObject::tr("Region ID"));
@@ -479,13 +519,18 @@ class RegionID : public MythUISpinBoxSetting
                                "See the MythTV Wiki https://www.mythtv.org/wiki/DVB_UK."));
        setValue(value);
     };
+
+    ~RegionID()
+    {
+        delete GetStorage();
+    }
 };
 
 class LCNOffset : public MythUISpinBoxSetting
 {
   public:
     LCNOffset(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "lcnoffset"),
+        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "lcnoffset"),
                              min_val, 20000, 100)
     {
        setLabel(QObject::tr("Logical Channel Number Offset"));
@@ -496,10 +541,15 @@ class LCNOffset : public MythUISpinBoxSetting
                                "or if the video sources do not have DVB logical channel numbers."));
        setValue(value);
     };
+
+    ~LCNOffset()
+    {
+        delete GetStorage();
+    }
 };
 
 FreqTableSelector::FreqTableSelector(const VideoSource &parent) :
-    MythUIComboBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "freqtable"))
+    MythUIComboBoxSetting(new VideoSourceDBStorage(this, parent, "freqtable"))
 {
     setLabel(QObject::tr("Channel frequency table"));
     addSelection("default");
@@ -510,6 +560,11 @@ FreqTableSelector::FreqTableSelector(const VideoSource &parent) :
     setHelpText(QObject::tr("Use default unless this source uses a "
                 "different frequency table than the system wide table "
                 "defined in the General settings."));
+}
+
+FreqTableSelector::~FreqTableSelector()
+{
+    delete GetStorage();
 }
 
 TransFreqTableSelector::TransFreqTableSelector(uint _sourceid) :
@@ -595,13 +650,18 @@ class UseEIT : public MythUICheckBoxSetting
 {
   public:
     explicit UseEIT(const VideoSource &parent) :
-        MythUICheckBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "useeit"))
+        MythUICheckBoxSetting(new VideoSourceDBStorage(this, parent, "useeit"))
     {
         setLabel(QObject::tr("Perform EIT scan"));
         setHelpText(QObject::tr(
                         "If enabled, program guide data for channels on this "
                         "source will be updated with data provided by the "
                         "channels themselves 'Over-the-Air'."));
+    }
+
+    ~UseEIT()
+    {
+        delete GetStorage();
     }
 };
 
@@ -976,7 +1036,7 @@ class CommandPath : public MythUITextEditSetting
 {
   public:
     explicit CommandPath(const CaptureCard &parent) :
-        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
+        MythUITextEditSetting(new CaptureCardDBStorage(this, parent,
                                                        "videodevice"))
     {
         setLabel(QObject::tr(""));
@@ -984,6 +1044,11 @@ class CommandPath : public MythUITextEditSetting
         setHelpText(QObject::tr("Specify the command to run, with any "
                                 "needed arguments."));
     };
+
+    ~CommandPath()
+    {
+        delete GetStorage();
+    }
 };
 
 class FileDevice : public MythUIFileBrowserSetting
@@ -991,11 +1056,16 @@ class FileDevice : public MythUIFileBrowserSetting
   public:
     explicit FileDevice(const CaptureCard &parent) :
         MythUIFileBrowserSetting(
-            std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")
+            new CaptureCardDBStorage(this, parent, "videodevice")
             /* mustexist, false */)
     {
         setLabel(QObject::tr("File path"));
     };
+
+    ~FileDevice()
+    {
+        delete GetStorage();
+    }
 };
 
 class AudioDevice : public CaptureCardComboBoxSetting
@@ -1093,7 +1163,7 @@ class SkipBtAudio : public MythUICheckBoxSetting
 {
   public:
     explicit SkipBtAudio(const CaptureCard &parent) :
-        MythUICheckBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
+        MythUICheckBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "skipbtaudio"))
     {
         setLabel(QObject::tr("Do not adjust volume"));
@@ -1102,6 +1172,11 @@ class SkipBtAudio : public MythUICheckBoxSetting
                         "DVB-T cards such as the AverTV DVB-T which "
                         "require the audio volume to be left alone."));
     };
+
+    ~SkipBtAudio()
+    {
+        delete GetStorage();
+    }
 };
 
 class DVBCardNum : public CaptureCardComboBoxSetting
@@ -1205,7 +1280,7 @@ class DVBNoSeqStart : public MythUICheckBoxSetting
   public:
     explicit DVBNoSeqStart(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_wait_for_seqstart"))
+            new CaptureCardDBStorage(this, parent, "dvb_wait_for_seqstart"))
     {
         setLabel(QObject::tr("Wait for SEQ start header"));
         setValue(true);
@@ -1213,6 +1288,11 @@ class DVBNoSeqStart : public MythUICheckBoxSetting
             QObject::tr("If enabled, drop packets from the start of a DVB "
                         "recording until a sequence start header is seen."));
     };
+
+    ~DVBNoSeqStart()
+    {
+        delete GetStorage();
+    }
 };
 
 class DVBOnDemand : public MythUICheckBoxSetting
@@ -1220,7 +1300,7 @@ class DVBOnDemand : public MythUICheckBoxSetting
   public:
     explicit DVBOnDemand(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_on_demand"))
+            new CaptureCardDBStorage(this, parent, "dvb_on_demand"))
     {
         setLabel(QObject::tr("Open DVB card on demand"));
         setValue(true);
@@ -1228,6 +1308,11 @@ class DVBOnDemand : public MythUICheckBoxSetting
             QObject::tr("If enabled, only open the DVB card when required, "
                         "leaving it free for other programs at other times."));
     };
+
+    ~DVBOnDemand()
+    {
+        delete GetStorage();
+    }
 };
 
 class DVBEITScan : public MythUICheckBoxSetting
@@ -1235,7 +1320,7 @@ class DVBEITScan : public MythUICheckBoxSetting
   public:
     explicit DVBEITScan(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_eitscan"))
+            new CaptureCardDBStorage(this, parent, "dvb_eitscan"))
     {
         setLabel(QObject::tr("Use DVB card for active EIT scan"));
         setValue(true);
@@ -1244,6 +1329,11 @@ class DVBEITScan : public MythUICheckBoxSetting
                         "program data (EIT). When this option is enabled "
                         "the DVB card is constantly in use."));
     };
+
+    ~DVBEITScan()
+    {
+        delete GetStorage();
+    }
 };
 
 class DVBTuningDelay : public CaptureCardSpinBoxSetting
@@ -1344,12 +1434,17 @@ class FirewireConnection : public MythUIComboBoxSetting
 {
   public:
     explicit FirewireConnection(const CaptureCard &parent) :
-        MythUIComboBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
+        MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "firewire_connection"))
     {
         setLabel(QObject::tr("Connection Type"));
         addSelection(QObject::tr("Point to Point"),"0");
         addSelection(QObject::tr("Broadcast"),"1");
+    }
+
+    ~FirewireConnection()
+    {
+        delete GetStorage();
     }
 };
 
@@ -1357,7 +1452,7 @@ class FirewireSpeed : public MythUIComboBoxSetting
 {
   public:
     explicit FirewireSpeed(const CaptureCard &parent) :
-        MythUIComboBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
+        MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "firewire_speed"))
     {
         setLabel(QObject::tr("Speed"));
@@ -1365,6 +1460,11 @@ class FirewireSpeed : public MythUIComboBoxSetting
         addSelection(QObject::tr("200Mbps"),"1");
         addSelection(QObject::tr("400Mbps"),"2");
         addSelection(QObject::tr("800Mbps"),"3");
+    }
+
+    ~FirewireSpeed()
+    {
+        delete GetStorage();
     }
 };
 
@@ -1406,11 +1506,16 @@ static void FirewireConfigurationGroup(CaptureCard& parent, CardType& cardtype)
 HDHomeRunDeviceID::HDHomeRunDeviceID(const CaptureCard &parent,
                                      HDHomeRunConfigurationGroup &_group) :
     MythUITextEditSetting(
-        std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")),
+        new CaptureCardDBStorage(this, parent, "videodevice")),
     m_group(_group)
 {
     setVisible(false);
 };
+
+HDHomeRunDeviceID::~HDHomeRunDeviceID()
+{
+    delete GetStorage();
+}
 
 void HDHomeRunDeviceID::Load(void)
 {
@@ -1429,7 +1534,7 @@ class HDHomeRunEITScan : public MythUICheckBoxSetting
   public:
     explicit HDHomeRunEITScan(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_eitscan"))
+            new CaptureCardDBStorage(this, parent, "dvb_eitscan"))
     {
         setLabel(QObject::tr("Use HDHomeRun for active EIT scan"));
         setValue(true);
@@ -1438,6 +1543,11 @@ class HDHomeRunEITScan : public MythUICheckBoxSetting
                         "program data (EIT). When this option is enabled "
                         "the HDHomeRun is constantly in use."));
     };
+
+    ~HDHomeRunEITScan()
+    {
+        delete GetStorage();
+    }
 };
 
 
@@ -1629,11 +1739,16 @@ void VBoxTunerIndex::UpdateDevices(const QString &v)
 }
 
 VBoxDeviceID::VBoxDeviceID(const CaptureCard &parent) :
-    MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice"))
+    MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice"))
 {
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of VBox device"));
     setReadOnly(true);
+}
+
+VBoxDeviceID::~VBoxDeviceID()
+{
+    delete GetStorage();
 }
 
 void VBoxDeviceID::SetIP(const QString &ip)
@@ -2087,11 +2202,16 @@ void CetonSetting::LoadValue(const QString &value)
 }
 
 CetonDeviceID::CetonDeviceID(const CaptureCard &parent) :
-    MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")),
+    MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice")),
     m_parent(parent)
 {
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of Ceton device"));
+}
+
+CetonDeviceID::~CetonDeviceID()
+{
+    delete GetStorage();
 }
 
 void CetonDeviceID::SetIP(const QString &ip)
@@ -2168,12 +2288,17 @@ class SchedGroupFalse : public MythUICheckBoxSetting
 {
   public:
     explicit SchedGroupFalse(const CaptureCard &parent) :
-        MythUICheckBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
+        MythUICheckBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "schedgroup"))
     {
         setValue(false);
         setVisible(false);
     };
+
+    ~SchedGroupFalse()
+    {
+        delete GetStorage();
+    }
 };
 
 V4LConfigurationGroup::V4LConfigurationGroup(CaptureCard& parent,
@@ -2785,20 +2910,30 @@ void CardType::fillSelections(MythUIComboBoxSetting* setting)
 }
 
 CaptureCard::Hostname::Hostname(const CaptureCard &parent) :
-    StandardSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "hostname"))
+    StandardSetting(new CaptureCardDBStorage(this, parent, "hostname"))
 {
     setVisible(false);
     setValue(gCoreContext->GetHostName());
+}
+
+CaptureCard::Hostname::~Hostname()
+{
+    delete GetStorage();
 }
 
 class InputName : public MythUIComboBoxSetting
 {
   public:
     explicit InputName(const CardInput &parent) :
-        MythUIComboBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "inputname"))
+        MythUIComboBoxSetting(new CardInputDBStorage(this, parent, "inputname"))
     {
         setLabel(QObject::tr("Input name"));
     };
+
+    ~InputName()
+    {
+        delete GetStorage();
+    }
 
     void Load(void) override // StandardSetting
     {
@@ -2844,8 +2979,7 @@ class InputDisplayName : public MythUITextEditSetting
 
   public:
     explicit InputDisplayName(const CardInput &parent) :
-        MythUITextEditSetting(std::make_shared<CardInputDBStorage>(this, parent,
-                    "displayname")), m_parent(parent)
+        MythUITextEditSetting(new CardInputDBStorage(this, parent, "displayname")), m_parent(parent)
     {
         setLabel(QObject::tr("Display name"));
         setHelpText(QObject::tr(
@@ -2854,6 +2988,11 @@ class InputDisplayName : public MythUITextEditSetting
                         "characters are unique for each input or use a "
                         "slash ('/') to designate the unique portion."));
     };
+
+    ~InputDisplayName()
+    {
+        delete GetStorage();
+    }
     void Load(void) override {
         MythUITextEditSetting::Load();
         if (getValue().isEmpty())
@@ -2867,8 +3006,13 @@ class CardInputComboBoxSetting : public MythUIComboBoxSetting
 {
   public:
     CardInputComboBoxSetting(const CardInput &parent, const QString &setting) :
-        MythUIComboBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, setting))
+        MythUIComboBoxSetting(new CardInputDBStorage(this, parent, setting))
     {
+    }
+
+    ~CardInputComboBoxSetting()
+    {
+        delete GetStorage();
     }
 };
 
@@ -3044,7 +3188,7 @@ class ExternalChannelCommand : public MythUITextEditSetting
 {
   public:
     explicit ExternalChannelCommand(const CardInput &parent) :
-        MythUITextEditSetting(std::make_shared<CardInputDBStorage>(this, parent, "externalcommand"))
+        MythUITextEditSetting(new CardInputDBStorage(this, parent, "externalcommand"))
     {
         setLabel(QObject::tr("External channel change command"));
         setValue("");
@@ -3053,13 +3197,18 @@ class ExternalChannelCommand : public MythUITextEditSetting
                     "tuner device such as a cable box. The first argument "
                     "will be the channel number."));
     };
+
+    ~ExternalChannelCommand()
+    {
+        delete GetStorage();
+    }
 };
 
 class PresetTuner : public MythUITextEditSetting
 {
   public:
     explicit PresetTuner(const CardInput &parent) :
-        MythUITextEditSetting(std::make_shared<CardInputDBStorage>(this, parent, "tunechan"))
+        MythUITextEditSetting(new CardInputDBStorage(this, parent, "tunechan"))
     {
         setLabel(QObject::tr("Preset tuner to channel"));
         setValue("");
@@ -3068,6 +3217,11 @@ class PresetTuner : public MythUITextEditSetting
                     "If so, you will need to specify the preset channel for "
                     "the signal (normally 3 or 4)."));
     };
+
+    ~PresetTuner()
+    {
+        delete GetStorage();
+    }
 };
 
 void StartingChannel::SetSourceID(const QString &sourceid)
@@ -3115,7 +3269,7 @@ class InputPriority : public MythUISpinBoxSetting
 {
   public:
     explicit InputPriority(const CardInput &parent) :
-        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "recpriority"),
+        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "recpriority"),
                              -99, 99, 1)
     {
         setLabel(QObject::tr("Input priority"));
@@ -3125,13 +3279,18 @@ class InputPriority : public MythUISpinBoxSetting
                     "at a later time so that it can record on an input with "
                     "a higher value."));
     };
+
+    ~InputPriority()
+    {
+        delete GetStorage();
+    }
 };
 
 class ScheduleOrder : public MythUISpinBoxSetting
 {
   public:
     ScheduleOrder(const CardInput &parent, int _value) :
-        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "schedorder"),
+        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "schedorder"),
                              0, 99, 1)
     {
         setLabel(QObject::tr("Schedule order"));
@@ -3142,13 +3301,18 @@ class ScheduleOrder : public MythUISpinBoxSetting
                                 "Setting this value to zero will make the "
                                 "input unavailable to the scheduler."));
     };
+
+    ~ScheduleOrder()
+    {
+        delete GetStorage();
+    }
 };
 
 class LiveTVOrder : public MythUISpinBoxSetting
 {
   public:
     LiveTVOrder(const CardInput &parent, int _value) :
-        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "livetvorder"),
+        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "livetvorder"),
                              0, 99, 1)
     {
         setLabel(QObject::tr("Live TV order"));
@@ -3161,13 +3325,18 @@ class LiveTVOrder : public MythUISpinBoxSetting
                                 "Setting this value to zero will make the "
                                 "input unavailable to live TV."));
     };
+
+    ~LiveTVOrder()
+    {
+        delete GetStorage();
+    }
 };
 
 class DishNetEIT : public MythUICheckBoxSetting
 {
   public:
     explicit DishNetEIT(const CardInput &parent) :
-        MythUICheckBoxSetting(std::make_shared<CardInputDBStorage>(this, parent,
+        MythUICheckBoxSetting(new CardInputDBStorage(this, parent,
                                                      "dishnet_eit"))
     {
         setLabel(QObject::tr("Use DishNet long-term EIT data"));
@@ -3178,6 +3347,11 @@ class DishNetEIT : public MythUICheckBoxSetting
                 "you may wish to enable this feature. For best results, "
                 "enable general EIT collection as well."));
     };
+
+    ~DishNetEIT()
+    {
+        delete GetStorage();
+    }
 };
 
 CardInput::CardInput(const QString & cardtype, const QString & device,
@@ -4060,7 +4234,7 @@ class DiSEqCPosition : public MythUISpinBoxSetting
 {
   public:
     explicit DiSEqCPosition(const CaptureCard &parent, int value, int min_val) :
-        MythUISpinBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_diseqc_type"),
+        MythUISpinBoxSetting(new CaptureCardDBStorage(this, parent, "dvb_diseqc_type"),
                              min_val, 0xff, 1)
     {
        setLabel(QObject::tr("DiSEqC position"));
@@ -4071,6 +4245,11 @@ class DiSEqCPosition : public MythUISpinBoxSetting
                                "the SatIP tune command."));
        setValue(value);
     };
+
+    ~DiSEqCPosition()
+    {
+        delete GetStorage();
+    }
 };
 
 SatIPConfigurationGroup::SatIPConfigurationGroup
@@ -4231,7 +4410,7 @@ void SatIPDeviceIDList::fillSelections(const QString &cur)
 };
 
 SatIPDeviceID::SatIPDeviceID(const CaptureCard &parent) :
-    MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")),
+    MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice")),
     m_parent(parent)
 {
     setLabel(tr("Device ID"));
@@ -4239,6 +4418,11 @@ SatIPDeviceID::SatIPDeviceID(const CaptureCard &parent) :
     setEnabled(true);
     setReadOnly(true);
 };
+
+SatIPDeviceID::~SatIPDeviceID()
+{
+    delete GetStorage();
+}
 
 void SatIPDeviceID::Load(void)
 {

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -172,10 +172,9 @@ class InstanceCount : public MythUISpinBoxSetting
 {
   public:
     explicit InstanceCount(const CardInput &parent) :
-        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "reclimit"),
+        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "reclimit"),
                              1, 10, 1)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Max recordings"));
         setValue(1);
         setHelpText(
@@ -193,9 +192,8 @@ class SchedGroup : public MythUICheckBoxSetting
 {
   public:
     explicit SchedGroup(const CardInput &parent) :
-        MythUICheckBoxSetting(new CardInputDBStorage(this, parent, "schedgroup"))
+        MythUICheckBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "schedgroup"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Schedule as group"));
         setValue(true);
         setHelpText(
@@ -263,11 +261,10 @@ class XMLTVGrabber : public MythUIComboBoxSetting
 {
   public:
     explicit XMLTVGrabber(const VideoSource &parent) :
-        MythUIComboBoxSetting(new VideoSourceDBStorage(this, parent,
+        MythUIComboBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent,
                                                        "xmltvgrabber")),
         m_parent(parent)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Listings grabber"));
     };
 
@@ -396,10 +393,9 @@ class CaptureCardSpinBoxSetting : public MythUISpinBoxSetting
                               std::chrono::milliseconds max_val,
                               std::chrono::milliseconds step,
                               const QString &setting) :
-        MythUISpinBoxSetting(new CaptureCardDBStorage(this, parent, setting),
+        MythUISpinBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent, setting),
                              min_val.count(), max_val.count(), step.count())
     {
-        m_newdStorage = true;
     }
     // Handles integer milliseconds (compiler converts seconds to milliseconds)
     void setValueMs (std::chrono::milliseconds newValue)
@@ -415,9 +411,8 @@ class CaptureCardTextEditSetting : public MythUITextEditSetting
   public:
     CaptureCardTextEditSetting(const CaptureCard &parent,
                                const QString &setting) :
-        MythUITextEditSetting(new CaptureCardDBStorage(this, parent, setting))
+        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, setting))
     {
-        m_newdStorage = true;
     }
 };
 
@@ -425,9 +420,8 @@ class ScanFrequencyStart : public MythUITextEditSetting
 {
   public:
     explicit ScanFrequencyStart(const VideoSource &parent) :
-        MythUITextEditSetting(new VideoSourceDBStorage(this, parent, "scanfrequency"))
+        MythUITextEditSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "scanfrequency"))
     {
-       m_newdStorage = true;
        setLabel(QObject::tr("Scan Frequency"));
        setHelpText(QObject::tr("The frequency to start scanning this video source. "
                                "This is then default for 'Full Scan (Tuned)' channel scanning. "
@@ -440,10 +434,9 @@ class DVBNetID : public MythUISpinBoxSetting
 {
   public:
     DVBNetID(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "dvb_nit_id"),
+        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "dvb_nit_id"),
                              min_val, 0xffff, 1)
     {
-       m_newdStorage = true;
        setLabel(QObject::tr("Network ID"));
        //: Network_ID is the name of an identifier in the DVB's Service
        //: Information standard specification.
@@ -458,10 +451,9 @@ class BouquetID : public MythUISpinBoxSetting
 {
   public:
     BouquetID(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "bouquet_id"),
+        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "bouquet_id"),
                              min_val, 0xffff, 1)
     {
-       m_newdStorage = true;
        setLabel(QObject::tr("Bouquet ID"));
        setHelpText(QObject::tr("Bouquet ID for Freesat or Sky on satellite Astra-2 28.2E. "
                                "Leave this at 0 if you do not receive this satellite. "
@@ -476,10 +468,9 @@ class RegionID : public MythUISpinBoxSetting
 {
   public:
     RegionID(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "region_id"),
+        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "region_id"),
                              min_val, 100, 1)
     {
-       m_newdStorage = true;
        setLabel(QObject::tr("Region ID"));
        setHelpText(QObject::tr("Region ID for Freesat or Sky on satellite Astra-2 28.2E. "
                                "Leave this at 0 you do not receive this satellite.  "
@@ -494,10 +485,9 @@ class LCNOffset : public MythUISpinBoxSetting
 {
   public:
     LCNOffset(const VideoSource &parent, signed int value, signed int min_val) :
-        MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "lcnoffset"),
+        MythUISpinBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "lcnoffset"),
                              min_val, 20000, 100)
     {
-       m_newdStorage = true;
        setLabel(QObject::tr("Logical Channel Number Offset"));
        setHelpText(QObject::tr("The offset is added to each logical channel number found "
                                "during a scan of a DVB video source. This makes it possible "
@@ -509,9 +499,8 @@ class LCNOffset : public MythUISpinBoxSetting
 };
 
 FreqTableSelector::FreqTableSelector(const VideoSource &parent) :
-    MythUIComboBoxSetting(new VideoSourceDBStorage(this, parent, "freqtable"))
+    MythUIComboBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "freqtable"))
 {
-    m_newdStorage = true;
     setLabel(QObject::tr("Channel frequency table"));
     addSelection("default");
 
@@ -606,9 +595,8 @@ class UseEIT : public MythUICheckBoxSetting
 {
   public:
     explicit UseEIT(const VideoSource &parent) :
-        MythUICheckBoxSetting(new VideoSourceDBStorage(this, parent, "useeit"))
+        MythUICheckBoxSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "useeit"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Perform EIT scan"));
         setHelpText(QObject::tr(
                         "If enabled, program guide data for channels on this "
@@ -988,10 +976,9 @@ class CommandPath : public MythUITextEditSetting
 {
   public:
     explicit CommandPath(const CaptureCard &parent) :
-        MythUITextEditSetting(new CaptureCardDBStorage(this, parent,
+        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
                                                        "videodevice"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr(""));
         setValue("");
         setHelpText(QObject::tr("Specify the command to run, with any "
@@ -1004,10 +991,9 @@ class FileDevice : public MythUIFileBrowserSetting
   public:
     explicit FileDevice(const CaptureCard &parent) :
         MythUIFileBrowserSetting(
-            new CaptureCardDBStorage(this, parent, "videodevice")
+            std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")
             /* mustexist, false */)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("File path"));
     };
 };
@@ -1107,10 +1093,9 @@ class SkipBtAudio : public MythUICheckBoxSetting
 {
   public:
     explicit SkipBtAudio(const CaptureCard &parent) :
-        MythUICheckBoxSetting(new CaptureCardDBStorage(this, parent,
+        MythUICheckBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
                                                        "skipbtaudio"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Do not adjust volume"));
         setHelpText(
             QObject::tr("Enable this option for budget BT878 based "
@@ -1220,9 +1205,8 @@ class DVBNoSeqStart : public MythUICheckBoxSetting
   public:
     explicit DVBNoSeqStart(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            new CaptureCardDBStorage(this, parent, "dvb_wait_for_seqstart"))
+            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_wait_for_seqstart"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Wait for SEQ start header"));
         setValue(true);
         setHelpText(
@@ -1236,9 +1220,8 @@ class DVBOnDemand : public MythUICheckBoxSetting
   public:
     explicit DVBOnDemand(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            new CaptureCardDBStorage(this, parent, "dvb_on_demand"))
+            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_on_demand"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Open DVB card on demand"));
         setValue(true);
         setHelpText(
@@ -1252,9 +1235,8 @@ class DVBEITScan : public MythUICheckBoxSetting
   public:
     explicit DVBEITScan(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            new CaptureCardDBStorage(this, parent, "dvb_eitscan"))
+            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_eitscan"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Use DVB card for active EIT scan"));
         setValue(true);
         setHelpText(
@@ -1362,10 +1344,9 @@ class FirewireConnection : public MythUIComboBoxSetting
 {
   public:
     explicit FirewireConnection(const CaptureCard &parent) :
-        MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent,
+        MythUIComboBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
                                                        "firewire_connection"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Connection Type"));
         addSelection(QObject::tr("Point to Point"),"0");
         addSelection(QObject::tr("Broadcast"),"1");
@@ -1376,10 +1357,9 @@ class FirewireSpeed : public MythUIComboBoxSetting
 {
   public:
     explicit FirewireSpeed(const CaptureCard &parent) :
-        MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent,
+        MythUIComboBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
                                                        "firewire_speed"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Speed"));
         addSelection(QObject::tr("100Mbps"),"0");
         addSelection(QObject::tr("200Mbps"),"1");
@@ -1426,10 +1406,9 @@ static void FirewireConfigurationGroup(CaptureCard& parent, CardType& cardtype)
 HDHomeRunDeviceID::HDHomeRunDeviceID(const CaptureCard &parent,
                                      HDHomeRunConfigurationGroup &_group) :
     MythUITextEditSetting(
-        new CaptureCardDBStorage(this, parent, "videodevice")),
+        std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")),
     m_group(_group)
 {
-    m_newdStorage = true;
     setVisible(false);
 };
 
@@ -1450,9 +1429,8 @@ class HDHomeRunEITScan : public MythUICheckBoxSetting
   public:
     explicit HDHomeRunEITScan(const CaptureCard &parent) :
         MythUICheckBoxSetting(
-            new CaptureCardDBStorage(this, parent, "dvb_eitscan"))
+            std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_eitscan"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Use HDHomeRun for active EIT scan"));
         setValue(true);
         setHelpText(
@@ -1651,9 +1629,8 @@ void VBoxTunerIndex::UpdateDevices(const QString &v)
 }
 
 VBoxDeviceID::VBoxDeviceID(const CaptureCard &parent) :
-    MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice"))
+    MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice"))
 {
-    m_newdStorage = true;
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of VBox device"));
     setReadOnly(true);
@@ -2110,10 +2087,9 @@ void CetonSetting::LoadValue(const QString &value)
 }
 
 CetonDeviceID::CetonDeviceID(const CaptureCard &parent) :
-    MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice")),
+    MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")),
     m_parent(parent)
 {
-    m_newdStorage = true;
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of Ceton device"));
 }
@@ -2192,10 +2168,9 @@ class SchedGroupFalse : public MythUICheckBoxSetting
 {
   public:
     explicit SchedGroupFalse(const CaptureCard &parent) :
-        MythUICheckBoxSetting(new CaptureCardDBStorage(this, parent,
+        MythUICheckBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
                                                        "schedgroup"))
     {
-        m_newdStorage = true;
         setValue(false);
         setVisible(false);
     };
@@ -2810,9 +2785,8 @@ void CardType::fillSelections(MythUIComboBoxSetting* setting)
 }
 
 CaptureCard::Hostname::Hostname(const CaptureCard &parent) :
-    StandardSetting(new CaptureCardDBStorage(this, parent, "hostname"))
+    StandardSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "hostname"))
 {
-    m_newdStorage = true;
     setVisible(false);
     setValue(gCoreContext->GetHostName());
 }
@@ -2821,9 +2795,8 @@ class InputName : public MythUIComboBoxSetting
 {
   public:
     explicit InputName(const CardInput &parent) :
-        MythUIComboBoxSetting(new CardInputDBStorage(this, parent, "inputname"))
+        MythUIComboBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "inputname"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Input name"));
     };
 
@@ -2871,9 +2844,9 @@ class InputDisplayName : public MythUITextEditSetting
 
   public:
     explicit InputDisplayName(const CardInput &parent) :
-        MythUITextEditSetting(new CardInputDBStorage(this, parent, "displayname")), m_parent(parent)
+        MythUITextEditSetting(std::make_shared<CardInputDBStorage>(this, parent,
+                    "displayname")), m_parent(parent)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Display name"));
         setHelpText(QObject::tr(
                         "This name is displayed on screen when Live TV begins "
@@ -2894,9 +2867,8 @@ class CardInputComboBoxSetting : public MythUIComboBoxSetting
 {
   public:
     CardInputComboBoxSetting(const CardInput &parent, const QString &setting) :
-        MythUIComboBoxSetting(new CardInputDBStorage(this, parent, setting))
+        MythUIComboBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, setting))
     {
-        m_newdStorage = true;
     }
 };
 
@@ -3072,9 +3044,8 @@ class ExternalChannelCommand : public MythUITextEditSetting
 {
   public:
     explicit ExternalChannelCommand(const CardInput &parent) :
-        MythUITextEditSetting(new CardInputDBStorage(this, parent, "externalcommand"))
+        MythUITextEditSetting(std::make_shared<CardInputDBStorage>(this, parent, "externalcommand"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("External channel change command"));
         setValue("");
         setHelpText(QObject::tr("If specified, this command will be run to "
@@ -3088,9 +3059,8 @@ class PresetTuner : public MythUITextEditSetting
 {
   public:
     explicit PresetTuner(const CardInput &parent) :
-        MythUITextEditSetting(new CardInputDBStorage(this, parent, "tunechan"))
+        MythUITextEditSetting(std::make_shared<CardInputDBStorage>(this, parent, "tunechan"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Preset tuner to channel"));
         setValue("");
         setHelpText(QObject::tr("Leave this blank unless you have an external "
@@ -3145,10 +3115,9 @@ class InputPriority : public MythUISpinBoxSetting
 {
   public:
     explicit InputPriority(const CardInput &parent) :
-        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "recpriority"),
+        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "recpriority"),
                              -99, 99, 1)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Input priority"));
         setValue(0);
         setHelpText(QObject::tr("If the input priority is not equal for "
@@ -3162,10 +3131,9 @@ class ScheduleOrder : public MythUISpinBoxSetting
 {
   public:
     ScheduleOrder(const CardInput &parent, int _value) :
-        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "schedorder"),
+        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "schedorder"),
                              0, 99, 1)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Schedule order"));
         setValue(_value);
         setHelpText(QObject::tr("If priorities and other factors are equal "
@@ -3180,10 +3148,9 @@ class LiveTVOrder : public MythUISpinBoxSetting
 {
   public:
     LiveTVOrder(const CardInput &parent, int _value) :
-        MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "livetvorder"),
+        MythUISpinBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "livetvorder"),
                              0, 99, 1)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Live TV order"));
         setValue(_value);
         setHelpText(QObject::tr("When entering Live TV, the available, local "
@@ -3200,10 +3167,9 @@ class DishNetEIT : public MythUICheckBoxSetting
 {
   public:
     explicit DishNetEIT(const CardInput &parent) :
-        MythUICheckBoxSetting(new CardInputDBStorage(this, parent,
+        MythUICheckBoxSetting(std::make_shared<CardInputDBStorage>(this, parent,
                                                      "dishnet_eit"))
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Use DishNet long-term EIT data"));
         setValue(false);
         setHelpText(
@@ -4094,10 +4060,9 @@ class DiSEqCPosition : public MythUISpinBoxSetting
 {
   public:
     explicit DiSEqCPosition(const CaptureCard &parent, int value, int min_val) :
-        MythUISpinBoxSetting(new CaptureCardDBStorage(this, parent, "dvb_diseqc_type"),
+        MythUISpinBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "dvb_diseqc_type"),
                              min_val, 0xff, 1)
     {
-       m_newdStorage = true;
        setLabel(QObject::tr("DiSEqC position"));
        setHelpText(QObject::tr("Position of the LNB on the DiSEqC switch. "
                                "Leave at 1 if there is no DiSEqC switch "
@@ -4266,10 +4231,9 @@ void SatIPDeviceIDList::fillSelections(const QString &cur)
 };
 
 SatIPDeviceID::SatIPDeviceID(const CaptureCard &parent) :
-    MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice")),
+    MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "videodevice")),
     m_parent(parent)
 {
-    m_newdStorage = true;
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of the Sat>IP tuner"));
     setEnabled(true);

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -175,6 +175,7 @@ class InstanceCount : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "reclimit"),
                              1, 10, 1)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Max recordings"));
         setValue(1);
         setHelpText(
@@ -194,6 +195,7 @@ class SchedGroup : public MythUICheckBoxSetting
     explicit SchedGroup(const CardInput &parent) :
         MythUICheckBoxSetting(new CardInputDBStorage(this, parent, "schedgroup"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Schedule as group"));
         setValue(true);
         setHelpText(
@@ -265,6 +267,7 @@ class XMLTVGrabber : public MythUIComboBoxSetting
                                                        "xmltvgrabber")),
         m_parent(parent)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Listings grabber"));
     };
 
@@ -396,6 +399,7 @@ class CaptureCardSpinBoxSetting : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new CaptureCardDBStorage(this, parent, setting),
                              min_val.count(), max_val.count(), step.count())
     {
+        m_newdStorage = true;
     }
     // Handles integer milliseconds (compiler converts seconds to milliseconds)
     void setValueMs (std::chrono::milliseconds newValue)
@@ -413,6 +417,7 @@ class CaptureCardTextEditSetting : public MythUITextEditSetting
                                const QString &setting) :
         MythUITextEditSetting(new CaptureCardDBStorage(this, parent, setting))
     {
+        m_newdStorage = true;
     }
 };
 
@@ -422,6 +427,7 @@ class ScanFrequencyStart : public MythUITextEditSetting
     explicit ScanFrequencyStart(const VideoSource &parent) :
         MythUITextEditSetting(new VideoSourceDBStorage(this, parent, "scanfrequency"))
     {
+       m_newdStorage = true;
        setLabel(QObject::tr("Scan Frequency"));
        setHelpText(QObject::tr("The frequency to start scanning this video source. "
                                "This is then default for 'Full Scan (Tuned)' channel scanning. "
@@ -437,6 +443,7 @@ class DVBNetID : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "dvb_nit_id"),
                              min_val, 0xffff, 1)
     {
+       m_newdStorage = true;
        setLabel(QObject::tr("Network ID"));
        //: Network_ID is the name of an identifier in the DVB's Service
        //: Information standard specification.
@@ -454,6 +461,7 @@ class BouquetID : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "bouquet_id"),
                              min_val, 0xffff, 1)
     {
+       m_newdStorage = true;
        setLabel(QObject::tr("Bouquet ID"));
        setHelpText(QObject::tr("Bouquet ID for Freesat or Sky on satellite Astra-2 28.2E. "
                                "Leave this at 0 if you do not receive this satellite. "
@@ -471,6 +479,7 @@ class RegionID : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "region_id"),
                              min_val, 100, 1)
     {
+       m_newdStorage = true;
        setLabel(QObject::tr("Region ID"));
        setHelpText(QObject::tr("Region ID for Freesat or Sky on satellite Astra-2 28.2E. "
                                "Leave this at 0 you do not receive this satellite.  "
@@ -488,6 +497,7 @@ class LCNOffset : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new VideoSourceDBStorage(this, parent, "lcnoffset"),
                              min_val, 20000, 100)
     {
+       m_newdStorage = true;
        setLabel(QObject::tr("Logical Channel Number Offset"));
        setHelpText(QObject::tr("The offset is added to each logical channel number found "
                                "during a scan of a DVB video source. This makes it possible "
@@ -501,6 +511,7 @@ class LCNOffset : public MythUISpinBoxSetting
 FreqTableSelector::FreqTableSelector(const VideoSource &parent) :
     MythUIComboBoxSetting(new VideoSourceDBStorage(this, parent, "freqtable"))
 {
+    m_newdStorage = true;
     setLabel(QObject::tr("Channel frequency table"));
     addSelection("default");
 
@@ -597,6 +608,7 @@ class UseEIT : public MythUICheckBoxSetting
     explicit UseEIT(const VideoSource &parent) :
         MythUICheckBoxSetting(new VideoSourceDBStorage(this, parent, "useeit"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Perform EIT scan"));
         setHelpText(QObject::tr(
                         "If enabled, program guide data for channels on this "
@@ -979,6 +991,7 @@ class CommandPath : public MythUITextEditSetting
         MythUITextEditSetting(new CaptureCardDBStorage(this, parent,
                                                        "videodevice"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr(""));
         setValue("");
         setHelpText(QObject::tr("Specify the command to run, with any "
@@ -994,6 +1007,7 @@ class FileDevice : public MythUIFileBrowserSetting
             new CaptureCardDBStorage(this, parent, "videodevice")
             /* mustexist, false */)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("File path"));
     };
 };
@@ -1096,12 +1110,13 @@ class SkipBtAudio : public MythUICheckBoxSetting
         MythUICheckBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "skipbtaudio"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Do not adjust volume"));
         setHelpText(
             QObject::tr("Enable this option for budget BT878 based "
                         "DVB-T cards such as the AverTV DVB-T which "
                         "require the audio volume to be left alone."));
-   };
+    };
 };
 
 class DVBCardNum : public CaptureCardComboBoxSetting
@@ -1207,6 +1222,7 @@ class DVBNoSeqStart : public MythUICheckBoxSetting
         MythUICheckBoxSetting(
             new CaptureCardDBStorage(this, parent, "dvb_wait_for_seqstart"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Wait for SEQ start header"));
         setValue(true);
         setHelpText(
@@ -1222,6 +1238,7 @@ class DVBOnDemand : public MythUICheckBoxSetting
         MythUICheckBoxSetting(
             new CaptureCardDBStorage(this, parent, "dvb_on_demand"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Open DVB card on demand"));
         setValue(true);
         setHelpText(
@@ -1237,6 +1254,7 @@ class DVBEITScan : public MythUICheckBoxSetting
         MythUICheckBoxSetting(
             new CaptureCardDBStorage(this, parent, "dvb_eitscan"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Use DVB card for active EIT scan"));
         setValue(true);
         setHelpText(
@@ -1347,6 +1365,7 @@ class FirewireConnection : public MythUIComboBoxSetting
         MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "firewire_connection"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Connection Type"));
         addSelection(QObject::tr("Point to Point"),"0");
         addSelection(QObject::tr("Broadcast"),"1");
@@ -1360,6 +1379,7 @@ class FirewireSpeed : public MythUIComboBoxSetting
         MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "firewire_speed"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Speed"));
         addSelection(QObject::tr("100Mbps"),"0");
         addSelection(QObject::tr("200Mbps"),"1");
@@ -1409,6 +1429,7 @@ HDHomeRunDeviceID::HDHomeRunDeviceID(const CaptureCard &parent,
         new CaptureCardDBStorage(this, parent, "videodevice")),
     m_group(_group)
 {
+    m_newdStorage = true;
     setVisible(false);
 };
 
@@ -1431,6 +1452,7 @@ class HDHomeRunEITScan : public MythUICheckBoxSetting
         MythUICheckBoxSetting(
             new CaptureCardDBStorage(this, parent, "dvb_eitscan"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Use HDHomeRun for active EIT scan"));
         setValue(true);
         setHelpText(
@@ -1631,6 +1653,7 @@ void VBoxTunerIndex::UpdateDevices(const QString &v)
 VBoxDeviceID::VBoxDeviceID(const CaptureCard &parent) :
     MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice"))
 {
+    m_newdStorage = true;
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of VBox device"));
     setReadOnly(true);
@@ -2090,6 +2113,7 @@ CetonDeviceID::CetonDeviceID(const CaptureCard &parent) :
     MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice")),
     m_parent(parent)
 {
+    m_newdStorage = true;
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of Ceton device"));
 }
@@ -2171,9 +2195,10 @@ class SchedGroupFalse : public MythUICheckBoxSetting
         MythUICheckBoxSetting(new CaptureCardDBStorage(this, parent,
                                                        "schedgroup"))
     {
+        m_newdStorage = true;
         setValue(false);
         setVisible(false);
-   };
+    };
 };
 
 V4LConfigurationGroup::V4LConfigurationGroup(CaptureCard& parent,
@@ -2787,6 +2812,7 @@ void CardType::fillSelections(MythUIComboBoxSetting* setting)
 CaptureCard::Hostname::Hostname(const CaptureCard &parent) :
     StandardSetting(new CaptureCardDBStorage(this, parent, "hostname"))
 {
+    m_newdStorage = true;
     setVisible(false);
     setValue(gCoreContext->GetHostName());
 }
@@ -2797,6 +2823,7 @@ class InputName : public MythUIComboBoxSetting
     explicit InputName(const CardInput &parent) :
         MythUIComboBoxSetting(new CardInputDBStorage(this, parent, "inputname"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Input name"));
     };
 
@@ -2846,6 +2873,7 @@ class InputDisplayName : public MythUITextEditSetting
     explicit InputDisplayName(const CardInput &parent) :
         MythUITextEditSetting(new CardInputDBStorage(this, parent, "displayname")), m_parent(parent)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Display name"));
         setHelpText(QObject::tr(
                         "This name is displayed on screen when Live TV begins "
@@ -2868,6 +2896,7 @@ class CardInputComboBoxSetting : public MythUIComboBoxSetting
     CardInputComboBoxSetting(const CardInput &parent, const QString &setting) :
         MythUIComboBoxSetting(new CardInputDBStorage(this, parent, setting))
     {
+        m_newdStorage = true;
     }
 };
 
@@ -3045,6 +3074,7 @@ class ExternalChannelCommand : public MythUITextEditSetting
     explicit ExternalChannelCommand(const CardInput &parent) :
         MythUITextEditSetting(new CardInputDBStorage(this, parent, "externalcommand"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("External channel change command"));
         setValue("");
         setHelpText(QObject::tr("If specified, this command will be run to "
@@ -3060,6 +3090,7 @@ class PresetTuner : public MythUITextEditSetting
     explicit PresetTuner(const CardInput &parent) :
         MythUITextEditSetting(new CardInputDBStorage(this, parent, "tunechan"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Preset tuner to channel"));
         setValue("");
         setHelpText(QObject::tr("Leave this blank unless you have an external "
@@ -3117,6 +3148,7 @@ class InputPriority : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "recpriority"),
                              -99, 99, 1)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Input priority"));
         setValue(0);
         setHelpText(QObject::tr("If the input priority is not equal for "
@@ -3133,6 +3165,7 @@ class ScheduleOrder : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "schedorder"),
                              0, 99, 1)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Schedule order"));
         setValue(_value);
         setHelpText(QObject::tr("If priorities and other factors are equal "
@@ -3150,6 +3183,7 @@ class LiveTVOrder : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new CardInputDBStorage(this, parent, "livetvorder"),
                              0, 99, 1)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Live TV order"));
         setValue(_value);
         setHelpText(QObject::tr("When entering Live TV, the available, local "
@@ -3169,6 +3203,7 @@ class DishNetEIT : public MythUICheckBoxSetting
         MythUICheckBoxSetting(new CardInputDBStorage(this, parent,
                                                      "dishnet_eit"))
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Use DishNet long-term EIT data"));
         setValue(false);
         setHelpText(
@@ -4062,6 +4097,7 @@ class DiSEqCPosition : public MythUISpinBoxSetting
         MythUISpinBoxSetting(new CaptureCardDBStorage(this, parent, "dvb_diseqc_type"),
                              min_val, 0xff, 1)
     {
+       m_newdStorage = true;
        setLabel(QObject::tr("DiSEqC position"));
        setHelpText(QObject::tr("Position of the LNB on the DiSEqC switch. "
                                "Leave at 1 if there is no DiSEqC switch "
@@ -4233,6 +4269,7 @@ SatIPDeviceID::SatIPDeviceID(const CaptureCard &parent) :
     MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "videodevice")),
     m_parent(parent)
 {
+    m_newdStorage = true;
     setLabel(tr("Device ID"));
     setHelpText(tr("Device ID of the Sat>IP tuner"));
     setEnabled(true);

--- a/mythtv/libs/libmythtv/videosource.h
+++ b/mythtv/libs/libmythtv/videosource.h
@@ -94,6 +94,7 @@ class FreqTableSelector :
     Q_OBJECT
 public:
     explicit FreqTableSelector(const VideoSource& parent);
+    ~FreqTableSelector();
 protected:
     QString m_freq;
 };
@@ -215,9 +216,14 @@ class VideoSource : public GroupSetting {
     {
       public:
         explicit Name(const VideoSource &parent) :
-            MythUITextEditSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "name"))
+            MythUITextEditSetting(new VideoSourceDBStorage(this, parent, "name"))
         {
             setLabel(QObject::tr("Video source name"));
+        }
+
+        ~Name()
+        {
+            delete GetStorage();
         }
     };
 
@@ -251,9 +257,14 @@ class CaptureCardComboBoxSetting : public MythUIComboBoxSetting
     CaptureCardComboBoxSetting(const CaptureCard &parent,
                                bool rw,
                                const QString &setting) :
-        MythUIComboBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent, setting),
+        MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent, setting),
                               rw)
     {
+    }
+
+    ~CaptureCardComboBoxSetting()
+    {
+        delete GetStorage();
     }
 };
 
@@ -278,10 +289,15 @@ class EmptyAudioDevice : public MythUITextEditSetting
     Q_OBJECT
   public:
     explicit EmptyAudioDevice(const CaptureCard &parent) :
-        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
+        MythUITextEditSetting(new CaptureCardDBStorage(this, parent,
                                                        "audiodevice"))
     {
         setVisible(false);
+    }
+
+    ~EmptyAudioDevice()
+    {
+        delete GetStorage();
     }
 
     void Save(void) override // StandardSetting
@@ -304,10 +320,15 @@ class EmptyVBIDevice : public MythUITextEditSetting
 
   public:
     explicit EmptyVBIDevice(const CaptureCard &parent) :
-        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "vbidevice"))
+        MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "vbidevice"))
     {
         setVisible(false);
     };
+
+    ~EmptyVBIDevice()
+    {
+        delete GetStorage();
+    }
 
     void Save(void) override // StandardSetting
     {
@@ -372,6 +393,7 @@ class HDHomeRunDeviceID : public MythUITextEditSetting
   public:
     HDHomeRunDeviceID(const CaptureCard &parent,
                       HDHomeRunConfigurationGroup &_group);
+    ~HDHomeRunDeviceID();
     void Load(void) override; // StandardSetting
     void Save(void) override; // StandardSetting
 
@@ -457,6 +479,7 @@ class SatIPDeviceID : public MythUITextEditSetting
 
   public:
     explicit SatIPDeviceID(const CaptureCard &parent);
+    ~SatIPDeviceID();
 
     void Load(void) override; // StandardSetting
 
@@ -761,6 +784,7 @@ private:
     {
       public:
         explicit Hostname(const CaptureCard &parent);
+        ~Hostname();
         void edit(MythScreenType */*screen*/) override {} // StandardSetting
         void resultEdit(DialogCompletionEvent */*dce*/) override {} // StandardSetting
     };
@@ -874,13 +898,18 @@ class StartingChannel : public MythUIComboBoxSetting
     Q_OBJECT
   public:
     explicit StartingChannel(const CardInput &parent) :
-        MythUIComboBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "startchan"),
+        MythUIComboBoxSetting(new CardInputDBStorage(this, parent, "startchan"),
                               false)
     {
         setLabel(QObject::tr("Starting channel"));
         setHelpText(QObject::tr("This channel is shown when 'Watch TV' is selected on the main menu. "
                                 "It is updated on every Live TV channel change. "
                                 "When the value is not valid a suitable default will be chosen."));
+    }
+
+    ~StartingChannel()
+    {
+        delete GetStorage();
     }
     static void fillSelections(void) {;}
   public slots:
@@ -1014,6 +1043,7 @@ class VBoxDeviceID : public MythUITextEditSetting
 
   public:
     explicit VBoxDeviceID(const CaptureCard &parent);
+    ~VBoxDeviceID();
 
     void Load(void) override; // StandardSetting
 
@@ -1051,6 +1081,7 @@ class CetonDeviceID : public MythUITextEditSetting
 
   public:
     explicit CetonDeviceID(const CaptureCard &parent);
+    ~CetonDeviceID();
 
     void Load(void) override; // StandardSetting
     void UpdateValues();

--- a/mythtv/libs/libmythtv/videosource.h
+++ b/mythtv/libs/libmythtv/videosource.h
@@ -217,6 +217,7 @@ class VideoSource : public GroupSetting {
         explicit Name(const VideoSource &parent) :
             MythUITextEditSetting(new VideoSourceDBStorage(this, parent, "name"))
         {
+            m_newdStorage = true;
             setLabel(QObject::tr("Video source name"));
         }
     };
@@ -254,6 +255,7 @@ class CaptureCardComboBoxSetting : public MythUIComboBoxSetting
         MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent, setting),
                               rw)
     {
+        m_newdStorage = true;
     }
 };
 
@@ -281,6 +283,7 @@ class EmptyAudioDevice : public MythUITextEditSetting
         MythUITextEditSetting(new CaptureCardDBStorage(this, parent,
                                                        "audiodevice"))
     {
+        m_newdStorage = true;
         setVisible(false);
     }
 
@@ -306,6 +309,7 @@ class EmptyVBIDevice : public MythUITextEditSetting
     explicit EmptyVBIDevice(const CaptureCard &parent) :
         MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "vbidevice"))
     {
+        m_newdStorage = true;
         setVisible(false);
     };
 
@@ -877,6 +881,7 @@ class StartingChannel : public MythUIComboBoxSetting
         MythUIComboBoxSetting(new CardInputDBStorage(this, parent, "startchan"),
                               false)
     {
+        m_newdStorage = true;
         setLabel(QObject::tr("Starting channel"));
         setHelpText(QObject::tr("This channel is shown when 'Watch TV' is selected on the main menu. "
                                 "It is updated on every Live TV channel change. "

--- a/mythtv/libs/libmythtv/videosource.h
+++ b/mythtv/libs/libmythtv/videosource.h
@@ -215,9 +215,8 @@ class VideoSource : public GroupSetting {
     {
       public:
         explicit Name(const VideoSource &parent) :
-            MythUITextEditSetting(new VideoSourceDBStorage(this, parent, "name"))
+            MythUITextEditSetting(std::make_shared<VideoSourceDBStorage>(this, parent, "name"))
         {
-            m_newdStorage = true;
             setLabel(QObject::tr("Video source name"));
         }
     };
@@ -252,10 +251,9 @@ class CaptureCardComboBoxSetting : public MythUIComboBoxSetting
     CaptureCardComboBoxSetting(const CaptureCard &parent,
                                bool rw,
                                const QString &setting) :
-        MythUIComboBoxSetting(new CaptureCardDBStorage(this, parent, setting),
+        MythUIComboBoxSetting(std::make_shared<CaptureCardDBStorage>(this, parent, setting),
                               rw)
     {
-        m_newdStorage = true;
     }
 };
 
@@ -280,10 +278,9 @@ class EmptyAudioDevice : public MythUITextEditSetting
     Q_OBJECT
   public:
     explicit EmptyAudioDevice(const CaptureCard &parent) :
-        MythUITextEditSetting(new CaptureCardDBStorage(this, parent,
+        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent,
                                                        "audiodevice"))
     {
-        m_newdStorage = true;
         setVisible(false);
     }
 
@@ -307,9 +304,8 @@ class EmptyVBIDevice : public MythUITextEditSetting
 
   public:
     explicit EmptyVBIDevice(const CaptureCard &parent) :
-        MythUITextEditSetting(new CaptureCardDBStorage(this, parent, "vbidevice"))
+        MythUITextEditSetting(std::make_shared<CaptureCardDBStorage>(this, parent, "vbidevice"))
     {
-        m_newdStorage = true;
         setVisible(false);
     };
 
@@ -878,10 +874,9 @@ class StartingChannel : public MythUIComboBoxSetting
     Q_OBJECT
   public:
     explicit StartingChannel(const CardInput &parent) :
-        MythUIComboBoxSetting(new CardInputDBStorage(this, parent, "startchan"),
+        MythUIComboBoxSetting(std::make_shared<CardInputDBStorage>(this, parent, "startchan"),
                               false)
     {
-        m_newdStorage = true;
         setLabel(QObject::tr("Starting channel"));
         setHelpText(QObject::tr("This channel is shown when 'Watch TV' is selected on the main menu. "
                                 "It is updated on every Live TV channel change. "

--- a/mythtv/libs/libmythui/standardsettings.cpp
+++ b/mythtv/libs/libmythui/standardsettings.cpp
@@ -32,13 +32,6 @@ StandardSetting::~StandardSetting()
             delete *i;
     }
     m_targets.clear();
-
-    if (m_storage && m_newdStorage)
-    {
-        // Storage memory was allocated with a 'new'
-        delete m_storage;
-        m_storage = nullptr;
-    }
 }
 
 MythUIButtonListItem * StandardSetting::createButton(MythUIButtonList * list)
@@ -221,6 +214,8 @@ void StandardSetting::Load(void)
 {
     if (m_storage)
         m_storage->Load();
+    else if (m_storage_ptr)
+        m_storage_ptr.get()->Load();
 
     m_haveChanged = false;
 
@@ -240,6 +235,8 @@ void StandardSetting::Save(void)
 {
     if (m_storage)
         m_storage->Save();
+    else if (m_storage_ptr)
+        m_storage_ptr.get()->Save();
 
     //we save only the relevant children
     QList<StandardSetting *> *children = getSubSettings();
@@ -290,6 +287,18 @@ void StandardSetting::MoveToThread(QThread *thread)
     {
         for (i = (*iMap).constBegin(); i != (*iMap).constEnd(); ++i)
             (*i)->MoveToThread(thread);
+    }
+}
+
+Storage * StandardSetting::GetStorage(void) const
+{
+    if (m_storage_ptr)
+    {
+        return m_storage_ptr.get();
+    }
+    else
+    {
+        return m_storage;
     }
 }
 
@@ -676,6 +685,40 @@ MythUISpinBoxSetting::MythUISpinBoxSetting(Storage *_storage, int min, int max,
     }
 }
 
+MythUISpinBoxSetting::MythUISpinBoxSetting(std::shared_ptr<Storage> _storage_ptr,
+                                           int min, int max, int step, int pageMultiple,
+                                           QString special_value_text)
+    : StandardSetting(_storage_ptr),
+      m_min(min),
+      m_max(max),
+      m_step(step),
+      m_pageMultiple(pageMultiple),
+      m_specialValueText(std::move(special_value_text))
+{
+    // We default to 0 unless 0 is out of range.
+    if (m_min > 0 || m_max < 0)
+        m_settingValue = QString::number(m_min);
+
+    // The settings pages were coded to assume a parameter true/false
+    // meaning allow_single_step. Many pages use this but it was not
+    // implemented. It is difficult to implement using the current
+    // UI widget design. So I have changed it so you can specify
+    // the size of pageup / pagedown increments as an integer instead.
+    // For compatibility with callers still using true to indicate
+    // allowing single step, the code will set the step size as 1 and
+    // the pageup / pagedown as the requested step.
+
+    if (m_pageMultiple == 1)
+    {
+        m_pageMultiple = step;
+        m_step = 1;
+    }
+    if (m_pageMultiple == 0)
+    {
+        m_pageMultiple = 5;
+    }
+}
+
 void MythUISpinBoxSetting::updateButton(MythUIButtonListItem *item)
 {
     item->DisplayState("spinbox", "widgettype");
@@ -733,6 +776,11 @@ void MythUISpinBoxSetting::resultEdit(DialogCompletionEvent *dce)
 
 MythUICheckBoxSetting::MythUICheckBoxSetting(Storage *_storage):
     StandardSetting(_storage)
+{
+}
+
+MythUICheckBoxSetting::MythUICheckBoxSetting(std::shared_ptr<Storage> _storage_ptr):
+    StandardSetting(_storage_ptr)
 {
 }
 

--- a/mythtv/libs/libmythui/standardsettings.cpp
+++ b/mythtv/libs/libmythui/standardsettings.cpp
@@ -32,8 +32,10 @@ StandardSetting::~StandardSetting()
             delete *i;
     }
     m_targets.clear();
-    if (m_storage)
+
+    if (m_storage && m_newdStorage)
     {
+        // Storage memory was allocated with a 'new'
         delete m_storage;
         m_storage = nullptr;
     }

--- a/mythtv/libs/libmythui/standardsettings.cpp
+++ b/mythtv/libs/libmythui/standardsettings.cpp
@@ -214,8 +214,6 @@ void StandardSetting::Load(void)
 {
     if (m_storage)
         m_storage->Load();
-    else if (m_storage_ptr)
-        m_storage_ptr.get()->Load();
 
     m_haveChanged = false;
 
@@ -235,8 +233,6 @@ void StandardSetting::Save(void)
 {
     if (m_storage)
         m_storage->Save();
-    else if (m_storage_ptr)
-        m_storage_ptr.get()->Save();
 
     //we save only the relevant children
     QList<StandardSetting *> *children = getSubSettings();
@@ -287,18 +283,6 @@ void StandardSetting::MoveToThread(QThread *thread)
     {
         for (i = (*iMap).constBegin(); i != (*iMap).constEnd(); ++i)
             (*i)->MoveToThread(thread);
-    }
-}
-
-Storage * StandardSetting::GetStorage(void) const
-{
-    if (m_storage_ptr)
-    {
-        return m_storage_ptr.get();
-    }
-    else
-    {
-        return m_storage;
     }
 }
 
@@ -685,40 +669,6 @@ MythUISpinBoxSetting::MythUISpinBoxSetting(Storage *_storage, int min, int max,
     }
 }
 
-MythUISpinBoxSetting::MythUISpinBoxSetting(std::shared_ptr<Storage> _storage_ptr,
-                                           int min, int max, int step, int pageMultiple,
-                                           QString special_value_text)
-    : StandardSetting(_storage_ptr),
-      m_min(min),
-      m_max(max),
-      m_step(step),
-      m_pageMultiple(pageMultiple),
-      m_specialValueText(std::move(special_value_text))
-{
-    // We default to 0 unless 0 is out of range.
-    if (m_min > 0 || m_max < 0)
-        m_settingValue = QString::number(m_min);
-
-    // The settings pages were coded to assume a parameter true/false
-    // meaning allow_single_step. Many pages use this but it was not
-    // implemented. It is difficult to implement using the current
-    // UI widget design. So I have changed it so you can specify
-    // the size of pageup / pagedown increments as an integer instead.
-    // For compatibility with callers still using true to indicate
-    // allowing single step, the code will set the step size as 1 and
-    // the pageup / pagedown as the requested step.
-
-    if (m_pageMultiple == 1)
-    {
-        m_pageMultiple = step;
-        m_step = 1;
-    }
-    if (m_pageMultiple == 0)
-    {
-        m_pageMultiple = 5;
-    }
-}
-
 void MythUISpinBoxSetting::updateButton(MythUIButtonListItem *item)
 {
     item->DisplayState("spinbox", "widgettype");
@@ -776,11 +726,6 @@ void MythUISpinBoxSetting::resultEdit(DialogCompletionEvent *dce)
 
 MythUICheckBoxSetting::MythUICheckBoxSetting(Storage *_storage):
     StandardSetting(_storage)
-{
-}
-
-MythUICheckBoxSetting::MythUICheckBoxSetting(std::shared_ptr<Storage> _storage_ptr):
-    StandardSetting(_storage_ptr)
 {
 }
 

--- a/mythtv/libs/libmythui/standardsettings.cpp
+++ b/mythtv/libs/libmythui/standardsettings.cpp
@@ -32,6 +32,11 @@ StandardSetting::~StandardSetting()
             delete *i;
     }
     m_targets.clear();
+    if (m_storage)
+    {
+        delete m_storage;
+        m_storage = nullptr;
+    }
 }
 
 MythUIButtonListItem * StandardSetting::createButton(MythUIButtonList * list)

--- a/mythtv/libs/libmythui/standardsettings.h
+++ b/mythtv/libs/libmythui/standardsettings.h
@@ -115,7 +115,8 @@ class MUI_PUBLIC StandardSetting : public QObject, public StorageUser
     QString m_helptext;
     QString m_name;
     bool    m_visible         {true};
-
+    bool    m_newdStorage     {false}; // Set true if 'new' was used to
+                                       // allocate memory put into storage
   private:
     bool    m_haveChanged     {false};
     Storage *m_storage        {nullptr};
@@ -169,14 +170,16 @@ class MUI_PUBLIC HostTextEditSetting: public MythUITextEditSetting
 {
   public:
     explicit HostTextEditSetting(const QString &name) :
-        MythUITextEditSetting(new HostDBStorage(this, name)) { }
+        MythUITextEditSetting(new HostDBStorage(this, name))
+    { m_newdStorage = true; }
 };
 
 class MUI_PUBLIC GlobalTextEditSetting: public MythUITextEditSetting
 {
   public:
     explicit GlobalTextEditSetting(const QString &name) :
-        MythUITextEditSetting(new GlobalDBStorage(this, name)) { }
+        MythUITextEditSetting(new GlobalDBStorage(this, name))
+    { m_newdStorage = true; }
 };
 
 /*******************************************************************************
@@ -207,7 +210,8 @@ class MUI_PUBLIC HostFileBrowserSetting: public MythUIFileBrowserSetting
 {
   public:
     explicit HostFileBrowserSetting(const QString &name) :
-        MythUIFileBrowserSetting(new HostDBStorage(this, name)) { }
+        MythUIFileBrowserSetting(new HostDBStorage(this, name))
+    { m_newdStorage = true; }
 };
 
 
@@ -258,7 +262,8 @@ class MUI_PUBLIC HostComboBoxSetting: public MythUIComboBoxSetting
 {
   public:
     explicit HostComboBoxSetting(const QString &name, bool rw = false) :
-        MythUIComboBoxSetting(new HostDBStorage(this, name), rw) { }
+        MythUIComboBoxSetting(new HostDBStorage(this, name), rw)
+    { m_newdStorage = true; }
 };
 
 
@@ -266,7 +271,8 @@ class MUI_PUBLIC GlobalComboBoxSetting: public MythUIComboBoxSetting
 {
   public:
     explicit GlobalComboBoxSetting(const QString &name, bool rw = false) :
-        MythUIComboBoxSetting(new GlobalDBStorage(this, name), rw) { }
+        MythUIComboBoxSetting(new GlobalDBStorage(this, name), rw)
+    { m_newdStorage = true; }
 };
 
 class MUI_PUBLIC TransMythUIComboBoxSetting: public MythUIComboBoxSetting
@@ -369,7 +375,7 @@ class MUI_PUBLIC HostSpinBoxSetting: public MythUISpinBoxSetting
                        const QString &special_value_text = QString()) :
         MythUISpinBoxSetting(new HostDBStorage(this, name), min, max, step,
                              pageMultiple, special_value_text)
-    { }
+    { m_newdStorage = true; }
 };
 
 class MUI_PUBLIC GlobalSpinBoxSetting: public MythUISpinBoxSetting
@@ -380,7 +386,7 @@ class MUI_PUBLIC GlobalSpinBoxSetting: public MythUISpinBoxSetting
                          const QString &special_value_text = QString()) :
         MythUISpinBoxSetting(new GlobalDBStorage(this, name), min, max, step,
                              pageMultiple, special_value_text)
-    { }
+    { m_newdStorage = true; }
 };
 
 /*******************************************************************************
@@ -418,14 +424,16 @@ class MUI_PUBLIC HostCheckBoxSetting: public MythUICheckBoxSetting
 {
   public:
     explicit HostCheckBoxSetting(const QString &name) :
-        MythUICheckBoxSetting(new HostDBStorage(this, name)) { }
+        MythUICheckBoxSetting(new HostDBStorage(this, name))
+    { m_newdStorage = true; }
 };
 
 class MUI_PUBLIC GlobalCheckBoxSetting: public MythUICheckBoxSetting
 {
   public:
     explicit GlobalCheckBoxSetting(const QString &name) :
-        MythUICheckBoxSetting(new GlobalDBStorage(this, name)) { }
+        MythUICheckBoxSetting(new GlobalDBStorage(this, name))
+    { m_newdStorage = true; }
 };
 
 /*******************************************************************************

--- a/mythtv/libs/libmythui/storagegroupeditor.cpp
+++ b/mythtv/libs/libmythui/storagegroupeditor.cpp
@@ -173,10 +173,15 @@ QString StorageGroupDirStorage::GetWhereClause(MSqlBindings &bindings) const
 }
 
 StorageGroupDirSetting::StorageGroupDirSetting(int id, const QString &group) :
-    MythUIFileBrowserSetting(std::make_shared<StorageGroupDirStorage>(this, id, group)),
+    MythUIFileBrowserSetting(new StorageGroupDirStorage(this, id, group)),
     m_id(id), m_group(group)
 {
     SetTypeFilter(QDir::AllDirs | QDir::Drives);
+}
+
+StorageGroupDirSetting::~StorageGroupDirSetting()
+{
+    delete GetStorage();
 }
 
 bool StorageGroupDirSetting::keyPressEvent(QKeyEvent *event)

--- a/mythtv/libs/libmythui/storagegroupeditor.cpp
+++ b/mythtv/libs/libmythui/storagegroupeditor.cpp
@@ -176,6 +176,7 @@ StorageGroupDirSetting::StorageGroupDirSetting(int id, const QString &group) :
     MythUIFileBrowserSetting(new StorageGroupDirStorage(this, id, group)),
     m_id(id), m_group(group)
 {
+    m_newdStorage = true;
     SetTypeFilter(QDir::AllDirs | QDir::Drives);
 }
 

--- a/mythtv/libs/libmythui/storagegroupeditor.cpp
+++ b/mythtv/libs/libmythui/storagegroupeditor.cpp
@@ -173,10 +173,9 @@ QString StorageGroupDirStorage::GetWhereClause(MSqlBindings &bindings) const
 }
 
 StorageGroupDirSetting::StorageGroupDirSetting(int id, const QString &group) :
-    MythUIFileBrowserSetting(new StorageGroupDirStorage(this, id, group)),
+    MythUIFileBrowserSetting(std::make_shared<StorageGroupDirStorage>(this, id, group)),
     m_id(id), m_group(group)
 {
-    m_newdStorage = true;
     SetTypeFilter(QDir::AllDirs | QDir::Drives);
 }
 

--- a/mythtv/libs/libmythui/storagegroupeditor.h
+++ b/mythtv/libs/libmythui/storagegroupeditor.h
@@ -60,6 +60,7 @@ class StorageGroupDirSetting : public MythUIFileBrowserSetting
 
   public:
       StorageGroupDirSetting(int id, const QString &group);
+      ~StorageGroupDirSetting();
 
     bool keyPressEvent(QKeyEvent *event) override; // StandardSetting
 


### PR DESCRIPTION
All of the classes derived from **StandardSetting** which use 'new' to allocate their storage memory have been updated to add destructors which call "_**delete GetStorage()**_;" This frees up memory allocated from the heap when an instance of that class falls out of scope or is deleted. This closes the StandardSetting related memory leaks.

Resolves: MythTV#1120

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

