### PR TITLE
AudioPlayer: Prevent incorrect notification from being displayed

### DIFF
--- a/mythtv/libs/libmythtv/audioplayer.cpp
+++ b/mythtv/libs/libmythtv/audioplayer.cpp
@@ -127,9 +127,13 @@ QString AudioPlayer::ReinitAudio(void)
             aos.m_init = false;
 
         m_audioOutput = AudioOutput::OpenAudio(aos);
-        if (m_audioOutput == nullptr || !m_audioOutput->isConfigured())
+        if (m_audioOutput == nullptr)
         {
             errMsg = tr("Unable to create AudioOutput.");
+        }
+        else if (aos.m_init && !m_audioOutput->isConfigured())
+        {
+            errMsg = tr("AudioOutput has not been successfully configured.");
         }
         AddVisuals();
     }


### PR DESCRIPTION
If AudioSettings::m_init is false, AudioOutput::OpenAudio() will not call AudioOutput::Reconfigure(), so the notifcation would always be displayed.

AudioPlayer::ReinitAudio() will be called again later after m_state is set and the audio works fine.

Fixes https://github.com/MythTV/mythtv/issues/1219

@linuxdude42 @warpme @kmdewaal This should correct the behavior.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

