### PR TITLE
Fix issue #1201 to allow very large descriptions in info by default

### DIFF
--- a/mythtv/themes/default/schedule-ui.xml
+++ b/mythtv/themes/default/schedule-ui.xml
@@ -1307,7 +1307,8 @@
             <buttonarea>20,0,-25,100%</buttonarea>
 
             <statetype name="buttonitem">
-                <area>0,0,100%,240</area>
+                <!-- tall to fit very long descriptions, auto-shrinks, fixes #1201 -->
+                <area>0,0,100%,800</area>
                 <minsize shrink="short">100%,5</minsize>
 
                 <state name="active">


### PR DESCRIPTION
Thanks to @mosource21 for the bug report and @rcrdnalor for the fix!

Note that themes that have a copy of the programdetails block in their schedule-ui.xml may override this and still have the truncated descriptions bug.  If so they will need the same fix.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

