### PR TITLE
Simplify symbol export macro headers

### DIFF
--- a/mythtv/libs/libmyth/mythexp.h
+++ b/mythtv/libs/libmyth/mythexp.h
@@ -1,14 +1,12 @@
 #ifndef MYTHEXP_H_
 #define MYTHEXP_H_
 
-#ifdef __cplusplus
-#include <QtCore/qglobal.h>
+#include <QtGlobal>
 
 #ifdef MYTH_API
 # define MPUBLIC Q_DECL_EXPORT
 #else
 # define MPUBLIC Q_DECL_IMPORT
 #endif
-#endif /* __cplusplus */
 
 #endif /* MYTHEXP_H_ */

--- a/mythtv/libs/libmythbase/mythbaseexp.h
+++ b/mythtv/libs/libmythbase/mythbaseexp.h
@@ -1,18 +1,11 @@
 #ifndef MYTHBASEEXP_H_
 #define MYTHBASEEXP_H_
 
-// This header is called from some non-QT projects,
-// and if non C++ then Q_DECL_XXX never defined
-
-#if defined( QT_CORE_LIB ) && defined( __cplusplus )
-# include <QtCore/qglobal.h>
-# if defined(MBASE_API) || defined(MPLUGIN_API)
-#  define MBASE_PUBLIC Q_DECL_EXPORT
-# else
-#  define MBASE_PUBLIC Q_DECL_IMPORT
-# endif
+#include <QtGlobal>
+#if defined(MBASE_API)
+# define MBASE_PUBLIC Q_DECL_EXPORT
 #else
-# define MBASE_PUBLIC
+# define MBASE_PUBLIC Q_DECL_IMPORT
 #endif
 
 #endif // MYTHBASEEXP_H_

--- a/mythtv/libs/libmythtv/mythtvexp.h
+++ b/mythtv/libs/libmythtv/mythtvexp.h
@@ -1,11 +1,10 @@
 #ifndef MYTHTVEXP_H_
 #define MYTHTVEXP_H_
 
-// This header is called from some non-QT projects, 
-// and if non C++ then Q_DECL_XXX never defined
+// Included by libdvdnav and libdvdread C code
 
-#if defined( QT_CORE_LIB ) && defined( __cplusplus )
-# include <QtCore/qglobal.h>
+#ifdef __cplusplus
+# include <QtGlobal>
 # ifdef MTV_API
 #  define MTV_PUBLIC Q_DECL_EXPORT
 # else


### PR DESCRIPTION
Only set MBASE_PUBLIC to export with MBASE_API since MPLUGIN_API has its own MPLUGIN_PUBLIC export/import define.

Only libmythtv/io/mythiowrapper.h is included by C code in libdvdnav and libdvdread.

@linuxdude42 Even if this doesn't fix the linking issues discussed on the mythtv-users mailing list, I still think this is a worthwhile change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

