### PR TITLE
GitHub Actions: Disable LTO for macOS builds

### DIFF
--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -336,7 +336,7 @@ jobs:
       CCACHE_DIR: $HOME/.ccache
       CCACHE_COMPRESS: true
       CCACHE_MAXSIZE: 250M
-      CONFIGURE_CMD: 'cmake --preset ${{ matrix.os.qt_version }} -G Ninja -DCMAKE_BUILD_TYPE=Release'
+      CONFIGURE_CMD: 'cmake --preset ${{ matrix.os.qt_version }} -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=OFF'
       MAKE_CMD: 'cmake --build build-${{ matrix.os.qt_version }}'
       TEST_CMD: 'cmake --build build-${{ matrix.os.qt_version }} -t MythTV-tests'
 


### PR DESCRIPTION
This was causing TestCopyFrames to abort after
passing all of the tests on macOS 15.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

