### PR TITLE
Fixed channel icon conflict when populating the database from XMLTV

### DIFF
--- a/mythtv/programs/mythfilldatabase/channeldata.cpp
+++ b/mythtv/programs/mythfilldatabase/channeldata.cpp
@@ -211,8 +211,13 @@ void ChannelData::handleChannels(int id, ChannelInfoList *chanlist) const
 
         if (!(*i).m_icon.isEmpty())
         {
-            QDir remotefile = QDir((*i).m_icon);
-            QString filename = remotefile.dirName();
+            QString remotename = QDir((*i).m_icon).dirName();
+            // Define an unique icon filename for this channel and xmltv source
+            // The most obvious format is <source_id>_<xmltv_id>_<remotename>
+            QString filename(QString::number(id));
+            filename.append("_").append((*i).m_xmltvId);
+            filename.append("_").append(remotename);
+            filename.remove(QRegularExpression("[ \\\\/\\:\\*\\[\\]\\(\\)]"));
 
             localfile = fileprefix + filename;
             QFile actualfile(localfile);


### PR DESCRIPTION
Based on the remote filenames of the icons, conflicts can arise, causing a mess:

    <icon src="https://static.te.../stations/308/icon320_light.png?v2023_48_0"/>
    <icon src="https://static.te.../stations/58/icon320_light.png?v2023_48_0"/>
    <icon src="https://static.te.../stations/383/icon320_light.png?v2023_48_0"/>

These cases generates the same icon filename 'icon320_light.png?v2023_48_0'.

The proposed solution no longer uses the original filename; it now generates a user-friendly name from the source identifier of channel (xmltvid), followed by the hash of the full remote URL and, optionally, the file extension. This way, the generated name can no longer conflict with that of another channel, and it is easily identifiable with the xmltv identifier, as it is user-configured.

    <xmltv_id>_<remote_url_hash>.<ext>

Now downloaded icon names from xmltv source look like the following.

    T18.fr_2fcaf706.svg.png
    NOVO19.fr_d890da17.svg.png
    TMC.fr_79bd517.png

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ X ] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [ X ] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [ X ] code compiles successfully without errors
- [ X ] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [ X ] documentation added/updated/removed where necessary
- [ X ] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

