### PR TITLE
Fix broken MythUIImage::GetFilename() method

### DIFF
--- a/mythtv/libs/libmythui/mythuiimage.h
+++ b/mythtv/libs/libmythui/mythuiimage.h
@@ -105,7 +105,7 @@ class MUI_PUBLIC MythUIImage : public MythUIType
     MythUIImage(MythUIType *parent, const QString &name);
    ~MythUIImage() override;
 
-    QString GetFilename(void) { return m_filename; }
+    QString GetFilename(void) { return m_imageProperties.m_filename; }
 
     /** Must be followed by a call to Load() to load the image. */
     void SetFilename(const QString &filename);
@@ -164,7 +164,6 @@ class MUI_PUBLIC MythUIImage : public MythUIType
 
     void FindRandomImage(void);
 
-    QString m_filename;
     QString m_origFilename;
 
     QHash<int, MythImage *> m_images;


### PR DESCRIPTION
MythUIImage::SetFilename() stores the given filename into m_imageProperties.m_filename. MythUIImage::GetFilename() was getting the filename from 'm_filename'. As a result, it always returned an empty string. The GetFilename() method has been updated to retrieve the filename from the same place where SetFilename() stores it. In addition, the 'm_filename' data member has been eliminated since there are no users of it anymore.

Resolves: #1138 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

