### PR TITLE
freemheg: update visibility of MHCreateEngine & MHSetLogging

### DIFF
--- a/mythtv/libs/libmythfreemheg/freemheg.h
+++ b/mythtv/libs/libmythfreemheg/freemheg.h
@@ -45,10 +45,16 @@ class MHContext;
 class MHEG;
 class MHStream;
 
+#ifdef MTV_API
+#  define MHEG_PUBLIC Q_DECL_IMPORT
+#else
+#  define MHEG_PUBLIC Q_DECL_EXPORT
+#endif
+
 // Called to create a new instance of the module.
-extern Q_DECL_EXPORT MHEG *MHCreateEngine(MHContext *context);
+extern MHEG_PUBLIC MHEG *MHCreateEngine(MHContext *context);
 // Set the logging stream and options.
-extern Q_DECL_EXPORT void MHSetLogging(FILE *logStream, unsigned int logLevel);
+extern MHEG_PUBLIC void MHSetLogging(FILE *logStream, unsigned int logLevel);
 
 // This abstract class is implemented by the MHEG Engine.
 class MHEG


### PR DESCRIPTION
-lmythfreemheg-35 is used when build libmythtv.35.so, so the visibility of MHCreateEngine & MHSetLogging should be different depends on "-DMTV_API", otherwise build is failed with:

> /usr/bin/x86_64-pc-linux-gnu-ld.bfd: obj/mhi.o: in function MHIContext:: MHIContext(InteractiveTV*)':
> /var/tmp/portage/media-tv/mythtv-35.0-r1/work/mythtv-35.0/mythtv/libs/libmythtv/mheg/mhi.cpp: 80:(.text+0xec): undefined reference to MHCreateEngine(MHContext*)'
> /usr/bin/x86_64-pc-linux-gnu-ld.bfd: obj/interactivetv.o: in function InteractiveTV::InteractiveTV(MythPlayerCaptionsUI*)':
> /var/tmp/portage/media-tv/mythtv-35.0-r1/work/mythtv-35.0/mythtv/libs/libmythtv/mheg/interactivetv.cpp: (.text+0x17b): undefined reference to MHSetLogging(_IO_FILE*, unsigned int)'
> /usr/bin/x86_64-pc-linux-gnu-ld.bfd: libmythtv-35.so.35.0.0: protected symbol _Z12MHSetLoggingP8_IO_FILEj' isn't defined
> /usr/bin/x86_64-pc-linux-gnu-ld.bfd: final link failed: bad value

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

