### PR TITLE
Fix compiling Qt6 on 32-bit architectures.

### DIFF
--- a/mythtv/programs/mythtv-setup/exitprompt.cpp
+++ b/mythtv/programs/mythtv-setup/exitprompt.cpp
@@ -75,7 +75,7 @@ void ExitPrompter::handleExit()
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         int limit = std::min(4, allproblems.size());
 #else
-        int limit = std::min(4LL, allproblems.size());
+        int limit = std::min(static_cast<qsizetype>(4), allproblems.size());
 #endif
         for (int i = 0; i < limit; ++i)
         {

--- a/mythtv/programs/mythutil/recordingutils.cpp
+++ b/mythtv/programs/mythutil/recordingutils.cpp
@@ -39,7 +39,7 @@ static QString CreateProgramInfoString(const ProgramInfo &pginfo)
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
         int maxll = std::max(title.length(), 20);
 #else
-        int maxll = std::max(title.length(), 20LL);
+        int maxll = std::max(title.length(), static_cast<qsizetype>(20));
 #endif
         if (extra.length() > maxll)
             extra = extra.left(maxll - 3) + "...";


### PR DESCRIPTION
In addition to 4f7f887aeed213259999e93f432aa781878f1480 fix more compile errors on 32bit.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)