### PR TITLE
GitHub Actions: fix macOS runner issue with out of sync python

### DIFF
--- a/.github/workflows/build-mythtv.yml
+++ b/.github/workflows/build-mythtv.yml
@@ -348,9 +348,9 @@ jobs:
           key: ${{ matrix.os.desc }}-${{ matrix.compiler.desc }}-build-core-ccache-${{ github.sha }}
           restore-keys: ${{ matrix.os.desc }}-${{ matrix.compiler.desc }}-build-core-ccache
 
-      - name: Update Homebrew Environment
+      - name: Establish Homebrew Environment
         run: |
-          brew update && brew upgrade
+          #brew update && brew upgrade
           PKGMGR_PREFIX=$(brew --prefix)
           echo "PKGMGR_PREFIX=$PKGMGR_PREFIX" >> $GITHUB_ENV
 


### PR DESCRIPTION
  Occaisionally, the github runners get caught between python upgrades
  requiring a re-link to the correct python3 environment. Address this
  by not updating the runner's packages.

  As homebrew is a harsh mistress, this will likely need to be
  uncommented in the near future.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [ ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ ] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

