### PR TITLE
mythtranscode: Fix lossless transcode

### DIFF
--- a/mythtv/programs/mythtranscode/mpeg2fix.cpp
+++ b/mythtv/programs/mythtranscode/mpeg2fix.cpp
@@ -2138,6 +2138,12 @@ int MPEG2fixup::Start()
         return GENERIC_EXIT_NOT_OK;
     }
 
+    if (m_inputFC->streams[m_vidId]->codecpar->codec_id != AV_CODEC_ID_MPEG2VIDEO)
+    {
+        LOG(VB_GENERAL, LOG_ERR, "Input video codec is not MPEG-2.");
+        return GENERIC_EXIT_NOT_OK;
+    }
+
     if (!FindStart())
     {
         av_packet_free(&pkt);

--- a/mythtv/programs/mythtranscode/mythtranscode.cpp
+++ b/mythtv/programs/mythtranscode/mythtranscode.cpp
@@ -583,6 +583,11 @@ int main(int argc, char *argv[])
             transcode->SetCMDAudioBitrate(cmdline.toInt("audiobitrate") * 1000);
     }
 
+    if (!cmdline.toBool("avf") && !cmdline.toBool("hls") && fifodir.isEmpty())
+    {
+        mpeg2 = true;
+    }
+
     if (showprogress)
         transcode->ShowProgress(true);
     if (!recorderOptions.isEmpty())
@@ -613,7 +618,7 @@ int main(int argc, char *argv[])
     }
 
     int exitcode = GENERIC_EXIT_OK;
-    if ((result == REENCODE_MPEG2TRANS) || mpeg2 || build_index)
+    if (mpeg2 || build_index)
     {
         void (*update_func)(float) = nullptr;
         int (*check_func)() = nullptr;


### PR DESCRIPTION
Before the removal of NuppelVideoRecorder, the code in Transcode::TranscodeFile() would check the given profilename for the "transcodelossless" option if the input was MPEG-2 and no output mode was set and would return REENCODE_MPEG2TRANS.

Instead, ignore the profile and assume lossless transcoding is wanted if no output mode is set, erroring out early in MPEG2Fixup::Start() if the file is not an MPEG-2 video.

The transcode RecordingProfiles are completely ignored.

---

This should also be applied to fixes/35.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

