### PR TITLE
Remove invalid reads after delete in DeviceContextFinished

### DIFF
--- a/mythtv/libs/libmythtv/decoders/mythcodeccontext.cpp
+++ b/mythtv/libs/libmythtv/decoders/mythcodeccontext.cpp
@@ -452,12 +452,13 @@ void MythCodecContext::DeviceContextFinished(AVHWDeviceContext* Context)
     auto * interop = reinterpret_cast<MythInteropGPU*>(Context->user_opaque);
     if (interop)
     {
-        DestroyInterop(interop);
         FreeAVHWDeviceContext free = interop->GetDefaultFree();
+        void *io_user_opaque = interop->GetDefaultUserOpaque();
+        DestroyInterop(interop);
         if (free)
         {
             LOG(VB_PLAYBACK, LOG_INFO, LOC + "Calling default device context free");
-            Context->user_opaque = interop->GetDefaultUserOpaque();
+            Context->user_opaque = io_user_opaque;
             free(Context);
         }
     }


### PR DESCRIPTION
In DeviceContextFinished(), interop->GetDefaultFree() and interop->GetDefaultUserOpaque() were called after
**interop** was deleted. These invocations have been moved to before the destruction of **interop**. This update eliminates two "_Invalid read of size 8_" errors reported by **valgrind**.

Resolves: #1166

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

