### PR TITLE
Python: Fix datetime.replace(tzinfo=None) with Python 3.13

### DIFF
--- a/mythtv/bindings/python/MythTV/utility/dt.py
+++ b/mythtv/bindings/python/MythTV/utility/dt.py
@@ -17,6 +17,7 @@ import time
 import sys
 
 IS_PY312plus = (sys.version_info[:3] >= (3, 12, 0))
+IS_PY313plus = (sys.version_info[:3] >= (3, 13, 0))
 
 HAVEZONEINFO = False
 try:
@@ -343,12 +344,16 @@ class datetime( _pydatetime ):
         return cls._utctz
 
     @classmethod
-    def fromDatetime(cls, dt, tzinfo=None, fold=None):
+    def fromDatetime(cls, dt, tzinfo=None, fold=0):
         if tzinfo is None:
             tzinfo = dt.tzinfo
             fold = dt.fold
+            if IS_PY313plus and tzinfo is None:
+                # in case dt is naive, i.e.: no tzinfo available
+                tzinfo = cls.localTZ()
+                fold = 0
         return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute,
-                   dt.second, dt.microsecond, tzinfo, fold)
+                   dt.second, dt.microsecond, tzinfo=tzinfo, fold=fold)
 
 # override existing classmethods to enforce use of timezone
     @classmethod
@@ -509,7 +514,7 @@ class datetime( _pydatetime ):
     def __new__(cls, year, month, day, hour=None, minute=None, second=None,
                       microsecond=None, tzinfo=None, fold=None):
 
-        if tzinfo is None:
+        if not IS_PY313plus and tzinfo is None:
             kwargs = {'tzinfo':cls.localTZ()}
         else:
             kwargs = {'tzinfo':tzinfo}


### PR DESCRIPTION
From Python 3.13 onwards `datetime.replace()` calls the `__new__()` constructor, which is subclassed within MythTVs Python bindings. The binding uses the datetime.replace(tzinfo=None) method to create a naive (timezone less) datetime instance used by the MySQL driver (e.g.: for recorded.starttime).
From now on care must be taken when creating a new `datetime` instance by attaching the correct timezone, like
d = datetime(2025, 9, 7, 19, 58, tzinfo=datetime.UTCTZ())

Refs MythTV#1179

Please note that this issue is intended to be backported to thef ixes/35 branch, where the minimal Python version
 is still 3.8.
 Enhancements on MythTV/master (v36-pre) will be handled by #1180.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

