### PR TITLE
Add include moc_*.cpp

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -301,6 +301,7 @@ CheckOptions:
   - { key: modernize-use-nullptr.NullMacros,               value: 'Z_NULL' }
   - { key: modernize-use-using.IgnoreMacros,               value: 1 }
 
+  - { key: performance-enum-size.EnumIgnoreList, value: 'some_compilers' }
   - { key: performance-inefficient-vector-operation.VectorLikeClasses,
     value: '::std::vector,QList,QByteArrayList,QItemSelection,QQueue,QStringList' }
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -281,6 +281,7 @@ Checks: '-*,
 
 CheckOptions:
   - { key: bugprone-narrowing-conversions.PedanticMode, value: 0 }
+  - { key: bugprone-suspicious-include.IgnoredRegex, value: '^(.*/)?(moc_.+)(\.cpp)$' }
   - { key: bugprone-suspicious-string-compare.WarnOnLogicalNotComparison, value: 1 }
   - { key: bugprone-pointer-arithmetic-on-polymorphic-object.IgnoreInheritedVirtualFunctions, value: 1 }
   - { key: bugprone-unused-return-value.AllowCastToVoid, value: 1 }

--- a/mythplugins/mytharchive/mytharchive/editmetadata.cpp
+++ b/mythplugins/mytharchive/mytharchive/editmetadata.cpp
@@ -75,3 +75,5 @@ void EditMetadataDialog::cancelPressed(void)
     emit haveResult(false, m_sourceMetadata);
     Close();
 }
+
+#include "moc_editmetadata.cpp"

--- a/mythplugins/mytharchive/mytharchive/exportnative.cpp
+++ b/mythplugins/mytharchive/mytharchive/exportnative.cpp
@@ -490,3 +490,5 @@ void ExportNative::handleAddVideo()
     if (selector->Create())
         mainStack->AddScreen(selector);
 }
+
+#include "moc_exportnative.cpp"

--- a/mythplugins/mytharchive/mytharchive/fileselector.cpp
+++ b/mythplugins/mytharchive/mytharchive/fileselector.cpp
@@ -439,3 +439,5 @@ void FileSelector::updateFileList()
             "MythArchive:  current directory does not exist!");
     }
 }
+
+#include "moc_fileselector.cpp"

--- a/mythplugins/mytharchive/mytharchive/importnative.cpp
+++ b/mythplugins/mytharchive/mytharchive/importnative.cpp
@@ -649,3 +649,5 @@ void ImportNative::gotCallsign(const QString& value)
         m_localCallsignText->SetText(query.value(3).toString());
     }
 }
+
+#include "moc_importnative.cpp"

--- a/mythplugins/mytharchive/mytharchive/logviewer.cpp
+++ b/mythplugins/mytharchive/mytharchive/logviewer.cpp
@@ -354,3 +354,5 @@ void LogViewer::ShowMenu()
     menuPopup->AddButton(tr("Show Progress Log"), &LogViewer::showProgressLog);
     menuPopup->AddButton(tr("Show Full Log"), &LogViewer::showFullLog);
 }
+
+#include "moc_logviewer.cpp"

--- a/mythplugins/mytharchive/mytharchive/mythburn.cpp
+++ b/mythplugins/mytharchive/mytharchive/mythburn.cpp
@@ -1181,4 +1181,4 @@ void BurnMenu::doBurn(int mode)
     showLogViewer();
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mythburn.cpp"

--- a/mythplugins/mytharchive/mytharchive/recordingselector.cpp
+++ b/mythplugins/mytharchive/mytharchive/recordingselector.cpp
@@ -517,3 +517,5 @@ void RecordingSelector::updateSelectedList()
         }
     }
 }
+
+#include "moc_recordingselector.cpp"

--- a/mythplugins/mytharchive/mytharchive/selectdestination.cpp
+++ b/mythplugins/mytharchive/mytharchive/selectdestination.cpp
@@ -322,3 +322,5 @@ void SelectDestination::filenameEditLostFocus()
         m_freeSpace = 0;
     }
 }
+
+#include "moc_selectdestination.cpp"

--- a/mythplugins/mytharchive/mytharchive/themeselector.cpp
+++ b/mythplugins/mytharchive/mytharchive/themeselector.cpp
@@ -252,3 +252,5 @@ void DVDThemeSelector::saveConfiguration(void)
     theme = theme.replace(QString(" "), QString("_"));
     gCoreContext->SaveSetting("MythBurnMenuTheme", theme);
 }
+
+#include "moc_themeselector.cpp"

--- a/mythplugins/mytharchive/mytharchive/thumbfinder.cpp
+++ b/mythplugins/mytharchive/mytharchive/thumbfinder.cpp
@@ -962,3 +962,5 @@ int ThumbFinder::calcFinalDuration()
 
     return m_archiveItem->duration;
 }
+
+#include "moc_thumbfinder.cpp"

--- a/mythplugins/mytharchive/mytharchive/videoselector.cpp
+++ b/mythplugins/mytharchive/mytharchive/videoselector.cpp
@@ -556,3 +556,5 @@ void VideoSelector::parentalLevelChanged(bool passwordValid, ParentalLevel::Leve
     }
 }
 
+
+#include "moc_videoselector.cpp"

--- a/mythplugins/mythbrowser/mythbrowser/bookmarkeditor.cpp
+++ b/mythplugins/mythbrowser/mythbrowser/bookmarkeditor.cpp
@@ -149,3 +149,5 @@ void BookmarkEditor::slotCategoryFound(const QString& category)
 {
     m_categoryEdit->SetText(category);
 }
+
+#include "moc_bookmarkeditor.cpp"

--- a/mythplugins/mythbrowser/mythbrowser/bookmarkmanager.cpp
+++ b/mythplugins/mythbrowser/mythbrowser/bookmarkmanager.cpp
@@ -659,3 +659,5 @@ void BookmarkManager::slotClearMarked(void)
         }
     }
 }
+
+#include "moc_bookmarkmanager.cpp"

--- a/mythplugins/mythbrowser/mythbrowser/mythbrowser.cpp
+++ b/mythplugins/mythbrowser/mythbrowser/mythbrowser.cpp
@@ -405,3 +405,5 @@ bool MythBrowser::keyPressEvent(QKeyEvent *event)
 }
 
 
+
+#include "moc_mythbrowser.cpp"

--- a/mythplugins/mythbrowser/mythbrowser/mythflashplayer.cpp
+++ b/mythplugins/mythbrowser/mythbrowser/mythflashplayer.cpp
@@ -111,3 +111,5 @@ bool MythFlashPlayer::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_mythflashplayer.cpp"

--- a/mythplugins/mythbrowser/mythbrowser/webpage.cpp
+++ b/mythplugins/mythbrowser/mythbrowser/webpage.cpp
@@ -139,3 +139,5 @@ void WebPage::slotTitleChanged(const QString &title)
     m_listItem->SetText(title);
     m_parent->m_pageList->Update();
 }
+
+#include "moc_webpage.cpp"

--- a/mythplugins/mythgame/mythgame/gamedetails.cpp
+++ b/mythplugins/mythgame/mythgame/gamedetails.cpp
@@ -94,3 +94,5 @@ void GameDetailsPopup::SetReturnEvent(QObject *retobject,
     m_id = resultid;
 }
 
+
+#include "moc_gamedetails.cpp"

--- a/mythplugins/mythgame/mythgame/gamehandler.cpp
+++ b/mythplugins/mythgame/mythgame/gamehandler.cpp
@@ -1016,3 +1016,5 @@ void GameHandler::CreateProgress(const QString& message)
         m_progressDlg = nullptr;
     }
 }
+
+#include "moc_gamehandler.cpp"

--- a/mythplugins/mythgame/mythgame/gamescan.cpp
+++ b/mythplugins/mythgame/mythgame/gamescan.cpp
@@ -255,4 +255,4 @@ void GameScanner::finishedScan()
     emit finished(m_scanThread->getDataChanged());
 }
 
-////////////////////////////////////////////////////////////////////////
+#include "moc_gamescan.cpp"

--- a/mythplugins/mythgame/mythgame/gamesettings.cpp
+++ b/mythplugins/mythgame/mythgame/gamesettings.cpp
@@ -429,3 +429,5 @@ void GamePlayersList::CreateNewPlayer(const QString& name)
     // Redraw list
     setVisible(true);
 }
+
+#include "moc_gamesettings.cpp"

--- a/mythplugins/mythgame/mythgame/gameui.cpp
+++ b/mythplugins/mythgame/mythgame/gameui.cpp
@@ -1113,3 +1113,5 @@ void GameUI::reloadAllData(bool dbChanged)
         BuildTree();
 }
 
+
+#include "moc_gameui.cpp"

--- a/mythplugins/mythgame/mythgame/romedit.cpp
+++ b/mythplugins/mythgame/mythgame/romedit.cpp
@@ -256,3 +256,5 @@ void EditRomInfoDialog::SetBoxart(const QString& file)
     m_workingRomInfo->setBoxart(file);
     m_boxartText->SetText(file);
 }
+
+#include "moc_romedit.cpp"

--- a/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
+++ b/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
@@ -626,3 +626,5 @@ Decoder *avfDecoderFactory::create(const QString &file, AudioOutput *output, boo
 
     return s_decoder;
 }
+
+#include "moc_avfdecoder.cpp"

--- a/mythplugins/mythmusic/mythmusic/cdrip.cpp
+++ b/mythplugins/mythmusic/mythmusic/cdrip.cpp
@@ -1641,3 +1641,5 @@ void RipStatus::startRip(void)
     m_ripperThread = new CDRipperThread(this, m_cdDevice, m_tracks, m_quality);
     m_ripperThread->start();
 }
+
+#include "moc_cdrip.cpp"

--- a/mythplugins/mythmusic/mythmusic/decoderhandler.cpp
+++ b/mythplugins/mythmusic/mythmusic/decoderhandler.cpp
@@ -383,3 +383,5 @@ void DecoderHandler::doOperationStop(void)
     DecoderHandlerEvent ev(DecoderHandlerEvent::kOperationStop);
     dispatch(ev);
 }
+
+#include "moc_decoderhandler.cpp"

--- a/mythplugins/mythmusic/mythmusic/editmetadata.cpp
+++ b/mythplugins/mythmusic/mythmusic/editmetadata.cpp
@@ -1383,3 +1383,5 @@ void EditAlbumartDialog::removeCachedImage(const AlbumArtImage *image)
 
     GetMythUI()->RemoveFromCacheByFile(image->m_filename);
 }
+
+#include "moc_editmetadata.cpp"

--- a/mythplugins/mythmusic/mythmusic/generalsettings.cpp
+++ b/mythplugins/mythmusic/mythmusic/generalsettings.cpp
@@ -170,3 +170,5 @@ void GeneralSettings::slotSave(void)
 
     Close();
 }
+
+#include "moc_generalsettings.cpp"

--- a/mythplugins/mythmusic/mythmusic/importmusic.cpp
+++ b/mythplugins/mythmusic/mythmusic/importmusic.cpp
@@ -1150,3 +1150,5 @@ void ImportCoverArtDialog::updateTypeSelector()
     else
         m_typeList->SetValue(tr("<Unknown>"));
 }
+
+#include "moc_importmusic.cpp"

--- a/mythplugins/mythmusic/mythmusic/importsettings.cpp
+++ b/mythplugins/mythmusic/mythmusic/importsettings.cpp
@@ -124,3 +124,5 @@ void ImportSettings::slotSave(void)
 
     Close();
 }
+
+#include "moc_importsettings.cpp"

--- a/mythplugins/mythmusic/mythmusic/lyricsview.cpp
+++ b/mythplugins/mythmusic/mythmusic/lyricsview.cpp
@@ -662,3 +662,5 @@ void EditLyricsDialog::cancelPressed(void )
     emit haveResult(false);
     Close();
 }
+
+#include "moc_lyricsview.cpp"

--- a/mythplugins/mythmusic/mythmusic/mainvisual.cpp
+++ b/mythplugins/mythmusic/mythmusic/mainvisual.cpp
@@ -281,3 +281,5 @@ void MainVisual::customEvent(QEvent *event)
         m_playing = false;
     }
 }
+
+#include "moc_mainvisual.cpp"

--- a/mythplugins/mythmusic/mythmusic/miniplayer.cpp
+++ b/mythplugins/mythmusic/mythmusic/miniplayer.cpp
@@ -108,3 +108,5 @@ bool MiniPlayer::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_miniplayer.cpp"

--- a/mythplugins/mythmusic/mythmusic/musiccommon.cpp
+++ b/mythplugins/mythmusic/mythmusic/musiccommon.cpp
@@ -2933,3 +2933,5 @@ bool TrackInfoDialog::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_musiccommon.cpp"

--- a/mythplugins/mythmusic/mythmusic/musicdata.cpp
+++ b/mythplugins/mythmusic/mythmusic/musicdata.cpp
@@ -142,3 +142,5 @@ void MusicData::loadMusic(void) const
     if (busy)
         busy->Close();
 }
+
+#include "moc_musicdata.cpp"

--- a/mythplugins/mythmusic/mythmusic/musicplayer.cpp
+++ b/mythplugins/mythmusic/mythmusic/musicplayer.cpp
@@ -1679,3 +1679,5 @@ void MusicPlayer::sendNotification(int notificationID, const QString &title, con
     GetNotificationCenter()->Queue(*n);
     delete n;
 }
+
+#include "moc_musicplayer.cpp"

--- a/mythplugins/mythmusic/mythmusic/playersettings.cpp
+++ b/mythplugins/mythmusic/mythmusic/playersettings.cpp
@@ -108,3 +108,4 @@ void PlayerSettings::slotSave(void)
     Close();
 }
 
+#include "moc_playersettings.cpp"

--- a/mythplugins/mythmusic/mythmusic/playlist.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlist.cpp
@@ -1456,3 +1456,5 @@ int Playlist::CreateCDAudio(void)
     return -1;
 }
 #endif
+
+#include "moc_playlist.cpp"

--- a/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlisteditorview.cpp
@@ -1806,3 +1806,5 @@ void PlaylistEditorView::deletePlaylist(bool ok)
         }
     }
 }
+
+#include "moc_playlisteditorview.cpp"

--- a/mythplugins/mythmusic/mythmusic/playlistview.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlistview.cpp
@@ -56,3 +56,5 @@ bool PlaylistView::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_playlistview.cpp"

--- a/mythplugins/mythmusic/mythmusic/ratingsettings.cpp
+++ b/mythplugins/mythmusic/mythmusic/ratingsettings.cpp
@@ -76,4 +76,4 @@ void RatingSettings::slotSave(void)
     Close();
 }
 
-
+#include "moc_ratingsettings.cpp"

--- a/mythplugins/mythmusic/mythmusic/searchview.cpp
+++ b/mythplugins/mythmusic/mythmusic/searchview.cpp
@@ -497,3 +497,5 @@ void SearchView::trackVisible(MythUIButtonListItem *item)
         }
     }
 }
+
+#include "moc_searchview.cpp"

--- a/mythplugins/mythmusic/mythmusic/smartplaylist.cpp
+++ b/mythplugins/mythmusic/mythmusic/smartplaylist.cpp
@@ -2207,3 +2207,4 @@ void SmartPLDateDialog::valueChanged(void)
     m_okButton->SetEnabled(bValidDate);
 }
 
+#include "moc_smartplaylist.cpp"

--- a/mythplugins/mythmusic/mythmusic/streamview.cpp
+++ b/mythplugins/mythmusic/mythmusic/streamview.cpp
@@ -1163,3 +1163,5 @@ void SearchStream::doUpdateStreams(void)
 
     m_updating = false;
 }
+
+#include "moc_streamview.cpp"

--- a/mythplugins/mythmusic/mythmusic/visualizationsettings.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualizationsettings.cpp
@@ -77,3 +77,5 @@ void VisualizationSettings::slotSave(void)
 
     Close();
 }
+
+#include "moc_visualizationsettings.cpp"

--- a/mythplugins/mythmusic/mythmusic/visualizerview.cpp
+++ b/mythplugins/mythmusic/mythmusic/visualizerview.cpp
@@ -289,3 +289,5 @@ bool TrackInfoPopup::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_visualizerview.cpp"

--- a/mythplugins/mythnetvision/mythnetvision/netbase.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/netbase.cpp
@@ -334,3 +334,5 @@ void NetBase::DoPlayVideo(void)
 
     DoPlayVideo(filename);
 }
+
+#include "moc_netbase.cpp"

--- a/mythplugins/mythnetvision/mythnetvision/neteditorbase.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/neteditorbase.cpp
@@ -246,3 +246,5 @@ void NetEditorBase::ToggleItem(MythUIButtonListItem *item)
         item->setChecked(MythUIButtonListItem::NotChecked);
     }
 }
+
+#include "moc_neteditorbase.cpp"

--- a/mythplugins/mythnetvision/mythnetvision/netsearch.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/netsearch.cpp
@@ -591,3 +591,5 @@ void NetSearch::customEvent(QEvent *event)
         NetBase::customEvent(event);
     }
 }
+
+#include "moc_netsearch.cpp"

--- a/mythplugins/mythnetvision/mythnetvision/nettree.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/nettree.cpp
@@ -1004,3 +1004,5 @@ void NetTree::SetSubfolderData(MythGenericTree *folder)
                     "childcount");
     folder->DisplayState("subfolder", "nodetype");
 }
+
+#include "moc_nettree.cpp"

--- a/mythplugins/mythnetvision/mythnetvision/rsseditor.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/rsseditor.cpp
@@ -557,3 +557,5 @@ void RSSEditor::ListChanged()
     m_changed = true;
     LoadData();
 }
+
+#include "moc_rsseditor.cpp"

--- a/mythplugins/mythnetvision/mythnetvision/searcheditor.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/searcheditor.cpp
@@ -21,3 +21,5 @@ bool SearchEditor::Matches(bool search, bool /*tree*/)
 {
     return search;
 }
+
+#include "moc_searcheditor.cpp"

--- a/mythplugins/mythnetvision/mythnetvision/treeeditor.cpp
+++ b/mythplugins/mythnetvision/mythnetvision/treeeditor.cpp
@@ -26,3 +26,5 @@ bool TreeEditor::Matches(bool /*search*/, bool tree)
 {
     return tree;
 }
+
+#include "moc_treeeditor.cpp"

--- a/mythplugins/mythnews/mythnews/mythnews.cpp
+++ b/mythplugins/mythnews/mythnews/mythnews.cpp
@@ -735,3 +735,5 @@ QString MythNews::cleanText(const QString &text)
 
     return result;
 }
+
+#include "moc_mythnews.cpp"

--- a/mythplugins/mythnews/mythnews/mythnewsconfig.cpp
+++ b/mythplugins/mythnews/mythnews/mythnewsconfig.cpp
@@ -244,3 +244,5 @@ bool MythNewsConfig::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_mythnewsconfig.cpp"

--- a/mythplugins/mythnews/mythnews/mythnewseditor.cpp
+++ b/mythplugins/mythnews/mythnews/mythnewseditor.cpp
@@ -135,3 +135,5 @@ void MythNewsEditor::Save(void)
     }
     Close();
 }
+
+#include "moc_mythnewseditor.cpp"

--- a/mythplugins/mythnews/mythnews/newssite.cpp
+++ b/mythplugins/mythnews/mythnews/newssite.cpp
@@ -518,3 +518,5 @@ QString NewsSite::ReplaceHtmlChar(const QString &orig)
 
     return s;
 }
+
+#include "moc_newssite.cpp"

--- a/mythplugins/mythweather/mythweather/sourceManager.cpp
+++ b/mythplugins/mythweather/mythweather/sourceManager.cpp
@@ -379,3 +379,5 @@ void SourceManager::recurseDirs( QDir dir )
         }
     }
 }
+
+#include "moc_sourceManager.cpp"

--- a/mythplugins/mythweather/mythweather/weather.cpp
+++ b/mythplugins/mythweather/mythweather/weather.cpp
@@ -380,6 +380,4 @@ void Weather::nextpage_timeout()
     m_nextPageTimer->start(m_nextpageInterval);
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_weather.cpp"

--- a/mythplugins/mythweather/mythweather/weatherScreen.cpp
+++ b/mythplugins/mythweather/mythweather/weatherScreen.cpp
@@ -237,6 +237,4 @@ bool WeatherScreen::keyPressEvent(QKeyEvent *event)
     return GetFocusWidget() && GetFocusWidget()->keyPressEvent(event);
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_weatherScreen.cpp"

--- a/mythplugins/mythweather/mythweather/weatherSetup.cpp
+++ b/mythplugins/mythweather/mythweather/weatherSetup.cpp
@@ -1014,3 +1014,5 @@ void LocationDialog::itemClicked(MythUIButtonListItem *item)
 
     Close();
 }
+
+#include "moc_weatherSetup.cpp"

--- a/mythplugins/mythweather/mythweather/weatherSource.cpp
+++ b/mythplugins/mythweather/mythweather/weatherSource.cpp
@@ -602,3 +602,4 @@ void WeatherSource::processData()
     }
 }
 
+#include "moc_weatherSource.cpp"

--- a/mythplugins/mythzoneminder/mythzoneminder/zmclient.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/zmclient.cpp
@@ -1005,3 +1005,5 @@ void ZMClient::showMiniPlayer(int monitorID) const
     if (miniPlayer->Create())
         popupStack->AddScreen(miniPlayer);
 }
+
+#include "moc_zmclient.cpp"

--- a/mythplugins/mythzoneminder/mythzoneminder/zmconsole.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/zmconsole.cpp
@@ -291,3 +291,5 @@ void ZMConsole::functionChanged(bool changed)
     if (changed)
         updateStatus();
 }
+
+#include "moc_zmconsole.cpp"

--- a/mythplugins/mythzoneminder/mythzoneminder/zmevents.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/zmevents.cpp
@@ -493,3 +493,5 @@ void ZMEvents::doDeleteAll(bool doDelete)
         getEventList();
     }
 }
+
+#include "moc_zmevents.cpp"

--- a/mythplugins/mythzoneminder/mythzoneminder/zmliveplayer.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/zmliveplayer.cpp
@@ -517,3 +517,5 @@ void Player::updateCamera()
     if (m_cameraText)
         m_cameraText->SetText(m_monitor.name);
 }
+
+#include "moc_zmliveplayer.cpp"

--- a/mythplugins/mythzoneminder/mythzoneminder/zmminiplayer.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/zmminiplayer.cpp
@@ -149,3 +149,5 @@ bool ZMMiniPlayer::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_zmminiplayer.cpp"

--- a/mythplugins/mythzoneminder/mythzoneminder/zmplayer.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/zmplayer.cpp
@@ -399,3 +399,5 @@ void ZMPlayer::getFrame(void)
         }
     }
 }
+
+#include "moc_zmplayer.cpp"

--- a/mythtv/libs/libmyth/backendselect.cpp
+++ b/mythtv/libs/libmyth/backendselect.cpp
@@ -405,3 +405,5 @@ void BackendSelection::CloseWithDecision(Decision d)
     else
         MythScreenType::Close();
 }
+
+#include "moc_backendselect.cpp"

--- a/mythtv/libs/libmyth/guistartup.cpp
+++ b/mythtv/libs/libmyth/guistartup.cpp
@@ -238,3 +238,4 @@ void GUIStartup::Setup(void)
         m_loop->exit();
 }
 
+#include "moc_guistartup.cpp"

--- a/mythtv/libs/libmythbase/bonjourregister.cpp
+++ b/mythtv/libs/libmythbase/bonjourregister.cpp
@@ -166,3 +166,5 @@ bool BonjourRegister::ReAnnounceService(void)
     }
     return kDNSServiceErr_NoError != res;
 }
+
+#include "moc_bonjourregister.cpp"

--- a/mythtv/libs/libmythbase/hardwareprofile.cpp
+++ b/mythtv/libs/libmythbase/hardwareprofile.cpp
@@ -287,3 +287,5 @@ bool HardwareProfileTask::DoRun(void)
     HardwareProfile hp;
     return hp.SubmitProfile(false);
 }
+
+#include "moc_hardwareprofile.cpp"

--- a/mythtv/libs/libmythbase/housekeeper.cpp
+++ b/mythtv/libs/libmythbase/housekeeper.cpp
@@ -912,3 +912,5 @@ bool DBConnPurgeTask::DoRun()
     GetMythDB()->GetDBManager()->PurgeIdleConnections(false);
     return true;
 }
+
+#include "moc_housekeeper.cpp"

--- a/mythtv/libs/libmythbase/http/mythhttpserver.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttpserver.cpp
@@ -627,3 +627,5 @@ void MythHTTPServer::DebugHosts()
             LOG(VB_GENERAL, LOG_INFO, LOC + QString("Host: %1").arg(address));
     }
 }
+
+#include "moc_mythhttpserver.cpp"

--- a/mythtv/libs/libmythbase/http/mythhttpservice.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttpservice.cpp
@@ -283,3 +283,5 @@ QString& MythHTTPService::Name()
 {
     return m_name;
 }
+
+#include "moc_mythhttpservice.cpp"

--- a/mythtv/libs/libmythbase/http/mythhttpservices.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttpservices.cpp
@@ -22,3 +22,5 @@ QStringList MythHTTPServices::GetServiceList()
 {
     return m_serviceList;
 }
+
+#include "moc_mythhttpservices.cpp"

--- a/mythtv/libs/libmythbase/http/mythhttpsocket.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttpsocket.cpp
@@ -651,3 +651,5 @@ void MythHTTPSocket::NewBinaryMessage(const DataPayloads& Payloads)
     if (Payloads.empty())
         return;
 }
+
+#include "moc_mythhttpsocket.cpp"

--- a/mythtv/libs/libmythbase/http/mythhttpthreadpool.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttpthreadpool.cpp
@@ -100,3 +100,5 @@ void MythHTTPThreadPool::ThreadUpgraded(QThread* Thread)
             .arg(upgraded).arg(m_maxThreads));
     }
 }
+
+#include "moc_mythhttpthreadpool.cpp"

--- a/mythtv/libs/libmythbase/http/mythwebsocket.cpp
+++ b/mythtv/libs/libmythbase/http/mythwebsocket.cpp
@@ -686,3 +686,4 @@ void MythWebSocket::SendPing()
         SendFrame(WSOpPing, { payload });
 }
 
+#include "moc_mythwebsocket.cpp"

--- a/mythtv/libs/libmythbase/http/mythwebsocketevent.cpp
+++ b/mythtv/libs/libmythbase/http/mythwebsocketevent.cpp
@@ -82,3 +82,5 @@ void MythWebSocketEvent::customEvent(QEvent* event)
         emit SendTextMessage(message);
     }
 }
+
+#include "moc_mythwebsocketevent.cpp"

--- a/mythtv/libs/libmythbase/http/mythwebsocketevent.h
+++ b/mythtv/libs/libmythbase/http/mythwebsocketevent.h
@@ -1,3 +1,6 @@
+#ifndef LIBMYTHBASE_HTTP_MYTHWEBSOCKETEVENT_H
+#define LIBMYTHBASE_HTTP_MYTHWEBSOCKETEVENT_H
+
 #include <QObject>
 #include <QString>
 
@@ -26,3 +29,5 @@ class MythWebSocketEvent : public QObject
         QStringList m_filters;
         bool        m_sendEvents {false}; /// True if the client has enabled events
 };
+
+#endif // LIBMYTHBASE_HTTP_MYTHWEBSOCKETEVENT_H

--- a/mythtv/libs/libmythbase/lcddevice.cpp
+++ b/mythtv/libs/libmythbase/lcddevice.cpp
@@ -736,3 +736,5 @@ bool LCD::startLCDServer(void)
     uint retval = myth_system(command, flags);
     return( retval == GENERIC_EXIT_RUNNING );
 }
+
+#include "moc_lcddevice.cpp"

--- a/mythtv/libs/libmythbase/logging.cpp
+++ b/mythtv/libs/libmythbase/logging.cpp
@@ -1041,7 +1041,4 @@ QString logStrerror(int errnum)
     return QString("%1 (%2)").arg(strerror(errnum)).arg(errnum);
 }
 
-
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_logging.cpp"

--- a/mythtv/libs/libmythbase/loggingserver.cpp
+++ b/mythtv/libs/libmythbase/loggingserver.cpp
@@ -490,6 +490,4 @@ void logForwardMessage(LoggingItem *item)
         gLogItemListNotEmpty.wakeAll();
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_loggingserver.cpp"

--- a/mythtv/libs/libmythbase/mythcdrom.cpp
+++ b/mythtv/libs/libmythbase/mythcdrom.cpp
@@ -256,3 +256,5 @@ MythCDROM::ImageType MythCDROM::inspectImage(const QString &path)
 
     return imageType;
 }
+
+#include "moc_mythcdrom.cpp"

--- a/mythtv/libs/libmythbase/mythcorecontext.cpp
+++ b/mythtv/libs/libmythbase/mythcorecontext.cpp
@@ -2199,4 +2199,4 @@ bool MythCoreContext::IsRegisteredFileForWrite(const QString& file)
     return d->m_fileswritten.contains(file);
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mythcorecontext.cpp"

--- a/mythtv/libs/libmythbase/mythdownloadmanager.cpp
+++ b/mythtv/libs/libmythbase/mythdownloadmanager.cpp
@@ -1826,5 +1826,4 @@ void MythCookieJar::save(const QString &filename)
         stream << cookie.toRawForm() << Qt::endl;
 }
 
-
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mythdownloadmanager.cpp"

--- a/mythtv/libs/libmythbase/mythmedia.cpp
+++ b/mythtv/libs/libmythbase/mythmedia.cpp
@@ -562,3 +562,5 @@ QString MythMediaDevice::MediaTypeString(uint type)
 
     return mediatype;
 }
+
+#include "moc_mythmedia.cpp"

--- a/mythtv/libs/libmythbase/mythpower.cpp
+++ b/mythtv/libs/libmythbase/mythpower.cpp
@@ -386,3 +386,5 @@ void MythPower::PowerLevelChanged(int Level)
 
     m_powerLevel = Level;
 }
+
+#include "moc_mythpower.cpp"

--- a/mythtv/libs/libmythbase/mythsingledownload.cpp
+++ b/mythtv/libs/libmythbase/mythsingledownload.cpp
@@ -137,3 +137,5 @@ void MythSingleDownload::Progress(qint64 bytesRead, qint64 /*totalBytes*/)
         Cancel();
     }
 }
+
+#include "moc_mythsingledownload.cpp"

--- a/mythtv/libs/libmythbase/mythsocket.cpp
+++ b/mythtv/libs/libmythbase/mythsocket.cpp
@@ -999,3 +999,5 @@ void MythSocket::ResetReal(void)
 
     m_dataAvailable.fetchAndStoreOrdered(0);
 }
+
+#include "moc_mythsocket.cpp"

--- a/mythtv/libs/libmythbase/mythsystemlegacy.cpp
+++ b/mythtv/libs/libmythbase/mythsystemlegacy.cpp
@@ -530,6 +530,4 @@ uint myth_system(const QString &Command, const QStringList& Args, uint Flags,
     return result;
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_mythsystemlegacy.cpp"

--- a/mythtv/libs/libmythbase/mythsystemunix.cpp
+++ b/mythtv/libs/libmythbase/mythsystemunix.cpp
@@ -1168,6 +1168,4 @@ void MythSystemLegacyUnix::JumpAbort(void)
     manager->jumpAbort();
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_mythsystemunix.cpp"

--- a/mythtv/libs/libmythbase/mythsystemwindows.cpp
+++ b/mythtv/libs/libmythbase/mythsystemwindows.cpp
@@ -790,6 +790,4 @@ void MythSystemLegacyWindows::JumpAbort(void)
     manager->jumpAbort();
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_mythsystemwindows.cpp"

--- a/mythtv/libs/libmythbase/netgrabbermanager.cpp
+++ b/mythtv/libs/libmythbase/netgrabbermanager.cpp
@@ -415,3 +415,5 @@ void Search::SetData(QByteArray data)
     m_document.setContent(m_data, QDomDocument::ParseOption::UseNamespaceProcessing);
 #endif
 }
+
+#include "moc_netgrabbermanager.cpp"

--- a/mythtv/libs/libmythbase/platforms/mythpowerdbus.cpp
+++ b/mythtv/libs/libmythbase/platforms/mythpowerdbus.cpp
@@ -569,3 +569,5 @@ void MythPowerDBus::ReleaseLock(void)
     close(m_lockHandle);
     m_lockHandle = -1;
 }
+
+#include "moc_mythpowerdbus.cpp"

--- a/mythtv/libs/libmythbase/platforms/mythpowerosx.cpp
+++ b/mythtv/libs/libmythbase/platforms/mythpowerosx.cpp
@@ -236,3 +236,5 @@ OSStatus SendAppleEventToSystemProcess(AEEventID EventToSend)
     AEDisposeDesc(&eventReply);
     return error;
 }
+
+#include "moc_mythpowerosx.cpp"

--- a/mythtv/libs/libmythbase/portchecker.cpp
+++ b/mythtv/libs/libmythbase/portchecker.cpp
@@ -261,5 +261,4 @@ void PortChecker::cancelPortCheck(void)
     m_cancelCheck = true;
 }
 
-
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_portchecker.cpp"

--- a/mythtv/libs/libmythbase/rssmanager.cpp
+++ b/mythtv/libs/libmythbase/rssmanager.cpp
@@ -260,3 +260,5 @@ void RSSSite::process(void)
 
     emit finished(this);
 }
+
+#include "moc_rssmanager.cpp"

--- a/mythtv/libs/libmythbase/rssparse.cpp
+++ b/mythtv/libs/libmythbase/rssparse.cpp
@@ -1181,3 +1181,5 @@ QString Parse::UnescapeHTML(const QString& escaped)
 
     return result;
 }
+
+#include "moc_rssparse.cpp"

--- a/mythtv/libs/libmythbase/serverpool.cpp
+++ b/mythtv/libs/libmythbase/serverpool.cpp
@@ -903,3 +903,5 @@ int ServerPool::tryBindingPort(QUdpSocket *socket, int baseport,
     }
     return port;
 }
+
+#include "moc_serverpool.cpp"

--- a/mythtv/libs/libmythbase/signalhandling.cpp
+++ b/mythtv/libs/libmythbase/signalhandling.cpp
@@ -360,6 +360,4 @@ void SignalHandler::handleSignal(void)
 #endif // Q_OS_WINDOWS
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_signalhandling.cpp"

--- a/mythtv/libs/libmythbase/test/test_iso639/test_iso639.cpp
+++ b/mythtv/libs/libmythbase/test/test_iso639/test_iso639.cpp
@@ -159,3 +159,5 @@ void TestISO639::test_key_to_cankey(void)
 
 
 QTEST_APPLESS_MAIN(TestISO639)
+
+#include "moc_test_iso639.cpp"

--- a/mythtv/libs/libmythbase/test/test_lcddevice/test_lcddevice.cpp
+++ b/mythtv/libs/libmythbase/test/test_lcddevice/test_lcddevice.cpp
@@ -61,3 +61,5 @@ void TestLcdDevice::test_quotedString (void)
 }
 
 QTEST_APPLESS_MAIN(TestLcdDevice)
+
+#include "moc_test_lcddevice.cpp"

--- a/mythtv/libs/libmythbase/test/test_logging/test_logging.cpp
+++ b/mythtv/libs/libmythbase/test/test_logging/test_logging.cpp
@@ -353,3 +353,5 @@ void TestLogging::test_logPropagateCalc (void)
 }
 
 QTEST_APPLESS_MAIN(TestLogging)
+
+#include "moc_test_logging.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythbinaryplist/test_mythbinaryplist.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythbinaryplist/test_mythbinaryplist.cpp
@@ -180,3 +180,5 @@ void TestMythBinaryPList::plist_read(void)
 
 
 QTEST_APPLESS_MAIN(TestMythBinaryPList)
+
+#include "moc_test_mythbinaryplist.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythcommandlineparser/test_mythcommandlineparser.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythcommandlineparser/test_mythcommandlineparser.cpp
@@ -268,3 +268,5 @@ void TestCommandLineParser::test_parse_cmdline(void)
 }
 
 QTEST_APPLESS_MAIN(TestCommandLineParser)
+
+#include "moc_test_mythcommandlineparser.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythdate/test_mythdate.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythdate/test_mythdate.cpp
@@ -57,3 +57,5 @@ void TestMythDate::formatting(void)
 }
 
 QTEST_APPLESS_MAIN(TestMythDate)
+
+#include "moc_test_mythdate.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythdbcon/test_mythdbcon.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythdbcon/test_mythdbcon.cpp
@@ -83,3 +83,5 @@ void TestDbCon::cleanupTestCase()
 }
 
 QTEST_GUILESS_MAIN(TestDbCon)
+
+#include "moc_test_mythdbcon.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythsorthelper/test_mythsorthelper.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythsorthelper/test_mythsorthelper.cpp
@@ -165,3 +165,5 @@ void TestSortHelper::Variations_test(void)
 }
 
 QTEST_APPLESS_MAIN(TestSortHelper)
+
+#include "moc_test_mythsorthelper.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythsystem/test_mythsystem.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythsystem/test_mythsystem.cpp
@@ -1,3 +1,5 @@
 #include "test_mythsystem.h"
 
 QTEST_APPLESS_MAIN(TestMythSystem)
+
+#include "moc_test_mythsystem.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythsystemlegacy/test_mythsystemlegacy.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythsystemlegacy/test_mythsystemlegacy.cpp
@@ -1,3 +1,5 @@
 #include "test_mythsystemlegacy.h"
 
 QTEST_APPLESS_MAIN(TestMythSystemLegacy)
+
+#include "moc_test_mythsystemlegacy.cpp"

--- a/mythtv/libs/libmythbase/test/test_mythtimer/test_mythtimer.cpp
+++ b/mythtv/libs/libmythbase/test/test_mythtimer/test_mythtimer.cpp
@@ -1,3 +1,5 @@
 #include "test_mythtimer.h"
 
 QTEST_APPLESS_MAIN(TestMythTimer)
+
+#include "moc_test_mythtimer.cpp"

--- a/mythtv/libs/libmythbase/test/test_rssparse/test_rssparse.cpp
+++ b/mythtv/libs/libmythbase/test/test_rssparse/test_rssparse.cpp
@@ -120,3 +120,5 @@ void TestRSSParse::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestRSSParse)
+
+#include "moc_test_rssparse.cpp"

--- a/mythtv/libs/libmythbase/test/test_template/test_template.cpp
+++ b/mythtv/libs/libmythbase/test/test_template/test_template.cpp
@@ -88,3 +88,5 @@ void TestTemplate::example_repeated_test(void)
 }
 
 QTEST_APPLESS_MAIN(TestTemplate)
+
+#include "moc_test_template.cpp"

--- a/mythtv/libs/libmythbase/test/test_theme_version/test_theme_version.cpp
+++ b/mythtv/libs/libmythbase/test/test_theme_version/test_theme_version.cpp
@@ -67,3 +67,5 @@ void TestThemeVersion::test_version(void)
 }
 
 QTEST_APPLESS_MAIN(TestThemeVersion)
+
+#include "moc_test_theme_version.cpp"

--- a/mythtv/libs/libmythbase/test/test_unzip/test_unzip.cpp
+++ b/mythtv/libs/libmythbase/test/test_unzip/test_unzip.cpp
@@ -95,3 +95,5 @@ void TestUnzip::test_theme_file(void)
 }
 
 QTEST_APPLESS_MAIN(TestUnzip)
+
+#include "moc_test_unzip.cpp"

--- a/mythtv/libs/libmythfreemheg/test/test_mheg_parser/test_mheg_parser.cpp
+++ b/mythtv/libs/libmythfreemheg/test/test_mheg_parser/test_mheg_parser.cpp
@@ -5990,3 +5990,5 @@ void TestMhegParser::test_parser_text(void)
 }
 
 QTEST_GUILESS_MAIN(TestMhegParser)
+
+#include "moc_test_mheg_parser.cpp"

--- a/mythtv/libs/libmythmetadata/lyricsdata.cpp
+++ b/mythtv/libs/libmythmetadata/lyricsdata.cpp
@@ -382,3 +382,5 @@ void LyricsData::setLyrics(const QStringList &lyrics)
         m_lyricsMap.insert(line->m_time, line);
     }
 }
+
+#include "moc_lyricsdata.cpp"

--- a/mythtv/libs/libmythmetadata/mythuiimageresults.cpp
+++ b/mythtv/libs/libmythmetadata/mythuiimageresults.cpp
@@ -158,3 +158,4 @@ void ImageSearchResultsDialog::sendResult(MythUIButtonListItem* item)
     Close();
 }
 
+#include "moc_mythuiimageresults.cpp"

--- a/mythtv/libs/libmythmetadata/mythuimetadataresults.cpp
+++ b/mythtv/libs/libmythmetadata/mythuimetadataresults.cpp
@@ -166,3 +166,5 @@ void MetadataResultsDialog::sendResult(MythUIButtonListItem* item)
     emit haveResult(lookup);
     Close();
 }
+
+#include "moc_mythuimetadataresults.cpp"

--- a/mythtv/libs/libmythmetadata/parentalcontrols.cpp
+++ b/mythtv/libs/libmythmetadata/parentalcontrols.cpp
@@ -374,3 +374,4 @@ void ParentalLevelChangeChecker::OnResultReady(bool passwordValid,
 }
 
 #include "parentalcontrols.moc"
+#include "moc_parentalcontrols.cpp"

--- a/mythtv/libs/libmythmetadata/test/test_lyrics/test_lyrics.cpp
+++ b/mythtv/libs/libmythmetadata/test/test_lyrics/test_lyrics.cpp
@@ -176,3 +176,5 @@ void TestLyrics::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestLyrics)
+
+#include "moc_test_lyrics.cpp"

--- a/mythtv/libs/libmythmetadata/test/test_metadatagrabber/test_metadatagrabber.cpp
+++ b/mythtv/libs/libmythmetadata/test/test_metadatagrabber/test_metadatagrabber.cpp
@@ -62,3 +62,5 @@ void TestMetadataGrabber::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestMetadataGrabber)
+
+#include "moc_test_metadatagrabber.cpp"

--- a/mythtv/libs/libmythmetadata/test/test_musicmetadata/test_musicmetadata.cpp
+++ b/mythtv/libs/libmythmetadata/test/test_musicmetadata/test_musicmetadata.cpp
@@ -165,3 +165,5 @@ void TestMusicMetadata::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestMusicMetadata)
+
+#include "moc_test_musicmetadata.cpp"

--- a/mythtv/libs/libmythmetadata/test/test_musicutils/test_musicutils.cpp
+++ b/mythtv/libs/libmythmetadata/test/test_musicutils/test_musicutils.cpp
@@ -118,3 +118,5 @@ void TestMusicUtils::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestMusicUtils)
+
+#include "moc_test_musicutils.cpp"

--- a/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.cpp
+++ b/mythtv/libs/libmythmetadata/test/test_videometadata/test_videometadata.cpp
@@ -1,3 +1,5 @@
 #include "test_videometadata.h"
 
 QTEST_APPLESS_MAIN(Testvideometadata)
+
+#include "moc_test_videometadata.cpp"

--- a/mythtv/libs/libmythmetadata/videoscan.cpp
+++ b/mythtv/libs/libmythmetadata/videoscan.cpp
@@ -495,3 +495,5 @@ bool RemoteGetActiveBackends(QStringList *list)
     list->removeFirst();
     return true;
 }
+
+#include "moc_videoscan.cpp"

--- a/mythtv/libs/libmythprotoserver/mythsocketmanager.cpp
+++ b/mythtv/libs/libmythprotoserver/mythsocketmanager.cpp
@@ -373,3 +373,5 @@ void MythSocketManager::HandleDone(MythSocket *sock)
     sock->DisconnectFromHost();
 }
 
+#include "moc_mythsocketmanager.cpp"
+#include "moc_socketrequesthandler.cpp" // header only

--- a/mythtv/libs/libmythprotoserver/requesthandler/basehandler.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/basehandler.cpp
@@ -209,3 +209,4 @@ bool BaseRequestHandler::HandleQueryTimeZone(SocketHandler *sock)
     return true;
 }
 
+#include "moc_basehandler.cpp"

--- a/mythtv/libs/libmythprotoserver/requesthandler/deletethread.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/deletethread.cpp
@@ -261,3 +261,5 @@ void DeleteThread::ProcessOld(void)
             break;
     }
 }
+
+#include "moc_deletethread.cpp"

--- a/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/fileserverhandler.cpp
@@ -1107,3 +1107,4 @@ bool FileServerHandler::HandleDownloadFile(SocketHandler *socket,
     return true;
 }
 
+#include "moc_fileserverhandler.cpp"

--- a/mythtv/libs/libmythprotoserver/requesthandler/messagehandler.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/messagehandler.cpp
@@ -104,3 +104,4 @@ bool MessageHandler::HandleOutbound(SocketHandler */*sock*/, QStringList &slist)
     return true;
 }
 
+#include "moc_messagehandler.cpp"

--- a/mythtv/libs/libmythprotoserver/requesthandler/outboundhandler.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/outboundhandler.cpp
@@ -84,3 +84,5 @@ void OutboundRequestHandler::connectionClosed(MythSocket *socket)
     if (socket == m_socket)
         ConnectToMaster();
 }
+
+#include "moc_outboundhandler.cpp"

--- a/mythtv/libs/libmythtv/AirPlay/mythairplayserver.cpp
+++ b/mythtv/libs/libmythtv/AirPlay/mythairplayserver.cpp
@@ -1354,3 +1354,5 @@ void MythAirplayServer::HideAllPhotos(void)
         ++it;
     }
 }
+
+#include "moc_mythairplayserver.cpp"

--- a/mythtv/libs/libmythtv/AirPlay/mythraopconnection.cpp
+++ b/mythtv/libs/libmythtv/AirPlay/mythraopconnection.cpp
@@ -1916,3 +1916,5 @@ void MythRAOPConnection::SendNotification(bool update)
     m_firstSend = true;
     delete n;
 }
+
+#include "moc_mythraopconnection.cpp"

--- a/mythtv/libs/libmythtv/AirPlay/mythraopdevice.cpp
+++ b/mythtv/libs/libmythtv/AirPlay/mythraopdevice.cpp
@@ -285,3 +285,5 @@ void MythRAOPDevice::DeleteAllClients(MythRAOPConnection *keep)
     }
     LOG(VB_GENERAL, LOG_DEBUG, LOC + "Exiting DeleteAllClients.");
 }
+
+#include "moc_mythraopdevice.cpp"

--- a/mythtv/libs/libmythtv/Bluray/mythbdoverlayscreen.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdoverlayscreen.cpp
@@ -53,3 +53,5 @@ void MythBDOverlayScreen::DisplayBDOverlay(MythBDOverlay *Overlay)
     SetRedraw();
     delete Overlay;
 }
+
+#include "moc_mythbdoverlayscreen.cpp"

--- a/mythtv/libs/libmythtv/Bluray/mythbdplayer.cpp
+++ b/mythtv/libs/libmythtv/Bluray/mythbdplayer.cpp
@@ -429,3 +429,5 @@ void MythBDPlayer::CreateDecoder(TestBufferVec & TestBuffer)
     if (MythBDDecoder::CanHandle(TestBuffer, m_playerCtx->m_buffer->GetFilename()))
         SetDecoder(new MythBDDecoder(this, *m_playerCtx->m_playingInfo, m_playerFlags));
 }
+
+#include "moc_mythbdplayer.cpp"

--- a/mythtv/libs/libmythtv/DVD/mythdvdplayer.cpp
+++ b/mythtv/libs/libmythtv/DVD/mythdvdplayer.cpp
@@ -725,3 +725,5 @@ void MythDVDPlayer::CreateDecoder(TestBufferVec & Testbuf)
     if (MythDVDDecoder::CanHandle(Testbuf, m_playerCtx->m_buffer->GetFilename()))
         SetDecoder(new MythDVDDecoder(this, *m_playerCtx->m_playingInfo, m_playerFlags));
 }
+
+#include "moc_mythdvdplayer.cpp"

--- a/mythtv/libs/libmythtv/audioplayer.cpp
+++ b/mythtv/libs/libmythtv/audioplayer.cpp
@@ -557,3 +557,5 @@ int AudioPlayer::DecodeAudio(AVCodecContext *ctx,
     }
     return m_audioOutput->DecodeAudio(ctx, buffer, data_size, pkt);
 }
+
+#include "moc_audioplayer.cpp"

--- a/mythtv/libs/libmythtv/captions/subtitlereader.cpp
+++ b/mythtv/libs/libmythtv/captions/subtitlereader.cpp
@@ -208,3 +208,5 @@ void SubtitleReader::ClearRawTextSubtitles(void)
     QMutexLocker lock(&m_rawTextSubtitles.m_lock);
     m_rawTextSubtitles.m_buffers.clear();
 }
+
+#include "moc_subtitlereader.cpp"

--- a/mythtv/libs/libmythtv/captions/subtitlescreen.cpp
+++ b/mythtv/libs/libmythtv/captions/subtitlescreen.cpp
@@ -2647,3 +2647,5 @@ void SubtitleScreen::RenderAssTrack(std::chrono::milliseconds timecode, bool for
     }
 }
 #endif // CONFIG_LIBASS
+
+#include "moc_subtitlescreen.cpp"

--- a/mythtv/libs/libmythtv/captions/teletextscreen.cpp
+++ b/mythtv/libs/libmythtv/captions/teletextscreen.cpp
@@ -723,3 +723,5 @@ bool TeletextScreen::InitialiseFont()
         .arg(font));
     return true;
 }
+
+#include "moc_teletextscreen.cpp"

--- a/mythtv/libs/libmythtv/captions/textsubtitleparser.cpp
+++ b/mythtv/libs/libmythtv/captions/textsubtitleparser.cpp
@@ -434,3 +434,5 @@ void TextSubtitleParser::SeekFrame(int64_t ts, int flags)
             .arg(ts).arg(flags));
     }
 }
+
+#include "moc_textsubtitleparser.cpp"

--- a/mythtv/libs/libmythtv/cardutil.cpp
+++ b/mythtv/libs/libmythtv/cardutil.cpp
@@ -3555,3 +3555,5 @@ bool CardUtil::IsSatIPPresent(uint inputid)
     return false;
 }
 #endif
+
+#include "moc_cardutil.cpp"

--- a/mythtv/libs/libmythtv/channelscan/channelimporter.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelimporter.cpp
@@ -2536,3 +2536,5 @@ bool ChannelImporter::CheckChannelNumber(
         num, chan.m_sourceId, chan.m_channelId);
     return ok;
 }
+
+#include "moc_channelimporter.cpp"

--- a/mythtv/libs/libmythtv/channelscan/channelscanner_gui.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner_gui.cpp
@@ -184,3 +184,5 @@ void ChannelScannerGUI::MonitorProgress(bool lock, bool strength,
         m_scanStage = nullptr;
     }
 }
+
+#include "moc_channelscanner_gui.cpp"

--- a/mythtv/libs/libmythtv/channelscan/channelscanner_gui_scan_pane.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscanner_gui_scan_pane.cpp
@@ -169,3 +169,5 @@ void ChannelScannerGUIScanPane::SetScanProgress(double value)
     if (m_progressBar)
         m_progressBar->SetUsed(static_cast<uint>(value * 65535));
 }
+
+#include "moc_channelscanner_gui_scan_pane.cpp"

--- a/mythtv/libs/libmythtv/channelscan/inputselectorsetting.cpp
+++ b/mythtv/libs/libmythtv/channelscan/inputselectorsetting.cpp
@@ -142,3 +142,5 @@ bool InputSelector::Parse(const QString &cardid_inputname,
 
     return true;
 }
+
+#include "moc_inputselectorsetting.cpp"

--- a/mythtv/libs/libmythtv/channelscan/multiplexsetting.cpp
+++ b/mythtv/libs/libmythtv/channelscan/multiplexsetting.cpp
@@ -87,3 +87,5 @@ void MultiplexSetting::SetSourceID(uint sourceid)
     m_sourceid = sourceid;
     Load();
 }
+
+#include "moc_multiplexsetting.cpp"

--- a/mythtv/libs/libmythtv/channelscan/scanmonitor.cpp
+++ b/mythtv/libs/libmythtv/channelscan/scanmonitor.cpp
@@ -167,3 +167,5 @@ void ScanMonitor::customEvent(QEvent *e)
             m_channelScanner->HandleEvent(scanEvent);
     }
 }
+
+#include "moc_scanmonitor.cpp"

--- a/mythtv/libs/libmythtv/channelscan/scanwizardconfig.cpp
+++ b/mythtv/libs/libmythtv/channelscan/scanwizardconfig.cpp
@@ -721,3 +721,5 @@ void ScanOptionalConfig::SetTuningPaneValuesATSC(const QString &freqtable)
         pane->SetFrequencyTable(freqtable);
     }
 }
+
+#include "moc_scanwizardconfig.cpp"

--- a/mythtv/libs/libmythtv/channelsettings.cpp
+++ b/mythtv/libs/libmythtv/channelsettings.cpp
@@ -963,4 +963,4 @@ void ChannelOptionsRawTS::Save(void)
     ChannelUtil::SaveCachedPids(chanid, pid_cache, true /* delete_all */);
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_channelsettings.cpp"

--- a/mythtv/libs/libmythtv/decoders/mythvdpauhelper.cpp
+++ b/mythtv/libs/libmythtv/decoders/mythvdpauhelper.cpp
@@ -619,3 +619,5 @@ QSize MythVDPAUHelper::GetSurfaceParameters(VdpVideoSurface Surface, VdpChromaTy
 
     return {static_cast<int>(width), static_cast<int>(height)};
 }
+
+#include "moc_mythvdpauhelper.cpp"

--- a/mythtv/libs/libmythtv/diseqcsettings.cpp
+++ b/mythtv/libs/libmythtv/diseqcsettings.cpp
@@ -1442,3 +1442,5 @@ void DTVDeviceConfigGroup::AddChild(
     else
         group->addChild(setting);
 }
+
+#include "moc_diseqcsettings.cpp"

--- a/mythtv/libs/libmythtv/drm/mythvideodrm.cpp
+++ b/mythtv/libs/libmythtv/drm/mythvideodrm.cpp
@@ -144,3 +144,5 @@ bool MythVideoDRM::RenderFrame(AVDRMFrameDescriptor* DRMDesc, MythVideoFrame* Fr
 
     return m_device->QueueAtomics({{ id, m_videoPlane->m_fbIdProp->m_id, handle->GetFB() }});
 }
+
+#include "moc_mythvideodrm.cpp"

--- a/mythtv/libs/libmythtv/jobqueue.cpp
+++ b/mythtv/libs/libmythtv/jobqueue.cpp
@@ -2528,4 +2528,4 @@ int JobQueue::UserJobTypeToIndex(int jobType)
     return JOB_NONE;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_jobqueue.cpp"

--- a/mythtv/libs/libmythtv/mheg/interactivescreen.cpp
+++ b/mythtv/libs/libmythtv/mheg/interactivescreen.cpp
@@ -52,3 +52,5 @@ void InteractiveScreen::OptimiseDisplayedArea()
     for (auto *img : std::as_const(m_childrenList))
         img->SetArea(MythRect(img->GetArea().translated(left, top)));
 }
+
+#include "moc_interactivescreen.cpp"

--- a/mythtv/libs/libmythtv/mheg/mhegic.cpp
+++ b/mythtv/libs/libmythtv/mheg/mhegic.cpp
@@ -184,4 +184,4 @@ void MHInteractionChannel::slotFinished(QObject *obj)
     m_finished.insert(url, p);
 }
 
-/* End of file */
+#include "moc_mhegic.cpp"

--- a/mythtv/libs/libmythtv/mheg/netstream.cpp
+++ b/mythtv/libs/libmythtv/mheg/netstream.cpp
@@ -1016,4 +1016,4 @@ QDateTime NAMThread::GetLastModified(const QUrl &url)
     return lastMod;
 }
 
-/* End of file */
+#include "moc_netstream.cpp"

--- a/mythtv/libs/libmythtv/mythcaptionsoverlay.cpp
+++ b/mythtv/libs/libmythtv/mythcaptionsoverlay.cpp
@@ -235,3 +235,5 @@ void MythCaptionsOverlay::DisplayBDOverlay(MythBDOverlay* Overlay)
             bd->DisplayBDOverlay(Overlay);
     }
 }
+
+#include "moc_mythcaptionsoverlay.cpp"

--- a/mythtv/libs/libmythtv/mythinteropgpu.cpp
+++ b/mythtv/libs/libmythtv/mythinteropgpu.cpp
@@ -102,3 +102,4 @@ void* MythInteropGPU::GetDefaultUserOpaque()
     return m_defaultUserOpaque;
 }
 
+#include "moc_mythinteropgpu.cpp"

--- a/mythtv/libs/libmythtv/mythmediaoverlay.cpp
+++ b/mythtv/libs/libmythtv/mythmediaoverlay.cpp
@@ -167,3 +167,5 @@ void MythMediaOverlay::RevertUIScale()
     }
     m_uiScaleOverride = false;
 }
+
+#include "moc_mythmediaoverlay.cpp"

--- a/mythtv/libs/libmythtv/mythplayer.cpp
+++ b/mythtv/libs/libmythtv/mythplayer.cpp
@@ -2023,3 +2023,5 @@ static unsigned dbg_ident(const MythPlayer *player)
         return *it;
     return s_dbgIdent[player] = s_dbgNextIdent++;
 }
+
+#include "moc_mythplayer.cpp"

--- a/mythtv/libs/libmythtv/mythplayeraudioui.cpp
+++ b/mythtv/libs/libmythtv/mythplayeraudioui.cpp
@@ -206,3 +206,4 @@ void MythPlayerAudioUI::AdjustAudioTimecodeOffset(std::chrono::milliseconds Delt
         emit AudioStateChanged({ &m_audio, newwrap });
 }
 
+#include "moc_mythplayeraudioui.cpp"

--- a/mythtv/libs/libmythtv/mythplayercaptionsui.cpp
+++ b/mythtv/libs/libmythtv/mythplayercaptionsui.cpp
@@ -665,3 +665,5 @@ void MythPlayerCaptionsUI::StreamPlay(bool Playing)
     else
         Pause();
 }
+
+#include "moc_mythplayercaptionsui.cpp"

--- a/mythtv/libs/libmythtv/mythplayereditorui.cpp
+++ b/mythtv/libs/libmythtv/mythplayereditorui.cpp
@@ -295,3 +295,5 @@ bool MythPlayerEditorUI::DoRewindSecs(float Seconds, double Inaccuracy, bool Use
     uint64_t targetFrame = FindFrame(target, UseCutlist);
     return DoRewind(m_framesPlayed - targetFrame, Inaccuracy);
 }
+
+#include "moc_mythplayereditorui.cpp"

--- a/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
+++ b/mythtv/libs/libmythtv/mythplayeroverlayui.cpp
@@ -280,4 +280,4 @@ std::chrono::seconds MythPlayerOverlayUI::GetTotalSeconds(bool HonorCutList) con
     return duration_cast<std::chrono::seconds>(GetTotalMilliseconds(HonorCutList));
 }
 
-
+#include "moc_mythplayeroverlayui.cpp"

--- a/mythtv/libs/libmythtv/mythplayerui.cpp
+++ b/mythtv/libs/libmythtv/mythplayerui.cpp
@@ -1258,3 +1258,5 @@ void MythPlayerUI::JumpToProgram()
     m_playerCtx->SetPlayerChangingBuffers(false);
     LOG(VB_PLAYBACK, LOG_INFO, LOC + "JumpToProgram - end");
 }
+
+#include "moc_mythplayerui.cpp"

--- a/mythtv/libs/libmythtv/mythplayeruibase.cpp
+++ b/mythtv/libs/libmythtv/mythplayeruibase.cpp
@@ -29,3 +29,5 @@ MythRender* MythPlayerUIBase::GetRender() const
 {
     return m_render;
 }
+
+#include "moc_mythplayeruibase.cpp"

--- a/mythtv/libs/libmythtv/mythplayervideoui.cpp
+++ b/mythtv/libs/libmythtv/mythplayervideoui.cpp
@@ -239,3 +239,4 @@ void MythPlayerVideoUI::CheckAspectRatio(MythVideoFrame* Frame)
     }
 }
 
+#include "moc_mythplayervideoui.cpp"

--- a/mythtv/libs/libmythtv/mythplayervisualiserui.cpp
+++ b/mythtv/libs/libmythtv/mythplayervisualiserui.cpp
@@ -148,3 +148,5 @@ void MythPlayerVisualiserUI::RenderVisualiser()
         return;
     m_visual->Draw(m_visualiserState.m_embedding ? m_embedRect : m_uiScreenRect, m_painter, nullptr);
 }
+
+#include "moc_mythplayervisualiserui.cpp"

--- a/mythtv/libs/libmythtv/mythsystemevent.cpp
+++ b/mythtv/libs/libmythtv/mythsystemevent.cpp
@@ -477,4 +477,4 @@ MythSystemEventEditor::MythSystemEventEditor(MythScreenStack *parent,
         tr("Any event");
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mythsystemevent.cpp"

--- a/mythtv/libs/libmythtv/mythvideobounds.cpp
+++ b/mythtv/libs/libmythtv/mythvideobounds.cpp
@@ -935,3 +935,5 @@ void MythVideoBounds::SetStereoOverride(StereoscopicMode Mode)
         emit UpdateOSDMessage(StereoscopictoString(Mode));
     }
 }
+
+#include "moc_mythvideobounds.cpp"

--- a/mythtv/libs/libmythtv/mythvideocolourspace.cpp
+++ b/mythtv/libs/libmythtv/mythvideocolourspace.cpp
@@ -579,3 +579,5 @@ MythColourSpace MythVideoColourSpace::GetPrimaries(int Primary, float &Gamma)
         default: return MythColourSpace::s_BT709;
     }
 }
+
+#include "moc_mythvideocolourspace.cpp"

--- a/mythtv/libs/libmythtv/mythvideogpu.cpp
+++ b/mythtv/libs/libmythtv/mythvideogpu.cpp
@@ -134,3 +134,5 @@ void MythVideoGPU::SetViewportRect(QRect DisplayVisibleRect)
 {
     SetMasterViewport(DisplayVisibleRect.size());
 }
+
+#include "moc_mythvideogpu.cpp"

--- a/mythtv/libs/libmythtv/mythvideoout.cpp
+++ b/mythtv/libs/libmythtv/mythvideoout.cpp
@@ -435,3 +435,5 @@ void MythVideoOutput::DiscardFrames(bool KeyFrame, bool /*Flushed*/)
 {
     m_videoBuffers.DiscardFrames(KeyFrame);
 }
+
+#include "moc_mythvideoout.cpp"

--- a/mythtv/libs/libmythtv/mythvideooutgpu.cpp
+++ b/mythtv/libs/libmythtv/mythvideooutgpu.cpp
@@ -778,3 +778,5 @@ void MythVideoOutputGPU::ResizeForVideo(QSize Size)
     if (hide)
         m_mainWindow->Show();
 }
+
+#include "moc_mythvideooutgpu.cpp"

--- a/mythtv/libs/libmythtv/mythvideoprofile.cpp
+++ b/mythtv/libs/libmythtv/mythvideoprofile.cpp
@@ -1382,3 +1382,5 @@ void MythVideoProfile::InitStatics(bool Reinit /*= false*/)
             .arg(decoder, -12).arg(GetVideoRenderers(decoder).join(" ")));
     }
 }
+
+#include "moc_mythvideoprofile.cpp"

--- a/mythtv/libs/libmythtv/opengl/mythopenglinterop.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythopenglinterop.cpp
@@ -159,3 +159,5 @@ void MythOpenGLInterop::DeleteTextures()
         m_openglTextures.clear();
     }
 }
+
+#include "moc_mythopenglinterop.cpp"

--- a/mythtv/libs/libmythtv/opengl/mythopengltonemap.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythopengltonemap.cpp
@@ -181,3 +181,5 @@ bool MythOpenGLTonemap::CreateTexture(QSize Size)
     m_render->SetTextureFilters(m_texture, QOpenGLTexture::Linear);
     return true;
 }
+
+#include "moc_mythopengltonemap.cpp"

--- a/mythtv/libs/libmythtv/opengl/mythopenglvideo.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythopenglvideo.cpp
@@ -1113,3 +1113,5 @@ void MythOpenGLVideo::SetupBicubic(VideoResizing& Resize)
         }
     }
 }
+
+#include "moc_mythopenglvideo.cpp"

--- a/mythtv/libs/libmythtv/opengl/mythvaapiglxinterop.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythvaapiglxinterop.cpp
@@ -510,3 +510,5 @@ bool MythVAAPIInteropGLXPixmap::IsSupported(MythRenderOpenGL* Context)
     return extensions.contains("GLX_EXT_texture_from_pixmap");
 }
 #endif // CONFIG_VAAPI_X11
+
+#include "moc_mythvaapiglxinterop.cpp"

--- a/mythtv/libs/libmythtv/opengl/mythvdpauinterop.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythvdpauinterop.cpp
@@ -391,3 +391,5 @@ bool MythVDPAUInterop::IsPreempted(void) const
 {
     return m_preempted;
 }
+
+#include "moc_mythvdpauinterop.cpp"

--- a/mythtv/libs/libmythtv/opengl/mythvideooutopengl.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythvideooutopengl.cpp
@@ -390,3 +390,5 @@ QStringList MythVideoOutputOpenGL::GetAllowedRenderers(MythRenderOpenGL *Render,
     }
     return allowed;
 }
+
+#include "moc_mythvideooutopengl.cpp"

--- a/mythtv/libs/libmythtv/osd.cpp
+++ b/mythtv/libs/libmythtv/osd.cpp
@@ -854,3 +854,5 @@ void OSD::DialogGetText(InfoMap &Map)
     if (edit)
         edit->GetText(Map);
 }
+
+#include "moc_osd.cpp"

--- a/mythtv/libs/libmythtv/overlays/mythchanneloverlay.cpp
+++ b/mythtv/libs/libmythtv/overlays/mythchanneloverlay.cpp
@@ -123,3 +123,5 @@ void MythChannelOverlay::SendResult(int result)
     auto *dce = new DialogCompletionEvent("", result, "", message);
     QCoreApplication::postEvent(m_tv, dce);
 }
+
+#include "moc_mythchanneloverlay.cpp"

--- a/mythtv/libs/libmythtv/overlays/mythnavigationoverlay.cpp
+++ b/mythtv/libs/libmythtv/overlays/mythnavigationoverlay.cpp
@@ -208,3 +208,5 @@ void MythNavigationOverlay::More()
     if (group != nullptr)
         group->SetVisible(true);
 }
+
+#include "moc_mythnavigationoverlay.cpp"

--- a/mythtv/libs/libmythtv/playgroup.cpp
+++ b/mythtv/libs/libmythtv/playgroup.cpp
@@ -375,3 +375,5 @@ void PlayGroupEditor::Load()
     //TODO select the new one or the edited one
     emit settingsChanged(nullptr);
 }
+
+#include "moc_playgroup.cpp"

--- a/mythtv/libs/libmythtv/previewgenerator.cpp
+++ b/mythtv/libs/libmythtv/previewgenerator.cpp
@@ -862,3 +862,5 @@ uint8_t *PreviewGenerator::GetScreenGrab(
 
     return retbuf;
 }
+
+#include "moc_previewgenerator.cpp"

--- a/mythtv/libs/libmythtv/previewgeneratorqueue.cpp
+++ b/mythtv/libs/libmythtv/previewgeneratorqueue.cpp
@@ -788,3 +788,5 @@ void PreviewGeneratorQueue::ClearPreviewGeneratorAttempts(const QString &key)
  * \addtogroup myth_network_protocol
  * \par PREVIEW_FAILED \e recordingId \e outFileName \e msg \e datetime \e token
  */
+
+#include "moc_previewgeneratorqueue.cpp"

--- a/mythtv/libs/libmythtv/profilegroup.cpp
+++ b/mythtv/libs/libmythtv/profilegroup.cpp
@@ -226,3 +226,5 @@ void ProfileGroupEditor::Load(void)
     ProfileGroup::fillSelections(this);
     StandardSetting::Load();
 }
+
+#include "moc_profilegroup.cpp"

--- a/mythtv/libs/libmythtv/programinfo.cpp
+++ b/mythtv/libs/libmythtv/programinfo.cpp
@@ -6725,4 +6725,4 @@ bool RemoteCheckFile(ProgramInfo *pginfo, bool checkSlaves)
     return true;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_programinfo.cpp"

--- a/mythtv/libs/libmythtv/recorders/cetonrtsp.cpp
+++ b/mythtv/libs/libmythtv/recorders/cetonrtsp.cpp
@@ -490,3 +490,5 @@ void CetonRTSP::timerEvent(QTimerEvent* /*event*/)
         ProcessRequest("OPTIONS", nullptr, false, false, "*");
     }
 }
+
+#include "moc_cetonrtsp.cpp"

--- a/mythtv/libs/libmythtv/recorders/httptsstreamhandler.cpp
+++ b/mythtv/libs/libmythtv/recorders/httptsstreamhandler.cpp
@@ -247,3 +247,5 @@ void HTTPReader::Cancel(void)
         m_reply->abort();
     }
 }
+
+#include "moc_httptsstreamhandler.cpp"

--- a/mythtv/libs/libmythtv/recorders/iptvchannel.cpp
+++ b/mythtv/libs/libmythtv/recorders/iptvchannel.cpp
@@ -212,4 +212,4 @@ bool IPTVChannel::Tune(const IPTVTuningData &tuning, bool scanning)
     return true;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_iptvchannel.cpp"

--- a/mythtv/libs/libmythtv/recorders/iptvstreamhandler.cpp
+++ b/mythtv/libs/libmythtv/recorders/iptvstreamhandler.cpp
@@ -543,3 +543,5 @@ void IPTVStreamHandlerWriteHelper::SendRTCPReport(void)
                                           m_parent->m_rtspRtcpPort);
     m_previousLastSequenceNumber = m_lastSequenceNumber;
 }
+
+#include "moc_iptvstreamhandler.cpp"

--- a/mythtv/libs/libmythtv/recorders/satiprtsp.cpp
+++ b/mythtv/libs/libmythtv/recorders/satiprtsp.cpp
@@ -321,3 +321,5 @@ void SatIPRTSP::timerEvent(QTimerEvent* timerEvent)
 
     sendMessage("OPTIONS");
 }
+
+#include "moc_satiprtsp.cpp"

--- a/mythtv/libs/libmythtv/recorders/satipstreamhandler.cpp
+++ b/mythtv/libs/libmythtv/recorders/satipstreamhandler.cpp
@@ -766,3 +766,5 @@ uint SatIPStreamHandler::SetUDPReceiveBufferSize(QUdpSocket *socket, uint rcvbuf
     }
     return SatIPStreamHandler::GetUDPReceiveBufferSize(socket);
 }
+
+#include "moc_satipstreamhandler.cpp"

--- a/mythtv/libs/libmythtv/recordingprofile.cpp
+++ b/mythtv/libs/libmythtv/recordingprofile.cpp
@@ -1918,5 +1918,4 @@ void RecordingProfile::deleteEntry(void)
 
 }
 
-
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_recordingprofile.cpp"

--- a/mythtv/libs/libmythtv/recordingstatus.cpp
+++ b/mythtv/libs/libmythtv/recordingstatus.cpp
@@ -312,3 +312,5 @@ QString RecStatus::toDescription(RecStatus::Type recstatus, RecordingType rectyp
 
     return message;
 }
+
+#include "moc_recordingstatus.cpp"

--- a/mythtv/libs/libmythtv/restoredata.cpp
+++ b/mythtv/libs/libmythtv/restoredata.cpp
@@ -450,3 +450,5 @@ bool RestoreData::doSave(void)
     LOG(VB_GENERAL, LOG_INFO, LOC + QString("Restored data for %1 channels").arg(m_ocd.size()));
     return true;
 }
+
+#include "moc_restoredata.cpp"

--- a/mythtv/libs/libmythtv/scanwizard.cpp
+++ b/mythtv/libs/libmythtv/scanwizard.cpp
@@ -223,3 +223,5 @@ void ScanWizard::SetInput(const QString &cardid_inputname)
         m_lastHWCardType  = CardUtil::toInputType(subtype);
     }
 }
+
+#include "moc_scanwizard.cpp"

--- a/mythtv/libs/libmythtv/test/test_audioconvert/test_audioconvert.cpp
+++ b/mythtv/libs/libmythtv/test/test_audioconvert/test_audioconvert.cpp
@@ -1,3 +1,5 @@
 #include "test_audioconvert.h"
 
 QTEST_APPLESS_MAIN(TestAudioConvert)
+
+#include "moc_test_audioconvert.cpp"

--- a/mythtv/libs/libmythtv/test/test_avcinfo/test_avcinfo.cpp
+++ b/mythtv/libs/libmythtv/test/test_avcinfo/test_avcinfo.cpp
@@ -63,3 +63,5 @@ void TestAvcInfo::cleanupTestCase(void)
 }
 
 QTEST_APPLESS_MAIN(TestAvcInfo)
+
+#include "moc_test_avcinfo.cpp"

--- a/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
+++ b/mythtv/libs/libmythtv/test/test_bitreader/test_bitreader.cpp
@@ -213,3 +213,5 @@ void TestBitReader::get_se_golomb2()
 }
 
 QTEST_APPLESS_MAIN(TestBitReader)
+
+#include "moc_test_bitreader.cpp"

--- a/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.cpp
+++ b/mythtv/libs/libmythtv/test/test_copyframes/test_copyframes.cpp
@@ -249,3 +249,5 @@ void TestCopyFrames::TestCopy()
 }
 
 QTEST_APPLESS_MAIN(TestCopyFrames)
+
+#include "moc_test_copyframes.cpp"

--- a/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.cpp
+++ b/mythtv/libs/libmythtv/test/test_eitfixups/test_eitfixups.cpp
@@ -3701,3 +3701,5 @@ void TestEITFixups::testGreekCategories()
 
 
 QTEST_APPLESS_MAIN(TestEITFixups)
+
+#include "moc_test_eitfixups.cpp"

--- a/mythtv/libs/libmythtv/test/test_frequencies/test_frequencies.cpp
+++ b/mythtv/libs/libmythtv/test/test_frequencies/test_frequencies.cpp
@@ -151,3 +151,5 @@ void TestFrequencies::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestFrequencies)
+
+#include "moc_test_frequencies.cpp"

--- a/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.cpp
+++ b/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.cpp
@@ -1,3 +1,5 @@
 #include "test_iptvrecorder.h"
 
 QTEST_APPLESS_MAIN(TestIPTVRecorder)
+
+#include "moc_test_iptvrecorder.cpp"

--- a/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.pro
+++ b/mythtv/libs/libmythtv/test/test_iptvrecorder/test_iptvrecorder.pro
@@ -8,9 +8,6 @@ TEMPLATE = app
 TARGET = test_iptvrecorder
 INCLUDEPATH += ../../..
 
-LIBS += ../../$(OBJECTS_DIR)iptvchannelfetcher.o
-LIBS += ../../$(OBJECTS_DIR)scanmonitor.o
-LIBS += ../../$(OBJECTS_DIR)moc_scanmonitor.o
 LIBS += -L../../../libmythbase -lmythbase-$$LIBVERSION
 LIBS += -L../../../libmythui -lmythui-$$LIBVERSION
 LIBS += -L../../../libmythupnp -lmythupnp-$$LIBVERSION

--- a/mythtv/libs/libmythtv/test/test_mheg_dsmcc/test_mheg_dsmcc.cpp
+++ b/mythtv/libs/libmythtv/test/test_mheg_dsmcc/test_mheg_dsmcc.cpp
@@ -88,3 +88,5 @@ void TestMhegDsmcc::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestMhegDsmcc)
+
+#include "moc_test_mheg_dsmcc.cpp"

--- a/mythtv/libs/libmythtv/test/test_mpegtables/test_mpegtables.cpp
+++ b/mythtv/libs/libmythtv/test/test_mpegtables/test_mpegtables.cpp
@@ -2783,3 +2783,5 @@ void TestMPEGTables::mss_test(void)
 }
 
 QTEST_APPLESS_MAIN(TestMPEGTables)
+
+#include "moc_test_mpegtables.cpp"

--- a/mythtv/libs/libmythtv/test/test_mythiowrapper/test_mythiowrapper.cpp
+++ b/mythtv/libs/libmythtv/test/test_mythiowrapper/test_mythiowrapper.cpp
@@ -57,3 +57,5 @@ void TestMythIOWrapper::cleanupTestCase(void)
 }
 
 QTEST_APPLESS_MAIN(TestMythIOWrapper)
+
+#include "moc_test_mythiowrapper.cpp"

--- a/mythtv/libs/libmythtv/test/test_pink_noise/test_pink_noise.cpp
+++ b/mythtv/libs/libmythtv/test/test_pink_noise/test_pink_noise.cpp
@@ -1,3 +1,5 @@
 #include "test_pink_noise.h"
 
 QTEST_APPLESS_MAIN(TestPinkNoise)
+
+#include "moc_test_pink_noise.cpp"

--- a/mythtv/libs/libmythtv/test/test_programinfo/test_programinfo.cpp
+++ b/mythtv/libs/libmythtv/test/test_programinfo/test_programinfo.cpp
@@ -1,3 +1,5 @@
 #include "test_programinfo.h"
 
 QTEST_GUILESS_MAIN(TestProgramInfo)
+
+#include "moc_test_programinfo.cpp"

--- a/mythtv/libs/libmythtv/test/test_subtitlescreen/test_subtitlescreen.cpp
+++ b/mythtv/libs/libmythtv/test/test_subtitlescreen/test_subtitlescreen.cpp
@@ -105,3 +105,5 @@ void TestSubtitleScreen::test608()
 
 
 QTEST_APPLESS_MAIN(TestSubtitleScreen)
+
+#include "moc_test_subtitlescreen.cpp"

--- a/mythtv/libs/libmythtv/transporteditor.cpp
+++ b/mythtv/libs/libmythtv/transporteditor.cpp
@@ -961,3 +961,5 @@ uint TransportSetting::getMplexId() const
 {
     return m_mplexid->getValue().toUInt();
 }
+
+#include "moc_transporteditor.cpp"

--- a/mythtv/libs/libmythtv/tv_play.cpp
+++ b/mythtv/libs/libmythtv/tv_play.cpp
@@ -10586,3 +10586,5 @@ void SavePositionThread::run()
         }
     }
 }
+
+#include "moc_tv_play.cpp"

--- a/mythtv/libs/libmythtv/tv_play_win.cpp
+++ b/mythtv/libs/libmythtv/tv_play_win.cpp
@@ -96,3 +96,5 @@ bool TvPlayWindow::gestureEvent(MythGestureEvent *event)
 #endif
     return handled;
 }
+
+#include "moc_tv_play_win.cpp"

--- a/mythtv/libs/libmythtv/tvplaybackstate.cpp
+++ b/mythtv/libs/libmythtv/tvplaybackstate.cpp
@@ -54,3 +54,5 @@ void TVPlaybackState::EditorStateChanged(const MythEditorState& EditorState)
 {
     m_editorState = EditorState;
 }
+
+#include "moc_tvplaybackstate.cpp"

--- a/mythtv/libs/libmythtv/videosource.cpp
+++ b/mythtv/libs/libmythtv/videosource.cpp
@@ -4452,3 +4452,5 @@ SatIPDeviceAttribute::SatIPDeviceAttribute(const QString& label, const QString& 
     setHelpText(helptext);
 };
 #endif // CONFIG_SATIP
+
+#include "moc_videosource.cpp"

--- a/mythtv/libs/libmythtv/vulkan/mythvideooutputvulkan.cpp
+++ b/mythtv/libs/libmythtv/vulkan/mythvideooutputvulkan.cpp
@@ -133,3 +133,5 @@ void MythVideoOutputVulkan::EndFrame()
     if (m_video)
         m_video->EndFrame();
 }
+
+#include "moc_mythvideooutputvulkan.cpp"

--- a/mythtv/libs/libmythtv/vulkan/mythvideovulkan.cpp
+++ b/mythtv/libs/libmythtv/vulkan/mythvideovulkan.cpp
@@ -155,4 +155,4 @@ void MythVideoVulkan::ColourSpaceUpdate(bool /*PrimariesChanged*/)
 {
 }
 
-
+#include "moc_mythvideovulkan.cpp"

--- a/mythtv/libs/libmythui/dbsettings.cpp
+++ b/mythtv/libs/libmythui/dbsettings.cpp
@@ -206,3 +206,5 @@ DatabaseSettings::~DatabaseSettings()
 {
     emit isClosing();
 }
+
+#include "moc_dbsettings.cpp"

--- a/mythtv/libs/libmythui/devices/AppleRemote.cpp
+++ b/mythtv/libs/libmythui/devices/AppleRemote.cpp
@@ -391,3 +391,5 @@ void AppleRemote::_handleEventWithCookieString(const std::string& cookieString,
             _listener->appleRemoteButton(buttonid, sumOfValues>0);
     }
 }
+
+#include "moc_AppleRemote.cpp"

--- a/mythtv/libs/libmythui/devices/lirc.cpp
+++ b/mythtv/libs/libmythui/devices/lirc.cpp
@@ -547,3 +547,5 @@ QList<QByteArray> LIRC::GetCodes(void)
     m_bufOffset = m_buf.size();
     return ret;
 }
+
+#include "moc_lirc.cpp"

--- a/mythtv/libs/libmythui/devices/mythinputdevicehandler.cpp
+++ b/mythtv/libs/libmythui/devices/mythinputdevicehandler.cpp
@@ -266,3 +266,5 @@ void MythInputDeviceHandler::customEvent([[maybe_unused]] QEvent* Event)
         QCoreApplication::sendEvent(target, key.data());
     }
 }
+
+#include "moc_mythinputdevicehandler.cpp"

--- a/mythtv/libs/libmythui/langsettings.cpp
+++ b/mythtv/libs/libmythui/langsettings.cpp
@@ -240,3 +240,5 @@ void LanguageSelection::Close(void)
     else
         MythScreenType::Close();
 }
+
+#include "moc_langsettings.cpp"

--- a/mythtv/libs/libmythui/mediamonitor-unix.cpp
+++ b/mythtv/libs/libmythui/mediamonitor-unix.cpp
@@ -987,3 +987,7 @@ void MediaMonitorUnix::CheckDeviceNotifications(void)
     }
 }
 #endif //!CONFIG_QTDBUS
+
+#if CONFIG_QTDBUS
+#include "moc_mediamonitor-unix.cpp"
+#endif

--- a/mythtv/libs/libmythui/mediamonitor.cpp
+++ b/mythtv/libs/libmythui/mediamonitor.cpp
@@ -999,6 +999,4 @@ void MediaMonitor::ejectOpticalDisc()
     }
 }
 
-/*
- * vim:ts=4:sw=4:ai:et:si:sts=4
- */
+#include "moc_mediamonitor.cpp"

--- a/mythtv/libs/libmythui/mythdialogbox.cpp
+++ b/mythtv/libs/libmythui/mythdialogbox.cpp
@@ -1059,3 +1059,5 @@ void MythTimeInputDialog::okClicked(void)
 
     Close();
 }
+
+#include "moc_mythdialogbox.cpp"

--- a/mythtv/libs/libmythui/mythdisplay.cpp
+++ b/mythtv/libs/libmythui/mythdisplay.cpp
@@ -1290,3 +1290,5 @@ void MythDisplay::ConfigureQtGUI(int SwapInterval, const MythCommandLineParser& 
     if (forcevrr && !(gsyncchanged || freesyncchanged))
         LOG(VB_GENERAL, LOG_INFO, LOC + "Variable refresh rate not adjusted");
 }
+
+#include "moc_mythdisplay.cpp"

--- a/mythtv/libs/libmythui/mythgesture.cpp
+++ b/mythtv/libs/libmythui/mythgesture.cpp
@@ -394,3 +394,5 @@ bool MythGesture::Record(QPoint Point, Qt::MouseButton Button)
 
     return true;
 }
+
+#include "moc_mythgesture.cpp"

--- a/mythtv/libs/libmythui/mythhdr.cpp
+++ b/mythtv/libs/libmythui/mythhdr.cpp
@@ -84,3 +84,5 @@ QStringList MythHDR::TypesToString() const
 {
     return MythHDR::TypesToString(m_supportedTypes);
 }
+
+#include "moc_mythhdr.cpp"

--- a/mythtv/libs/libmythui/mythmainwindow.cpp
+++ b/mythtv/libs/libmythui/mythmainwindow.cpp
@@ -2288,4 +2288,5 @@ void MythMainWindow::OnApplicationStateChange(Qt::ApplicationState State)
             break;
     }
 }
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+
+#include "moc_mythmainwindow.cpp"

--- a/mythtv/libs/libmythui/mythnotificationcenter.cpp
+++ b/mythtv/libs/libmythui/mythnotificationcenter.cpp
@@ -1536,3 +1536,5 @@ void ShowNotification(MythNotification::Type type,
     MythNotificationCenter::GetInstance()->Queue(*n);
     delete n;
 }
+
+#include "moc_mythnotificationcenter_private.cpp"

--- a/mythtv/libs/libmythui/mythpainter.cpp
+++ b/mythtv/libs/libmythui/mythpainter.cpp
@@ -611,3 +611,5 @@ void MythPainter::SetMaximumCacheSizes(int hardware, int software)
         .arg(m_maxHardwareCacheSize / kOneMeg)
         .arg(m_maxSoftwareCacheSize / kOneMeg));
 }
+
+#include "moc_mythpainter.cpp"

--- a/mythtv/libs/libmythui/mythpaintergpu.cpp
+++ b/mythtv/libs/libmythui/mythpaintergpu.cpp
@@ -31,3 +31,5 @@ void MythPainterGPU::DisplayChanged()
     m_pixelRatio = window ? window->devicePixelRatio() : screen->devicePixelRatio();
     m_usingHighDPI = !qFuzzyCompare(m_pixelRatio, 1.0);
 }
+
+#include "moc_mythpaintergpu.cpp"

--- a/mythtv/libs/libmythui/mythpainterwindow.cpp
+++ b/mythtv/libs/libmythui/mythpainterwindow.cpp
@@ -182,3 +182,5 @@ void MythPainterWindow::resizeEvent(QResizeEvent* /*ResizeEvent*/)
         m_waylandDev->SetOpaqueRegion(rect());
 #endif
 }
+
+#include "moc_mythpainterwindow.cpp"

--- a/mythtv/libs/libmythui/mythpainterwindowqt.cpp
+++ b/mythtv/libs/libmythui/mythpainterwindowqt.cpp
@@ -13,3 +13,5 @@ void MythPainterWindowQt::paintEvent(QPaintEvent *Event)
 {
     m_parent->drawScreen(Event);
 }
+
+#include "moc_mythpainterwindowqt.cpp"

--- a/mythtv/libs/libmythui/mythprogressdialog.cpp
+++ b/mythtv/libs/libmythui/mythprogressdialog.cpp
@@ -241,3 +241,5 @@ void MythUIProgressDialog::UpdateProgress()
     if (m_progressText)
         m_progressText->SetText(QString("%1%").arg(percentage));
 }
+
+#include "moc_mythprogressdialog.cpp"

--- a/mythtv/libs/libmythui/mythscreensaver.cpp
+++ b/mythtv/libs/libmythui/mythscreensaver.cpp
@@ -83,3 +83,5 @@ bool MythScreenSaverControl::Asleep()
             return true;
     return false;
 }
+
+#include "moc_mythscreensaver.cpp"

--- a/mythtv/libs/libmythui/mythscreenstack.cpp
+++ b/mythtv/libs/libmythui/mythscreenstack.cpp
@@ -390,3 +390,5 @@ MythPainter* MythScreenStack::GetPainter(void)
 {
     return GetMythPainter();
 }
+
+#include "moc_mythscreenstack.cpp"

--- a/mythtv/libs/libmythui/mythscreentype.cpp
+++ b/mythtv/libs/libmythui/mythscreentype.cpp
@@ -561,3 +561,5 @@ MythPainter* MythScreenType::GetPainter(void)
         return MythScreenStack::GetPainter();
     return GetMythPainter();
 }
+
+#include "moc_mythscreentype.cpp"

--- a/mythtv/libs/libmythui/mythterminal.cpp
+++ b/mythtv/libs/libmythui/mythterminal.cpp
@@ -178,3 +178,5 @@ bool MythTerminal::Create(void)
 
     return true;
 }
+
+#include "moc_mythterminal.cpp"

--- a/mythtv/libs/libmythui/myththemedmenu.cpp
+++ b/mythtv/libs/libmythui/myththemedmenu.cpp
@@ -992,3 +992,5 @@ void MythThemedMenu::mediaEvent(MythMediaEvent* event)
             return;
     }
 }
+
+#include "moc_myththemedmenu.cpp"

--- a/mythtv/libs/libmythui/mythudplistener.cpp
+++ b/mythtv/libs/libmythui/mythudplistener.cpp
@@ -232,3 +232,5 @@ void MythUDP::StopUDPListener()
     delete Instance().m_listener;
     Instance().m_listener = nullptr;
 }
+
+#include "moc_mythudplistener.cpp"

--- a/mythtv/libs/libmythui/mythuibutton.cpp
+++ b/mythtv/libs/libmythui/mythuibutton.cpp
@@ -310,3 +310,5 @@ void MythUIButton::Finalize()
     SetInitialStates();
     SetText(m_valueText);
 }
+
+#include "moc_mythuibutton.cpp"

--- a/mythtv/libs/libmythui/mythuibuttonlist.cpp
+++ b/mythtv/libs/libmythui/mythuibuttonlist.cpp
@@ -4112,3 +4112,5 @@ void MythUIButtonList::SetScrollBarPosition()
     m_scrollBar->SetSliderPosition(m_selPosition);
     m_scrollBar->MoveToTop();
 }
+
+#include "moc_mythuibuttonlist.cpp"

--- a/mythtv/libs/libmythui/mythuibuttontree.cpp
+++ b/mythtv/libs/libmythui/mythuibuttontree.cpp
@@ -712,3 +712,5 @@ void MythUIButtonTree::CopyFrom(MythUIType *base)
 
     m_initialized = false;
 }
+
+#include "moc_mythuibuttontree.cpp"

--- a/mythtv/libs/libmythui/mythuicheckbox.cpp
+++ b/mythtv/libs/libmythui/mythuicheckbox.cpp
@@ -217,3 +217,5 @@ void MythUICheckBox::Finalize()
 {
     SetInitialStates();
 }
+
+#include "moc_mythuicheckbox.cpp"

--- a/mythtv/libs/libmythui/mythuicomposite.cpp
+++ b/mythtv/libs/libmythui/mythuicomposite.cpp
@@ -38,3 +38,5 @@ void MythUIComposite::ResetMap(const InfoMap &infoMap)
             group->ResetMap(infoMap);
     }
 }
+
+#include "moc_mythuicomposite.cpp"

--- a/mythtv/libs/libmythui/mythuifilebrowser.cpp
+++ b/mythtv/libs/libmythui/mythuifilebrowser.cpp
@@ -725,4 +725,4 @@ bool MythUIFileBrowser::GetRemoteFileList(const QString &url,
 
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mythuifilebrowser.cpp"

--- a/mythtv/libs/libmythui/mythuigroup.cpp
+++ b/mythtv/libs/libmythui/mythuigroup.cpp
@@ -20,3 +20,5 @@ void MythUIGroup::CreateCopy(MythUIType *parent)
     auto *group = new MythUIGroup(parent, objectName());
     group->CopyFrom(this);
 }
+
+#include "moc_mythuigroup.cpp"

--- a/mythtv/libs/libmythui/mythuiguidegrid.cpp
+++ b/mythtv/libs/libmythui/mythuiguidegrid.cpp
@@ -841,3 +841,5 @@ void MythUIGuideGrid::SetMultiLine(bool multiline)
     else
         m_justification &= ~Qt::TextWordWrap;
 }
+
+#include "moc_mythuiguidegrid.cpp"

--- a/mythtv/libs/libmythui/mythuiimage.cpp
+++ b/mythtv/libs/libmythui/mythuiimage.cpp
@@ -1706,3 +1706,5 @@ void MythUIImage::FindRandomImage(void)
 
     m_origFilename = m_imageProperties.m_filename = randFile;
 }
+
+#include "moc_mythuiimage.cpp"

--- a/mythtv/libs/libmythui/mythuiscreenbounds.cpp
+++ b/mythtv/libs/libmythui/mythuiscreenbounds.cpp
@@ -260,3 +260,5 @@ void MythUIScreenBounds::SetFontStretch(int Stretch)
 {
     m_fontStretch = Stretch;
 }
+
+#include "moc_mythuiscreenbounds.cpp"

--- a/mythtv/libs/libmythui/mythuiscrollbar.cpp
+++ b/mythtv/libs/libmythui/mythuiscrollbar.cpp
@@ -178,3 +178,5 @@ void MythUIScrollBar::DoneFading(void)
     disconnect(this, &MythUIType::FinishedFading, nullptr, nullptr);
     Hide();
 }
+
+#include "moc_mythuiscrollbar.cpp"

--- a/mythtv/libs/libmythui/mythuispinbox.cpp
+++ b/mythtv/libs/libmythui/mythuispinbox.cpp
@@ -359,3 +359,5 @@ void SpinBoxEntryDialog::okClicked(void)
     m_parentList->SetItemCurrent(m_selection);
     Close();
 }
+
+#include "moc_mythuispinbox.cpp"

--- a/mythtv/libs/libmythui/mythuitextedit.cpp
+++ b/mythtv/libs/libmythui/mythuitextedit.cpp
@@ -646,3 +646,5 @@ void MythUITextEdit::CreateCopy(MythUIType *parent)
     auto *textedit = new MythUITextEdit(parent, objectName());
     textedit->CopyFrom(this);
 }
+
+#include "moc_mythuitextedit.cpp"

--- a/mythtv/libs/libmythui/mythuitype.cpp
+++ b/mythtv/libs/libmythui/mythuitype.cpp
@@ -1494,3 +1494,5 @@ void MythUIType::ConnectDependants(bool recurse)
         }
     }
 }
+
+#include "moc_mythuitype.cpp"

--- a/mythtv/libs/libmythui/mythuiwebbrowser.cpp
+++ b/mythtv/libs/libmythui/mythuiwebbrowser.cpp
@@ -1439,3 +1439,5 @@ void MythUIWebBrowser::CreateCopy(MythUIType *parent)
     auto *browser = new MythUIWebBrowser(parent, objectName());
     browser->CopyFrom(this);
 }
+
+#include "moc_mythuiwebbrowser.cpp"

--- a/mythtv/libs/libmythui/mythvirtualkeyboard.cpp
+++ b/mythtv/libs/libmythui/mythvirtualkeyboard.cpp
@@ -700,3 +700,5 @@ void MythUIVirtualKeyboard::loadEventKeyDefinitions(
     *keyDef = a[0];
 #endif
 }
+
+#include "moc_mythvirtualkeyboard.cpp"

--- a/mythtv/libs/libmythui/opengl/mythpainteropengl.cpp
+++ b/mythtv/libs/libmythui/opengl/mythpainteropengl.cpp
@@ -354,3 +354,5 @@ void MythOpenGLPainter::PopTransformation(void)
     if (m_render)
         m_render->PopTransformation();
 }
+
+#include "moc_mythpainteropengl.cpp"

--- a/mythtv/libs/libmythui/opengl/mythpainterwindowopengl.cpp
+++ b/mythtv/libs/libmythui/opengl/mythpainterwindowopengl.cpp
@@ -64,3 +64,5 @@ void MythPainterWindowOpenGL::paintEvent(QPaintEvent* /*PaintEvent*/)
 {
     m_parent->drawScreen();
 }
+
+#include "moc_mythpainterwindowopengl.cpp"

--- a/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
+++ b/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
@@ -1583,3 +1583,5 @@ void MythRenderOpenGL::Check16BitFBO(void)
         delete fbo;
     }
 }
+
+#include "moc_mythrenderopengl.cpp"

--- a/mythtv/libs/libmythui/platforms/mythdisplaydrm.cpp
+++ b/mythtv/libs/libmythui/platforms/mythdisplaydrm.cpp
@@ -191,3 +191,5 @@ bool MythDisplayDRM::SwitchToVideoMode(QSize Size, double DesiredRate)
 
     return m_device->SwitchMode(m_modeMap.value(mode));
 }
+
+#include "moc_mythdisplaydrm.cpp"

--- a/mythtv/libs/libmythui/platforms/mythdisplaymutter.cpp
+++ b/mythtv/libs/libmythui/platforms/mythdisplaymutter.cpp
@@ -588,3 +588,5 @@ void MythDisplayMutter::UpdateResources()
     m_physicalSize  = QSize(m_outputs[m_outputIdx].widthmm, m_outputs[m_outputIdx].heightmm);
     m_edid = MythEDID(m_outputs[m_outputIdx].edid);
 }
+
+#include "moc_mythdisplaymutter.cpp"

--- a/mythtv/libs/libmythui/platforms/mythdisplayrpi.cpp
+++ b/mythtv/libs/libmythui/platforms/mythdisplayrpi.cpp
@@ -274,3 +274,5 @@ bool MythDisplayRPI::SwitchToVideoMode(QSize Size, double Framerate)
 
     return ret == 0;
 }
+
+#include "moc_mythdisplayrpi.cpp"

--- a/mythtv/libs/libmythui/platforms/mythdisplayx11.cpp
+++ b/mythtv/libs/libmythui/platforms/mythdisplayx11.cpp
@@ -5,6 +5,9 @@
 #include "mythxdisplay.h"
 
 // X11
+#if defined(_X11_XLIB_H_) && !defined(Bool)
+#define Bool int
+#endif
 #include <X11/Xatom.h>
 #define pointer Xpointer // Prevent conflicts with Qt6.
 #include <X11/extensions/Xrandr.h>

--- a/mythtv/libs/libmythui/platforms/mythscreensaverandroid.cpp
+++ b/mythtv/libs/libmythui/platforms/mythscreensaverandroid.cpp
@@ -91,3 +91,4 @@ bool MythScreenSaverAndroid::Asleep()
     return false;
 }
 
+#include "moc_mythscreensaverandroid.cpp"

--- a/mythtv/libs/libmythui/platforms/mythscreensaverdbus.cpp
+++ b/mythtv/libs/libmythui/platforms/mythscreensaverdbus.cpp
@@ -188,3 +188,5 @@ bool MythScreenSaverDBus::Asleep()
 {
     return false;
 }
+
+#include "moc_mythscreensaverdbus.cpp"

--- a/mythtv/libs/libmythui/platforms/mythscreensaverdrm.cpp
+++ b/mythtv/libs/libmythui/platforms/mythscreensaverdrm.cpp
@@ -44,3 +44,5 @@ bool MythScreenSaverDRM::Asleep()
 {
     return false;
 }
+
+#include "moc_mythscreensaverdrm.cpp"

--- a/mythtv/libs/libmythui/platforms/mythscreensaverosx.cpp
+++ b/mythtv/libs/libmythui/platforms/mythscreensaverosx.cpp
@@ -27,3 +27,5 @@ bool MythScreenSaverOSX::Asleep()
 {
     return false;
 }
+
+#include "moc_mythscreensaverosx.cpp"

--- a/mythtv/libs/libmythui/platforms/mythscreensaverwayland.cpp
+++ b/mythtv/libs/libmythui/platforms/mythscreensaverwayland.cpp
@@ -84,3 +84,5 @@ bool MythScreenSaverWayland::Asleep()
 {
     return false;
 }
+
+#include "moc_mythscreensaverwayland.cpp"

--- a/mythtv/libs/libmythui/platforms/mythscreensaverx11.cpp
+++ b/mythtv/libs/libmythui/platforms/mythscreensaverx11.cpp
@@ -12,10 +12,14 @@
 #include "platforms/mythscreensaverx11.h"
 
 // X11 headers
+#if defined(_X11_XLIB_H_) && !defined(Bool)
+#define Bool int
+#endif
 #include <X11/Xlib.h>
 extern "C" {
 #include <X11/extensions/dpms.h>
 }
+#undef Bool            // Interferes with moc file compilation
 
 #define LOC QString("ScreenSaverX11: ")
 
@@ -318,3 +322,5 @@ void MythScreenSaverX11::ResetSlot()
 {
     m_priv->ResetScreenSaver();
 }
+
+#include "moc_mythscreensaverx11.cpp"

--- a/mythtv/libs/libmythui/platforms/mythxdisplay.h
+++ b/mythtv/libs/libmythui/platforms/mythxdisplay.h
@@ -9,7 +9,11 @@
 #include "libmythui/mythuiexp.h"
 
 // X11
+#if defined(_X11_XLIB_H_) && !defined(Bool)
+#define Bool int
+#endif
 #include <X11/Xlib.h>
+#undef Bool            // Interferes with moc file compilation
 
 class MUI_PUBLIC MythXDisplay
 {

--- a/mythtv/libs/libmythui/rawsettingseditor.cpp
+++ b/mythtv/libs/libmythui/rawsettingseditor.cpp
@@ -223,4 +223,4 @@ void RawSettingsEditor::valueChanged(void)
         m_settingValue->GetText();
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_rawsettingseditor.cpp"

--- a/mythtv/libs/libmythui/schemawizard.cpp
+++ b/mythtv/libs/libmythui/schemawizard.cpp
@@ -482,3 +482,5 @@ SchemaUpgradeWizard::PromptForUpgrade(const char *name,
 
     return MYTH_SCHEMA_UPGRADE;
 }
+
+#include "moc_schemawizard.cpp"

--- a/mythtv/libs/libmythui/standardsettings.cpp
+++ b/mythtv/libs/libmythui/standardsettings.cpp
@@ -1143,3 +1143,5 @@ void StandardSettingDialog::deleteEntryConfirmed(bool ok)
     }
 
 }
+
+#include "moc_standardsettings.cpp"

--- a/mythtv/libs/libmythui/storagegroupeditor.cpp
+++ b/mythtv/libs/libmythui/storagegroupeditor.cpp
@@ -516,4 +516,4 @@ void StorageGroupListEditor::CreateNewGroup(const QString& name)
     emit settingsChanged(this);
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_storagegroupeditor.cpp"

--- a/mythtv/libs/libmythui/test/test_mythgenerictree/test_mythgenerictree.cpp
+++ b/mythtv/libs/libmythui/test/test_mythgenerictree/test_mythgenerictree.cpp
@@ -179,3 +179,5 @@ void TestMythGenericTree::cleanupTestCase()
 }
 
 QTEST_APPLESS_MAIN(TestMythGenericTree)
+
+#include "moc_test_mythgenerictree.cpp"

--- a/mythtv/libs/libmythui/test/test_settings/test_settings.cpp
+++ b/mythtv/libs/libmythui/test/test_settings/test_settings.cpp
@@ -1,3 +1,5 @@
 #include "test_settings.h"
 
 QTEST_APPLESS_MAIN(TestSettings)
+
+#include "moc_test_settings.cpp"

--- a/mythtv/libs/libmythui/vulkan/mythpaintervulkan.cpp
+++ b/mythtv/libs/libmythui/vulkan/mythpaintervulkan.cpp
@@ -537,3 +537,5 @@ void MythPainterVulkan::DeleteTextures()
         m_texturesToDelete.pop_front();
     }
 }
+
+#include "moc_mythpaintervulkan.cpp"

--- a/mythtv/libs/libmythui/vulkan/mythrendervulkan.cpp
+++ b/mythtv/libs/libmythui/vulkan/mythrendervulkan.cpp
@@ -803,3 +803,5 @@ VkPipeline MythRenderVulkan::CreatePipeline(MythShaderVulkan* Shader,
     LOG(VB_GENERAL, LOG_ERR, LOC + "Failed to create graphics pipeline");
     return MYTH_NULL_DISPATCH;
 }
+
+#include "moc_mythrendervulkan.cpp"

--- a/mythtv/libs/libmythupnp/httpserver.cpp
+++ b/mythtv/libs/libmythupnp/httpserver.cpp
@@ -685,4 +685,4 @@ void HttpWorker::run(void)
     LOG(VB_HTTP, LOG_DEBUG, QString("HttpWorker::run() socket=%1 -- end").arg(m_socket));
 }
 
-
+#include "moc_httpserver.cpp"

--- a/mythtv/libs/libmythupnp/ssdpcache.cpp
+++ b/mythtv/libs/libmythupnp/ssdpcache.cpp
@@ -660,3 +660,5 @@ void SSDPCache::Dump(void)
     LOG(VB_UPNP, LOG_DEBUG, "========================================"
                             "=======================================" );
 }
+
+#include "moc_ssdpcache.cpp"

--- a/mythtv/libs/libmythupnp/upnp.cpp
+++ b/mythtv/libs/libmythupnp/upnp.cpp
@@ -184,3 +184,5 @@ void UPnp::EnableNotificatins(std::chrono::milliseconds /*unused*/) const
 {
     SSDP::Instance()->EnableNotifications(m_nServicePort);
 }
+
+#include "moc_upnp.cpp"

--- a/mythtv/libs/libmythupnp/websocket.cpp
+++ b/mythtv/libs/libmythupnp/websocket.cpp
@@ -950,4 +950,4 @@ void WebSocketWorker::DeregisterExtension(WebSocketExtension* extension)
     }
 }
 
-
+#include "moc_websocket.cpp"

--- a/mythtv/libs/libmythupnp/websocket_extensions/websocket_mythevent.cpp
+++ b/mythtv/libs/libmythupnp/websocket_extensions/websocket_mythevent.cpp
@@ -75,3 +75,5 @@ void WebSocketMythEvent::customEvent(QEvent* event)
         emit SendTextMessage(message);
     }
 }
+
+#include "moc_websocket_mythevent.cpp"

--- a/mythtv/programs/mythbackend/autoexpire.cpp
+++ b/mythtv/programs/mythbackend/autoexpire.cpp
@@ -1135,4 +1135,4 @@ bool AutoExpire::IsInExpireList(
                                      (info->GetRecordingStartTime() == recstartts)); } );
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_autoexpire.cpp"

--- a/mythtv/programs/mythbackend/mainserver.cpp
+++ b/mythtv/programs/mythbackend/mainserver.cpp
@@ -8266,4 +8266,4 @@ void MainServer::UpdateSystemdStatus (void)
 #endif
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mainserver.cpp"

--- a/mythtv/programs/mythbackend/recordingextender.cpp
+++ b/mythtv/programs/mythbackend/recordingextender.cpp
@@ -1722,3 +1722,5 @@ void RecordingExtender::run()
     RunEpilog();
     quit();
 }
+
+#include "moc_recordingextender.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2capture.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2capture.cpp
@@ -1418,3 +1418,5 @@ bool V2Capture::UpdateRecProfileParam ( uint ProfileId, const QString  &Name, co
     }
     return true;
 }
+
+#include "moc_v2capture.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2channel.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2channel.cpp
@@ -1264,3 +1264,5 @@ bool V2Channel::CopyIconToBackend(const QString& Url, const QString& ChanId)
 
     return fRet;
 }
+
+#include "moc_v2channel.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2config.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2config.cpp
@@ -244,3 +244,5 @@ V2SystemEventList* V2Config::GetSystemEvents(const QString &Host)
     }
     return pList;
 }
+
+#include "moc_v2config.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2content.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2content.cpp
@@ -895,3 +895,5 @@ bool V2Content::DownloadFile( const QString &sURL, const QString &sStorageGroup 
 }
 
 // NOLINTEND(modernize-return-braced-init-list)
+
+#include "moc_v2content.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2dvr.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2dvr.cpp
@@ -2755,3 +2755,5 @@ QString V2Dvr::CheckPowerQuery(const QString & SelectClause)
     }
     return msg;
 }
+
+#include "moc_v2dvr.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2guide.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2guide.cpp
@@ -704,3 +704,5 @@ bool V2Guide::UpdateChannelGroup  ( const QString & oldName, const QString & new
 
 
 // NOLINTEND(modernize-return-braced-init-list)
+
+#include "moc_v2guide.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2music.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2music.cpp
@@ -134,3 +134,5 @@ V2MusicMetadataInfo* V2Music::GetTrack(int Id)
 
     return pMusicMetadataInfo;
 }
+
+#include "moc_v2music.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2myth.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2myth.cpp
@@ -1414,3 +1414,5 @@ QString  V2Myth::Proxy ( const QString &urlString)
 
     return {};
 }
+
+#include "moc_v2myth.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2status.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2status.cpp
@@ -1927,3 +1927,4 @@ QStringList V2Status::GetBackupsList()
 
 
 // vim:set shiftwidth=4 tabstop=4 expandtab:
+#include "moc_v2status.cpp"

--- a/mythtv/programs/mythbackend/servicesv2/v2video.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2video.cpp
@@ -1320,3 +1320,5 @@ V2VideoCategoryList*  V2Video::GetCategoryList (  )
 
     return pCatList;
 }
+
+#include "moc_v2video.cpp"

--- a/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.cpp
+++ b/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.cpp
@@ -948,3 +948,5 @@ void TestRecordingExtender::test_processNewRecordings(void)
 }
 
 QTEST_GUILESS_MAIN(TestRecordingExtender)
+
+#include "moc_test_recordingextender.cpp"

--- a/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.pro
+++ b/mythtv/programs/mythbackend/test/test_recordingextender/test_recordingextender.pro
@@ -10,7 +10,6 @@ INCLUDEPATH += . ../..
 INCLUDEPATH += ../../../../libs
 
 LIBS += ../../obj/recordingextender.o
-LIBS += ../../obj/moc_recordingextender.o
 
 # Add all the necessary libraries
 LIBS += -L../../../../libs/libmythbase -lmythbase-$$LIBVERSION

--- a/mythtv/programs/mythcommflag/ClassicCommDetector.cpp
+++ b/mythtv/programs/mythcommflag/ClassicCommDetector.cpp
@@ -2511,4 +2511,4 @@ void ClassicCommDetector::PrintFullMap(
     out << std::flush;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_ClassicCommDetector.cpp"

--- a/mythtv/programs/mythcommflag/CommDetectorBase.cpp
+++ b/mythtv/programs/mythcommflag/CommDetectorBase.cpp
@@ -15,5 +15,4 @@ void CommDetectorBase::resume()
     m_bPaused = false;
 }
 
-
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_CommDetectorBase.cpp"

--- a/mythtv/programs/mythcommflag/test/test_commflag_misc/test_commflag_misc.cpp
+++ b/mythtv/programs/mythcommflag/test/test_commflag_misc/test_commflag_misc.cpp
@@ -230,3 +230,5 @@ void TestCommFlagMisc::test_quick_selectf(void)
 }
 
 QTEST_GUILESS_MAIN(TestCommFlagMisc)
+
+#include "moc_test_commflag_misc.cpp"

--- a/mythtv/programs/mythexternrecorder/MythExternControl.cpp
+++ b/mythtv/programs/mythexternrecorder/MythExternControl.cpp
@@ -664,3 +664,5 @@ void Buffer::Run(void)
     m_parent->m_bufferRunning = false;
     m_parent->m_flowCond.notify_all();
 }
+
+#include "moc_MythExternControl.cpp"

--- a/mythtv/programs/mythexternrecorder/MythExternRecApp.cpp
+++ b/mythtv/programs/mythexternrecorder/MythExternRecApp.cpp
@@ -1142,3 +1142,5 @@ Q_SLOT void MythExternRecApp::ProcReadStandardOutput(void)
     if (!buf.isEmpty())
         emit Fill(buf);
 }
+
+#include "moc_MythExternRecApp.cpp"

--- a/mythtv/programs/mythfilerecorder/mythfilerecorder.cpp
+++ b/mythtv/programs/mythfilerecorder/mythfilerecorder.cpp
@@ -454,4 +454,4 @@ int main(int argc, char *argv[])
     return GENERIC_EXIT_OK;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mythfilerecorder.cpp"

--- a/mythtv/programs/mythfrontend/audiogeneralsettings.cpp
+++ b/mythtv/programs/mythfrontend/audiogeneralsettings.cpp
@@ -1332,4 +1332,5 @@ void AudioConfigSettings::setMPCMEnabled(bool flag)
 {
     m_mpcm->setEnabled(flag);
 }
-// vim:set sw=4 ts=4 expandtab:
+
+#include "moc_audiogeneralsettings.cpp"

--- a/mythtv/programs/mythfrontend/backendconnectionmanager.cpp
+++ b/mythtv/programs/mythfrontend/backendconnectionmanager.cpp
@@ -128,3 +128,5 @@ void BackendConnectionManager::ReconnectToBackend(void)
     m_reconnecting = new Reconnect();
     MThreadPool::globalInstance()->start(m_reconnecting, "Reconnect");
 }
+
+#include "moc_backendconnectionmanager.cpp"

--- a/mythtv/programs/mythfrontend/channelrecpriority.cpp
+++ b/mythtv/programs/mythfrontend/channelrecpriority.cpp
@@ -473,3 +473,5 @@ void ChannelRecPriority::customEvent(QEvent *event)
         }
     }
 }
+
+#include "moc_channelrecpriority.cpp"

--- a/mythtv/programs/mythfrontend/customedit.cpp
+++ b/mythtv/programs/mythfrontend/customedit.cpp
@@ -962,3 +962,5 @@ bool CustomEdit::keyPressEvent(QKeyEvent *event)
 
     return handled;
 }
+
+#include "moc_customedit.cpp"

--- a/mythtv/programs/mythfrontend/custompriority.cpp
+++ b/mythtv/programs/mythfrontend/custompriority.cpp
@@ -470,3 +470,5 @@ void CustomPriority::testSchedule(void)
         LOG(VB_GENERAL, LOG_ERR, msg);
     }
 }
+
+#include "moc_custompriority.cpp"

--- a/mythtv/programs/mythfrontend/editvideometadata.cpp
+++ b/mythtv/programs/mythfrontend/editvideometadata.cpp
@@ -1075,3 +1075,5 @@ void EditMetadataDialog::customEvent(QEvent *levent)
         GetNotificationCenter()->Queue(n);
     }
 }
+
+#include "moc_editvideometadata.cpp"

--- a/mythtv/programs/mythfrontend/exitprompt.cpp
+++ b/mythtv/programs/mythfrontend/exitprompt.cpp
@@ -310,3 +310,5 @@ void ExitPrompter::Confirm(MythPower::Feature Action)
         connect(dlg, &MythConfirmationDialog::haveResult, this, qOverload<bool>(&ExitPrompter::DoSuspend));
     ss->AddScreen(dlg);
 }
+
+#include "moc_exitprompt.cpp"

--- a/mythtv/programs/mythfrontend/galleryconfig.cpp
+++ b/mythtv/programs/mythfrontend/galleryconfig.cpp
@@ -314,3 +314,5 @@ GallerySettings::GallerySettings(bool enable)
     addChild(Password(enable));
     addChild(ClearDb(enable));
 }
+
+#include "moc_galleryconfig.cpp"

--- a/mythtv/programs/mythfrontend/galleryinfo.cpp
+++ b/mythtv/programs/mythfrontend/galleryinfo.cpp
@@ -302,3 +302,5 @@ void InfoList::Display(ImageItemK &im, const QStringList &tagStrings)
             m_screen.SetFocusWidget(m_btnList);
     }
 }
+
+#include "moc_galleryinfo.cpp"

--- a/mythtv/programs/mythfrontend/galleryslide.cpp
+++ b/mythtv/programs/mythfrontend/galleryslide.cpp
@@ -776,3 +776,5 @@ void SlideBuffer::Flush(Slide *slide)
 {
     Flush(slide, "Loaded");
 };
+
+#include "moc_galleryslide.cpp"

--- a/mythtv/programs/mythfrontend/galleryslideview.cpp
+++ b/mythtv/programs/mythfrontend/galleryslideview.cpp
@@ -840,3 +840,5 @@ void GallerySlideView::RepeatOn(int on)
 {
     gCoreContext->SaveSetting("GalleryRepeat", on);
 }
+
+#include "moc_galleryslideview.cpp"

--- a/mythtv/programs/mythfrontend/gallerythumbview.cpp
+++ b/mythtv/programs/mythfrontend/gallerythumbview.cpp
@@ -2221,3 +2221,5 @@ void GalleryThumbView::DoRepeat(int on)
 {
     gCoreContext->SaveSetting("GalleryRepeat", on);
 }
+
+#include "moc_gallerythumbview.cpp"

--- a/mythtv/programs/mythfrontend/gallerytransitions.cpp
+++ b/mythtv/programs/mythfrontend/gallerytransitions.cpp
@@ -424,4 +424,4 @@ void TransitionRandom::Finished()
     emit finished();
 }
 
-
+#include "moc_gallerytransitions.cpp"

--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -5125,4 +5125,4 @@ void ChannelGroupsSetting::CreateNewGroup(const QString& name)
     emit settingsChanged(this);
 }
 
-// vim:set sw=4 ts=4 expandtab:
+#include "moc_globalsettings.cpp"

--- a/mythtv/programs/mythfrontend/grabbersettings.cpp
+++ b/mythtv/programs/mythfrontend/grabbersettings.cpp
@@ -153,3 +153,5 @@ bool GrabberSettings::keyPressEvent(QKeyEvent *event)
 
     return MythScreenType::keyPressEvent(event);
 }
+
+#include "moc_grabbersettings.cpp"

--- a/mythtv/programs/mythfrontend/guidegrid.cpp
+++ b/mythtv/programs/mythfrontend/guidegrid.cpp
@@ -2733,3 +2733,5 @@ void GuideGrid::ShowJumpToTime(void)
         delete timedlg;
     }
 }
+
+#include "moc_guidegrid.cpp"

--- a/mythtv/programs/mythfrontend/idlescreen.cpp
+++ b/mythtv/programs/mythfrontend/idlescreen.cpp
@@ -299,3 +299,5 @@ void IdleScreen::customEvent(QEvent* event)
 
     MythUIType::customEvent(event);
 }
+
+#include "moc_idlescreen.cpp"

--- a/mythtv/programs/mythfrontend/keygrabber.cpp
+++ b/mythtv/programs/mythfrontend/keygrabber.cpp
@@ -121,3 +121,5 @@ void KeyGrabPopupBox::SendResult()
     emit HaveResult(m_capturedKey);
     Close();
 }
+
+#include "moc_keygrabber.cpp"

--- a/mythtv/programs/mythfrontend/manualschedule.cpp
+++ b/mythtv/programs/mythfrontend/manualschedule.cpp
@@ -275,3 +275,5 @@ void ManualSchedule::scheduleCreated(int ruleid)
     if (ruleid > 0)
         Close();
 }
+
+#include "moc_manualschedule.cpp"

--- a/mythtv/programs/mythfrontend/mythcontrols.cpp
+++ b/mythtv/programs/mythfrontend/mythcontrols.cpp
@@ -764,4 +764,4 @@ void MythControls::customEvent(QEvent *event)
 
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_mythcontrols.cpp"

--- a/mythtv/programs/mythfrontend/networkcontrol.cpp
+++ b/mythtv/programs/mythfrontend/networkcontrol.cpp
@@ -1914,4 +1914,4 @@ QString NetworkCommand::getFrom(int arg)
     return c;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_networkcontrol.cpp"

--- a/mythtv/programs/mythfrontend/playbackbox.cpp
+++ b/mythtv/programs/mythfrontend/playbackbox.cpp
@@ -5654,4 +5654,4 @@ bool PlaybackBox::PbbJobQueue::IsJobQueuedOrRunning(int jobType, uint chanid,
         IsJobRunning(jobType, chanid, recstartts);
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_playbackbox.cpp"

--- a/mythtv/programs/mythfrontend/prevreclist.cpp
+++ b/mythtv/programs/mythfrontend/prevreclist.cpp
@@ -807,3 +807,5 @@ void PrevRecordedList::DeleteOldSeries(bool ok)
         }
     }
 }
+
+#include "moc_prevreclist.cpp"

--- a/mythtv/programs/mythfrontend/progdetails.cpp
+++ b/mythtv/programs/mythfrontend/progdetails.cpp
@@ -936,3 +936,5 @@ void ProgDetails::loadPage(void)
 
     delete record;
 }
+
+#include "moc_progdetails.cpp"

--- a/mythtv/programs/mythfrontend/progfind.cpp
+++ b/mythtv/programs/mythfrontend/progfind.cpp
@@ -1092,4 +1092,4 @@ void SearchInputDialog::editChanged(void)
     }
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_progfind.cpp"

--- a/mythtv/programs/mythfrontend/proginfolist.cpp
+++ b/mythtv/programs/mythfrontend/proginfolist.cpp
@@ -109,3 +109,5 @@ void ProgInfoList::Display(const DataList& data)
     if (m_btnList->CanTakeFocus())
         m_screen.SetFocusWidget(m_btnList);
 }
+
+#include "moc_proginfolist.cpp"

--- a/mythtv/programs/mythfrontend/proglist.cpp
+++ b/mythtv/programs/mythfrontend/proglist.cpp
@@ -1777,3 +1777,5 @@ void ProgLister::customEvent(QEvent *event)
     if (needUpdate)
         FillItemList(true);
 }
+
+#include "moc_proglist.cpp"

--- a/mythtv/programs/mythfrontend/proglist_helpers.cpp
+++ b/mythtv/programs/mythfrontend/proglist_helpers.cpp
@@ -554,3 +554,5 @@ void EditPowerSearchPopup::initLists(void)
             m_channelList->SetItemCurrent(m_channelList->GetCount() - 1);
     }
 }
+
+#include "moc_proglist_helpers.cpp"

--- a/mythtv/programs/mythfrontend/programrecpriority.cpp
+++ b/mythtv/programs/mythfrontend/programrecpriority.cpp
@@ -1501,4 +1501,4 @@ ProgramInfo *ProgramRecPriority::GetCurrentProgram(void) const
     return item ? item->GetData().value<ProgramRecPriorityInfo*>() : nullptr;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_programrecpriority.cpp"

--- a/mythtv/programs/mythfrontend/schedulecommon.cpp
+++ b/mythtv/programs/mythfrontend/schedulecommon.cpp
@@ -613,3 +613,5 @@ void ScheduleCommon::AddGroupMenuItems(MythMenu *sortGroupMenu)
     sortGroupMenu->AddItem(tr("Group By Program ID"));
     sortGroupMenu->AddItem(tr("Group By None"));
 }
+
+#include "moc_schedulecommon.cpp"

--- a/mythtv/programs/mythfrontend/scheduleeditor.cpp
+++ b/mythtv/programs/mythfrontend/scheduleeditor.cpp
@@ -2889,3 +2889,5 @@ void PostProcMixin::TranscodeChanged(bool enable)
     if (m_transcodeprofileList)
         m_transcodeprofileList->SetEnabled(m_rule->m_autoTranscode);
 }
+
+#include "moc_scheduleeditor.cpp"

--- a/mythtv/programs/mythfrontend/servicecontracts/service.cpp
+++ b/mythtv/programs/mythfrontend/servicecontracts/service.cpp
@@ -179,3 +179,5 @@ bool Service::ToBool( const QString &sVal )
 
     return false;
 }
+
+#include "moc_service.cpp"

--- a/mythtv/programs/mythfrontend/services/frontend.cpp
+++ b/mythtv/programs/mythfrontend/services/frontend.cpp
@@ -463,3 +463,5 @@ bool Frontend::SendKey(const QString &sKey)
 
     return ret;
 }
+
+#include "moc_frontend.cpp"

--- a/mythtv/programs/mythfrontend/services/mythfrontendservice.cpp
+++ b/mythtv/programs/mythfrontend/services/mythfrontendservice.cpp
@@ -420,3 +420,5 @@ FrontendActionList::FrontendActionList(QVariantMap List)
     : m_ActionList(std::move(List))
 {
 }
+
+#include "moc_mythfrontendservice.cpp"

--- a/mythtv/programs/mythfrontend/setupwizard_audio.cpp
+++ b/mythtv/programs/mythfrontend/setupwizard_audio.cpp
@@ -427,3 +427,5 @@ void AudioSetupWizard::toggleSpeakers(void)
         m_testSpeakerButton->SetText(tr("Stop Speaker Test"));
     }
 }
+
+#include "moc_setupwizard_audio.cpp"

--- a/mythtv/programs/mythfrontend/setupwizard_general.cpp
+++ b/mythtv/programs/mythfrontend/setupwizard_general.cpp
@@ -293,3 +293,5 @@ void GeneralSetupWizard::CreateBusyDialog(const QString& message)
     if (m_busyPopup->Create())
         m_popupStack->AddScreen(m_busyPopup);
 }
+
+#include "moc_setupwizard_general.cpp"

--- a/mythtv/programs/mythfrontend/setupwizard_video.cpp
+++ b/mythtv/programs/mythfrontend/setupwizard_video.cpp
@@ -292,3 +292,5 @@ void VideoSetupWizard::customEvent(QEvent *e)
         }
     }
 }
+
+#include "moc_setupwizard_video.cpp"

--- a/mythtv/programs/mythfrontend/statusbox.cpp
+++ b/mythtv/programs/mythfrontend/statusbox.cpp
@@ -1673,4 +1673,4 @@ void StatusBox::doAutoExpireList(bool updateExpList)
 
 Q_DECLARE_METATYPE(LogLine)
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_statusbox.cpp"

--- a/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.cpp
+++ b/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.cpp
@@ -140,3 +140,5 @@ void TestVideoList::cleanupTestCase()
 }
 
 QTEST_GUILESS_MAIN(TestVideoList)
+
+#include "moc_test_videolist.cpp"

--- a/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.pro
+++ b/mythtv/programs/mythfrontend/test/test_videolist/test_videolist.pro
@@ -10,8 +10,8 @@ INCLUDEPATH += . ../..
 INCLUDEPATH += ../../../../libs
 
 LIBS += ../../obj/videolist.o
-LIBS += ../../obj/videofilter.o ../../obj/moc_videofilter.o
-LIBS += ../../obj/upnpscanner.o ../../obj/moc_upnpscanner.o
+LIBS += ../../obj/videofilter.o
+LIBS += ../../obj/upnpscanner.o
 
 # Add all the necessary libraries
 LIBS += -L../../../../libs/libmythbase -lmythbase-$$LIBVERSION

--- a/mythtv/programs/mythfrontend/themechooser.cpp
+++ b/mythtv/programs/mythfrontend/themechooser.cpp
@@ -1143,4 +1143,4 @@ void ThemeUpdateChecker::checkForUpdate(void)
     delete localTheme;
 }
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+#include "moc_themechooser.cpp"

--- a/mythtv/programs/mythfrontend/upnpscanner.cpp
+++ b/mythtv/programs/mythfrontend/upnpscanner.cpp
@@ -1417,3 +1417,5 @@ void UPNPScanner::ParseService(QDomElement &element, QUrl &controlURL,
         eventURL   = event_url;
     }
 }
+
+#include "moc_upnpscanner.cpp"

--- a/mythtv/programs/mythfrontend/videodlg.cpp
+++ b/mythtv/programs/mythfrontend/videodlg.cpp
@@ -3865,3 +3865,4 @@ void VideoDialog::PromptToScan()
 }
 
 #include "videodlg.moc"
+#include "moc_videodlg.cpp"

--- a/mythtv/programs/mythfrontend/videofileassoc.cpp
+++ b/mythtv/programs/mythfrontend/videofileassoc.cpp
@@ -529,3 +529,5 @@ void FileAssocDialog::UpdateScreen(bool useSelectionOverride /* = false*/)
 }
 
 Q_DECLARE_METATYPE(UIDToFAPair)
+
+#include "moc_videofileassoc.cpp"

--- a/mythtv/programs/mythfrontend/videofilter.cpp
+++ b/mythtv/programs/mythfrontend/videofilter.cpp
@@ -769,3 +769,5 @@ void VideoFilterDialog::setTextFilter()
     m_settings.setTextFilter(m_textFilter->GetText());
     update_numvideo();
 }
+
+#include "moc_videofilter.cpp"

--- a/mythtv/programs/mythfrontend/videometadatasettings.cpp
+++ b/mythtv/programs/mythfrontend/videometadatasettings.cpp
@@ -152,3 +152,5 @@ void MetadataSettings::toggleTrailers()
 
     m_trailerSpin->SetVisible(checkstate != 0);
 }
+
+#include "moc_videometadatasettings.cpp"

--- a/mythtv/programs/mythfrontend/videoplayersettings.cpp
+++ b/mythtv/programs/mythfrontend/videoplayersettings.cpp
@@ -172,3 +172,5 @@ void PlayerSettings::fillRegionList()
     if (item)
         m_blurayRegionList->SetItemCurrent(item);
 }
+
+#include "moc_videoplayersettings.cpp"

--- a/mythtv/programs/mythfrontend/videopopups.cpp
+++ b/mythtv/programs/mythfrontend/videopopups.cpp
@@ -73,3 +73,5 @@ bool PlotDialog::Create()
 
     return true;
 }
+
+#include "moc_videopopups.cpp"

--- a/mythtv/programs/mythfrontend/viewscheduled.cpp
+++ b/mythtv/programs/mythfrontend/viewscheduled.cpp
@@ -749,3 +749,5 @@ ProgramInfo *ViewScheduled::GetCurrentProgram(void) const
     MythUIButtonListItem *item = m_schedulesList->GetItemCurrent();
     return item ? item->GetData().value<ProgramInfo*>() : nullptr;
 }
+
+#include "moc_viewscheduled.cpp"

--- a/mythtv/programs/mythfrontend/viewschedulediff.cpp
+++ b/mythtv/programs/mythfrontend/viewschedulediff.cpp
@@ -353,3 +353,5 @@ ProgramInfo *ViewScheduleDiff::CurrentProgram()
         return s.m_after;
     return s.m_before;
 }
+
+#include "moc_viewschedulediff.cpp"

--- a/mythtv/programs/mythlcdserver/lcdprocclient.cpp
+++ b/mythtv/programs/mythlcdserver/lcdprocclient.cpp
@@ -2456,4 +2456,5 @@ void LCDProcClient::updateRecordingList(void)
     if (m_activeScreen == "Time" || m_activeScreen == "RecStatus")
         startTime();
 }
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
+
+#include "moc_lcdprocclient.cpp"

--- a/mythtv/programs/mythlcdserver/lcdserver.cpp
+++ b/mythtv/programs/mythlcdserver/lcdserver.cpp
@@ -818,3 +818,5 @@ void LCDServer::updateLEDs(const QStringList &tokens, QTcpSocket *socket)
 
     sendMessage(socket, "OK");
 }
+
+#include "moc_lcdserver.cpp"

--- a/mythtv/programs/mythscreenwizard/screenwizard.cpp
+++ b/mythtv/programs/mythscreenwizard/screenwizard.cpp
@@ -379,3 +379,5 @@ void ScreenWizard::customEvent(QEvent *event)
     }
 
 }
+
+#include "moc_screenwizard.cpp"

--- a/mythtv/programs/mythtv-setup/backendsettings.cpp
+++ b/mythtv/programs/mythtv-setup/backendsettings.cpp
@@ -1222,3 +1222,5 @@ BackendSettings::~BackendSettings()
     delete m_masterServerPort;
     m_masterServerPort=nullptr;
 }
+
+#include "moc_backendsettings.cpp"

--- a/mythtv/programs/mythtv-setup/channeleditor.cpp
+++ b/mythtv/programs/mythtv-setup/channeleditor.cpp
@@ -916,3 +916,5 @@ void ChannelEditor::customEvent(QEvent *event)
         }
     }
 }
+
+#include "moc_channeleditor.cpp"

--- a/mythtv/programs/mythtv-setup/exitprompt.cpp
+++ b/mythtv/programs/mythtv-setup/exitprompt.cpp
@@ -166,3 +166,5 @@ void ExitPrompter::quit()
 
     qApp->exit(GENERIC_EXIT_OK);
 }
+
+#include "moc_exitprompt.cpp"

--- a/mythtv/programs/mythtv-setup/importicons.cpp
+++ b/mythtv/programs/mythtv-setup/importicons.cpp
@@ -874,3 +874,5 @@ void ImportIconsWizard::Close()
 {
     MythScreenType::Close();
 }
+
+#include "moc_importicons.cpp"

--- a/mythtv/programs/mythtv-setup/startprompt.cpp
+++ b/mythtv/programs/mythtv-setup/startprompt.cpp
@@ -113,3 +113,5 @@ void StartPrompter::quit()
 {
     qApp->exit(GENERIC_EXIT_OK);
 }
+
+#include "moc_startprompt.cpp"

--- a/mythtv/programs/mythwelcome/welcomedialog.cpp
+++ b/mythtv/programs/mythwelcome/welcomedialog.cpp
@@ -736,3 +736,4 @@ void WelcomeDialog::shutdownNow(void)
     myth_system(command, kMSDontBlockInputDevs);
 }
 
+#include "moc_welcomedialog.cpp"

--- a/mythtv/programs/mythwelcome/welcomesettings.cpp
+++ b/mythtv/programs/mythwelcome/welcomesettings.cpp
@@ -170,3 +170,5 @@ MythShutdownSettings::MythShutdownSettings()
     addChild(MythShutdownXTermCmd());
     addChild(MythShutdownStartFECmd());
 }
+
+#include "moc_welcomesettings.cpp"


### PR DESCRIPTION
This improves compiler analysis since the entire class definition
is in one compilation unit and decreases compile and link times
due to fewer object files being linked together.  In addition,
for CMake this greatly speeds up incremental compilation since
this avoids the use of mocs_compilation.cpp where every moc_*.cpp
file was included.

I first had to fix header guards and hide the troublesome X11 headers.  This includes https://github.com/MythTV/mythtv/pull/1151 since that moved some of the X11 including headers.

With ccache, this was 1-2% faster.  With ccache cleared, qmake was about 10% faster.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

