### PR TITLE
Add option to default to Last Captions State

### DIFF
--- a/mythtv/libs/libmythtv/mythplayer.cpp
+++ b/mythtv/libs/libmythtv/mythplayer.cpp
@@ -93,7 +93,8 @@ MythPlayer::MythPlayer(PlayerContext* Context, PlayerFlags Flags)
     m_deleteMap.SetPlayerContext(m_playerCtx);
 
     m_vbiMode = VBIMode::Parse(gCoreContext->GetSetting("VbiFormat"));
-    m_captionsEnabledbyDefault = gCoreContext->GetBoolSetting("DefaultCCMode");
+    m_captionsEnabledbyDefault = gCoreContext->GetNumSetting("DefaultCCMode");
+    m_lastCaptionsEnabled = gCoreContext->GetBoolSetting("LastCaptions", false);
     m_endExitPrompt      = gCoreContext->GetNumSetting("EndOfRecordingExitPrompt");
 
     // Get VBI page number

--- a/mythtv/libs/libmythtv/mythplayer.h
+++ b/mythtv/libs/libmythtv/mythplayer.h
@@ -459,7 +459,8 @@ class MTV_PUBLIC MythPlayer : public QObject
     TeletextReader m_ttxReader;
     /// This allows us to enable captions/subtitles later if the streams
     /// are not immediately available when the video starts playing.
-    bool      m_captionsEnabledbyDefault  {false};
+    uint      m_captionsEnabledbyDefault  {0}; // 0=off, 1=on, 2=last
+    bool      m_lastCaptionsEnabled       {false};
     bool      m_enableForcedSubtitles     {false};
     bool      m_disableForcedSubtitles    {false};
     bool      m_allowForcedSubtitles      {true};

--- a/mythtv/libs/libmythtv/mythplayercaptionsui.cpp
+++ b/mythtv/libs/libmythtv/mythplayercaptionsui.cpp
@@ -267,7 +267,9 @@ void MythPlayerCaptionsUI::SetAllowForcedSubtitles(bool Allow)
 
 void MythPlayerCaptionsUI::ToggleCaptions()
 {
-    SetCaptionsEnabled(!(static_cast<bool>(m_captionsState.m_textDisplayMode)));
+    bool togval = !(static_cast<bool>(m_captionsState.m_textDisplayMode));
+    SetCaptionsEnabled(togval);
+    gCoreContext->SaveSetting("LastCaptions", togval);
 }
 
 void MythPlayerCaptionsUI::ToggleCaptionsByType(uint Type)

--- a/mythtv/libs/libmythtv/mythplayerui.cpp
+++ b/mythtv/libs/libmythtv/mythplayerui.cpp
@@ -463,7 +463,20 @@ void MythPlayerUI::VideoStart()
     if (hasForcedTextTrack)
         SetTrack(kTrackTypeRawText, forcedTrackNumber);
     else
-        SetCaptionsEnabled(m_captionsEnabledbyDefault, false);
+    {
+        switch (m_captionsEnabledbyDefault)
+        {
+            case 0:     // Captions off
+                SetCaptionsEnabled(false, false);
+                break;
+            case 1:     // Captions on
+                SetCaptionsEnabled(true, false);
+                break;
+            default:    // Last captions state
+                SetCaptionsEnabled(m_lastCaptionsEnabled, false);
+                break;
+        }
+    }
 
     m_osdLock.unlock();
 

--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -1673,14 +1673,16 @@ static HostSpinBoxSetting *YScanDisplacement()
     return gs;
 };
 
-static HostCheckBoxSetting *DefaultCCMode()
+static HostComboBoxSetting *DefaultCCMode()
 {
-    auto *gc = new HostCheckBoxSetting("DefaultCCMode");
+    auto *gc = new HostComboBoxSetting("DefaultCCMode");
 
-    gc->setLabel(OSDSettings::tr("Always display closed captioning or "
+    gc->setLabel(OSDSettings::tr("Default to display closed captioning or "
                                  "subtitles"));
 
-    gc->setValue(false);
+    gc->addSelection(OSDSettings::tr("Captions off"), "0");
+    gc->addSelection(OSDSettings::tr("Captions on"), "1");
+    gc->addSelection(OSDSettings::tr("Last captions state"), "2");
 
     gc->setHelpText(OSDSettings::tr("If enabled, captions will be displayed "
                                     "when playing back recordings or watching "


### PR DESCRIPTION
This change adds a new configuration option for _mythfrontend_ closed captioning. Setup -> Video -> Playback OSD -> _Always display Closed Captioning or Subtitles_ is switched to _Default to display Closed Captioning or Subtitles_ and the user is able to pick a new configuration option.

A LastCaptions entry is added into the Settings database. This boolean gets updated each time a user toggles captions on or off, and indicates whether captions were enabled or disabled the last time it changed. The m_captionsEnabledbyDefault variable is switched from a boolean to an unsigned int so that it can hold 0, 1, or 2. It's set to 2 when the **Last Captions State** configuration is selected. When starting up viewing of a video recording or Live TV, by default, captions are either disabled (0), enabled (1), or set to match the last caption state (2).

When a user picks **Last Captions State**, _mythfrontend_ will remember whether captions were enabled or disabled the last time something was watched, and will carry over that state for the next thing to be watched. Turn on captions, and they will continue to appear until you explicitly turn them off. Turn off captions and they will not appear until you explicitly turn them on.

Resolves: #1154

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

