### PR TITLE
mythtranscode: fix FIFO mode

### DIFF
--- a/mythtv/programs/mythtranscode/transcode.cpp
+++ b/mythtv/programs/mythtranscode/transcode.cpp
@@ -170,10 +170,9 @@ int Transcode::TranscodeFile(const QString &inputname,
         }
     }
 
-    if (!m_avfMode)
+    if (!m_avfMode && fifodir.isEmpty())
     {
-        LOG(VB_GENERAL, LOG_ERR,
-            "AVFormat mode not set.");
+        LOG(VB_GENERAL, LOG_ERR, "No output mode is set.");
         return REENCODE_ERROR;
     }
 


### PR DESCRIPTION
The check incorrectly required m_avfMode to always be true, but this is not required for FIFO output.

This should also be applied to fixes/35.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organized and have [good commit messages](https://chris.beams.io/posts/git-commit)

