### PR TITLE
Convert all sleep calls to std::this_thread::sleep_for

### DIFF
--- a/mythplugins/mytharchive/mytharchive/logviewer.cpp
+++ b/mythplugins/mytharchive/mytharchive/logviewer.cpp
@@ -1,7 +1,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
-#include <unistd.h>
+#include <thread>
 
 // qt
 #include <QCoreApplication>
@@ -62,7 +62,7 @@ void showLogViewer(void)
             }
         }
 
-        sleep(1);
+        std::this_thread::sleep_for(1s);
     }
 
     // do any logs exist?

--- a/mythplugins/mytharchive/mytharchive/recordingselector.cpp
+++ b/mythplugins/mytharchive/mytharchive/recordingselector.cpp
@@ -1,7 +1,7 @@
 
 // c++
 #include <cstdlib>
-#include <unistd.h>
+#include <thread>
 
 // qt
 #include <QApplication>
@@ -125,7 +125,7 @@ void RecordingSelector::Init(void)
     while (thread->isRunning())
     {
         QCoreApplication::processEvents();
-        usleep(2000);
+        std::this_thread::sleep_for(2ms);
     }
 
     if (!m_recordingList || m_recordingList->empty())

--- a/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
+++ b/mythplugins/mythmusic/mythmusic/avfdecoder.cpp
@@ -20,6 +20,7 @@
 
 // C++ headers
 #include <chrono>
+#include <thread>
 
 // QT headers
 #include <QFile>
@@ -512,10 +513,7 @@ void avfDecoder::run()
                 // never go below 1s buffered
                 if (buffered < 1s)
                     break;
-                // wait
-                long count = buffered.count();
-                const struct timespec ns {0, (count - 1000) * 1000000};
-                nanosleep(&ns, nullptr);
+                std::this_thread::sleep_for(buffered - 1s);
             }
         }
     }

--- a/mythplugins/mythmusic/mythmusic/cddecoder.cpp
+++ b/mythplugins/mythmusic/mythmusic/cddecoder.cpp
@@ -4,7 +4,7 @@
 // C
 #include <cstdlib>
 #include <cstring>
-#include <unistd.h>
+#include <thread>
 
 // Qt
 #include <QtGlobal>
@@ -135,7 +135,7 @@ void CdDecoder::writeBlock()
             }
             break;
         }
-        ::usleep(output()->GetAudioBufferedTime().count()<<9);
+        std::this_thread::sleep_for(output()->GetAudioBufferedTime() / 2);
     }
 }
 
@@ -386,7 +386,7 @@ void CdDecoder::run()
             if (fill < (thresh << 6))
                 break;
             // Wait for half of the buffer to drain
-            ::usleep(output()->GetAudioBufferedTime().count()<<9);
+            std::this_thread::sleep_for(output()->GetAudioBufferedTime() / 2);
         }
 
         // write a block if there's sufficient space for it

--- a/mythplugins/mythmusic/mythmusic/decoderhandler.cpp
+++ b/mythplugins/mythmusic/mythmusic/decoderhandler.cpp
@@ -1,7 +1,7 @@
 // c/c++
 #include <cassert>
 #include <cstdio>
-#include <unistd.h>
+#include <thread>
 
 // qt
 #include <QApplication>
@@ -329,7 +329,7 @@ void DecoderHandler::createPlaylistFromRemoteUrl(const QUrl &url)
         }
 
         QCoreApplication::processEvents();
-        usleep(500);
+        std::this_thread::sleep_for(500us);
     }
 }
 

--- a/mythplugins/mythmusic/mythmusic/editmetadata.cpp
+++ b/mythplugins/mythmusic/mythmusic/editmetadata.cpp
@@ -1,4 +1,5 @@
 // C++
+#include <thread>
 #include <utility>
 
 // qt
@@ -1353,8 +1354,7 @@ void EditAlbumartDialog::doCopyImageToTag(const AlbumArtImage *image)
     while (copyThread->isRunning())
     {
         qApp->processEvents();
-        const struct timespec onems {0, 1000000};
-        nanosleep(&onems, nullptr);
+        std::this_thread::sleep_for(1ms);
     }
 
     strList = copyThread->getResult();

--- a/mythplugins/mythmusic/mythmusic/importmusic.cpp
+++ b/mythplugins/mythmusic/mythmusic/importmusic.cpp
@@ -1,3 +1,5 @@
+#include <thread>
+
 // qt
 #include <QApplication>
 #include <QDir>
@@ -489,8 +491,7 @@ bool ImportMusicDialog::copyFile(const QString &src, const QString &dst)
 
     while (!copy->isFinished())
     {
-        const struct timespec halfms {0, 500000};
-        nanosleep(&halfms, nullptr);
+        std::this_thread::sleep_for(500us);
         QCoreApplication::processEvents();
     }
 
@@ -529,8 +530,7 @@ void ImportMusicDialog::startScan()
 
     while (!scanner->isFinished())
     {
-        const struct timespec halfms {0, 500000};
-        nanosleep(&halfms, nullptr);
+        std::this_thread::sleep_for(500us);
         QCoreApplication::processEvents();
     }
 

--- a/mythplugins/mythmusic/mythmusic/musicdata.cpp
+++ b/mythplugins/mythmusic/mythmusic/musicdata.cpp
@@ -1,5 +1,5 @@
 // C/C++
-#include <unistd.h> // for usleep()
+#include <thread>
 
 // qt
 #include <QApplication>
@@ -87,7 +87,7 @@ void MusicData::reloadMusic(void) const
     while (!m_all_music->doneLoading())
     {
         QCoreApplication::processEvents();
-        usleep(50000);
+        std::this_thread::sleep_for(50ms);
     }
 
     m_all_playlists->resync();
@@ -133,7 +133,7 @@ void MusicData::loadMusic(void) const
            || !gMusicData->m_all_music->doneLoading())
     {
         QCoreApplication::processEvents();
-        usleep(50000);
+        std::this_thread::sleep_for(50ms);
     }
 
     gPlayer->loadStreamPlaylist();

--- a/mythplugins/mythmusic/mythmusic/mythmusic.cpp
+++ b/mythplugins/mythmusic/mythmusic/mythmusic.cpp
@@ -1,8 +1,8 @@
 // C++ headers
 #include <cstdlib>
+#include <thread>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 // Qt headers
 #include <QApplication>
@@ -687,7 +687,7 @@ static void handleCDMedia(MythMediaDevice *cd, bool forcePlayback)
            || !gMusicData->m_all_music->doneLoading())
     {
         QCoreApplication::processEvents();
-        usleep(50000);
+        std::this_thread::sleep_for(50ms);
     }
 
     // remove any existing CD tracks

--- a/mythplugins/mythmusic/mythmusic/playlist.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlist.cpp
@@ -3,7 +3,7 @@
 #include <cinttypes>
 #include <cstdlib>
 #include <map>
-#include <unistd.h>
+#include <thread>
 
 // qt
 #include <QApplication>
@@ -1387,7 +1387,7 @@ int Playlist::CreateCDMP3(void)
     m_proc->Run();
 
     while( m_procExitVal == GENERIC_EXIT_RUNNING )
-        usleep( 100000 );
+        std::this_thread::sleep_for(100ms);
 
     uint retval = m_procExitVal;
 
@@ -1436,7 +1436,7 @@ int Playlist::CreateCDMP3(void)
         m_proc->Run();
 
         while( m_procExitVal == GENERIC_EXIT_RUNNING )
-            usleep( 100000 );
+            std::this_thread::sleep_for(100ms);
 
         retval = m_procExitVal;
 

--- a/mythplugins/mythmusic/mythmusic/playlistcontainer.cpp
+++ b/mythplugins/mythmusic/mythmusic/playlistcontainer.cpp
@@ -1,4 +1,5 @@
 // C/C++
+#include <thread>
 #include <utility>
 
 // MythTV
@@ -16,7 +17,7 @@ void PlaylistLoadingThread::run()
     RunProlog();
     while (!m_allMusic->doneLoading())
     {
-        usleep(250ms); // cppcheck-suppress usleepCalled
+        std::this_thread::sleep_for(250ms);
     }
     m_parent->load();
     RunEpilog();

--- a/mythplugins/mythzoneminder/mythzoneminder/alarmnotifythread.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/alarmnotifythread.cpp
@@ -1,4 +1,4 @@
-// Qt headers
+#include <thread>
 
 // MythTV headers
 #include <libmythbase/mythcorecontext.h>
@@ -66,8 +66,7 @@ void AlarmNotifyThread::run()
             }
         }
 
-        const struct timespec onesec {1, 0};
-        nanosleep(&onesec, nullptr);
+        std::this_thread::sleep_for(1s);
     }
 
     RunEpilog();

--- a/mythplugins/mythzoneminder/mythzoneminder/zmclient.cpp
+++ b/mythplugins/mythzoneminder/mythzoneminder/zmclient.cpp
@@ -3,7 +3,7 @@
 */
 
 // C++
-#include <unistd.h>
+#include <thread>
 
 // qt
 #include <QTimer>
@@ -93,7 +93,7 @@ bool ZMClient::connectToHost(const QString &lhostname, unsigned int lport)
             m_bConnected = true;
         }
 
-        usleep(999999);
+        std::this_thread::sleep_for(1s);
     }
 
     if (!m_bConnected)

--- a/mythtv/libs/libmyth/mythcontext.cpp
+++ b/mythtv/libs/libmyth/mythcontext.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <queue>
 #include <thread>
-#include <unistd.h> // for usleep(), gethostname
 #include <vector>
 
 #include <QtGlobal>
@@ -34,6 +33,7 @@
 #endif
 
 #ifdef Q_OS_WINDOWS
+#include <cstdlib> // getenv, _putenv
 #include "libmythbase/compat.h"
 #endif
 #include "libmythbase/configuration.h"
@@ -1179,7 +1179,7 @@ int MythContext::Impl::UPnPautoconf(const std::chrono::milliseconds milliSeconds
     MythTimer searchTime; searchTime.start();
     while (totalTime.elapsed() < milliSeconds)
     {
-        usleep(25000);
+        std::this_thread::sleep_for(25ms);
         auto ttl = milliSeconds - totalTime.elapsed();
         if ((searchTime.elapsed() > 249ms) && (ttl > 1s))
         {
@@ -1282,7 +1282,7 @@ bool MythContext::Impl::DefaultUPnP(QString& Error)
         if (devicelocation)
             break;
 
-        usleep(25000);
+        std::this_thread::sleep_for(25ms);
 
         auto ttl = timeout_ms - totalTime.elapsed();
         if ((searchTime.elapsed() > 249ms) && (ttl > 1s))

--- a/mythtv/libs/libmythbase/http/mythhttpinstance.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttpinstance.cpp
@@ -1,3 +1,5 @@
+#include <thread>
+
 // MythTV
 #include "mthread.h"
 #include "http/mythhttpinstance.h"
@@ -25,10 +27,10 @@ MythHTTPInstance::MythHTTPInstance()
 
     m_httpServer->moveToThread(m_httpServerThread->qthread());
     m_httpServerThread->start();
-    QThread::usleep(50);
+    std::this_thread::sleep_for(50us);
     while (!m_httpServerThread->qthread()->isRunning())
     {
-        QThread::usleep(50);
+        std::this_thread::sleep_for(50us);
     }
 }
 

--- a/mythtv/libs/libmythbase/lcddevice.cpp
+++ b/mythtv/libs/libmythbase/lcddevice.cpp
@@ -12,8 +12,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
-#include <fcntl.h>
-#include <unistd.h> // for usleep()
+#include <thread>
 
 // Qt headers
 #include <QApplication>
@@ -139,7 +138,7 @@ bool LCD::connectToHost(const QString &lhostname, unsigned int lport)
             return m_connected;
         }
 
-        usleep(500000);
+        std::this_thread::sleep_for(500ms);
     }
 
     for (int count = 1; count <= 10 && !m_connected; count++)
@@ -169,7 +168,7 @@ bool LCD::connectToHost(const QString &lhostname, unsigned int lport)
         }
         m_socket->close();
 
-        usleep(500000);
+        std::this_thread::sleep_for(500ms);
     }
 
     if (!m_connected)

--- a/mythtv/libs/libmythbase/loggingserver.cpp
+++ b/mythtv/libs/libmythbase/loggingserver.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <thread>
 
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
@@ -460,7 +461,7 @@ bool logForwardStart(void)
     logForwardThread = new LogForwardThread();
     logForwardThread->start();
 
-    usleep(10000);
+    std::this_thread::sleep_for(10ms);
     return (logForwardThread && logForwardThread->isRunning());
 }
 

--- a/mythtv/libs/libmythbase/mthread.cpp
+++ b/mythtv/libs/libmythbase/mthread.cpp
@@ -87,8 +87,6 @@ class MThreadInternal : public QThread
     static void SetTerminationEnabled(bool enabled = true)
     { QThread::setTerminationEnabled(enabled); }
 
-    static void USleep(std::chrono::microseconds time) { QThread::usleep(time.count()); }
-
   private:
     MThread &m_parent;
 };
@@ -330,11 +328,6 @@ int MThread::exec(void)
 void MThread::setTerminationEnabled(bool enabled)
 {
     MThreadInternal::SetTerminationEnabled(enabled);
-}
-
-void MThread::usleep(std::chrono::microseconds time)
-{
-    MThreadInternal::USleep(time);
 }
 
 /* vim: set expandtab tabstop=4 shiftwidth=4: */

--- a/mythtv/libs/libmythbase/mthread.h
+++ b/mythtv/libs/libmythbase/mthread.h
@@ -127,10 +127,6 @@ class MBASE_PUBLIC MThread
     int exec(void);
 
     static void setTerminationEnabled(bool enabled = true);
-    static void usleep(std::chrono::microseconds time);
-    template<typename R, typename P>
-    static typename std::enable_if_t<std::chrono::treat_as_floating_point<R>::value, void>
-    usleep(std::chrono::duration<R,P> time) { usleep(duration_cast<std::chrono::microseconds>(time)); }; // cppcheck-suppress [missingReturn,usleepCalled]
 
     MThreadInternal *m_thread {nullptr};
     QRunnable *m_runnable     {nullptr};

--- a/mythtv/libs/libmythbase/mythcorecontext.cpp
+++ b/mythtv/libs/libmythbase/mythcorecontext.cpp
@@ -28,7 +28,7 @@
 #include <cmath>
 #include <cstdarg>
 #include <queue>
-#include <unistd.h>       // for usleep()
+#include <thread>
 
 #ifdef Q_OS_WINDOWS
 #include <winsock2.h>
@@ -525,7 +525,7 @@ MythSocket *MythCoreContext::ConnectCommandSocket(
         }
 
         if (sleepus != 0us)
-            usleep(sleepus.count());
+            std::this_thread::sleep_for(sleepus);
     }
 
     if (we_attempted_wol)

--- a/mythtv/libs/libmythbase/mythdbcon.cpp
+++ b/mythtv/libs/libmythbase/mythdbcon.cpp
@@ -2,6 +2,7 @@
 
 // ANSI C
 #include <cstdlib>
+#include <thread>
 
 // Qt
 #include <QCoreApplication>
@@ -198,7 +199,7 @@ bool MSqlDatabase::OpenDatabase(bool skipdb)
                             .arg(m_dbparms.m_wolCommand));
                 }
 
-                sleep(m_dbparms.m_wolReconnect.count());
+                std::this_thread::sleep_for(m_dbparms.m_wolReconnect);
                 connected = m_db.open();
             }
 

--- a/mythtv/libs/libmythbase/mythdownloadmanager.cpp
+++ b/mythtv/libs/libmythbase/mythdownloadmanager.cpp
@@ -19,7 +19,7 @@
 #include <QTcpSocket>
 
 #include <cstdlib>
-#include <unistd.h> // for usleep()
+#include <thread>
 
 // libmythbase
 #include "compat.h"
@@ -161,13 +161,13 @@ MythDownloadManager *GetMythDownloadManager(void)
     auto *tmpDLM = new MythDownloadManager();
     tmpDLM->start();
     while (!tmpDLM->getQueueThread())
-        usleep(10000);
+        std::this_thread::sleep_for(10ms);
 
     tmpDLM->moveToThread(tmpDLM->getQueueThread());
     tmpDLM->setRunThread();
 
     while (!tmpDLM->isRunning())
-        usleep(10000);
+        std::this_thread::sleep_for(10ms);
 
     downloadManager = tmpDLM;
 
@@ -204,7 +204,7 @@ void MythDownloadManager::run(void)
     m_queueThread = QThread::currentThread();
 
     while (!m_runThread)
-        usleep(50ms);
+        std::this_thread::sleep_for(50ms);
 
     m_manager = new QNetworkAccessManager(this);
     m_diskCache = new QNetworkDiskCache(this);
@@ -1074,7 +1074,7 @@ void MythDownloadManager::cancelDownload(const QStringList &urls, bool block)
 
     while (!m_cancellationQueue.isEmpty())
     {
-        usleep(50ms); // re-test in another 50ms
+        std::this_thread::sleep_for(50ms); // re-test in another 50ms
     }
 }
 
@@ -1530,7 +1530,7 @@ bool MythDownloadManager::saveFile(const QString &outFile,
         if (written < 0)
         {
             failure_cnt++;
-            usleep(50ms);
+            std::this_thread::sleep_for(50ms);
             continue;
         }
 

--- a/mythtv/libs/libmythbase/mythmedia.cpp
+++ b/mythtv/libs/libmythbase/mythmedia.cpp
@@ -1,6 +1,7 @@
 // C header
 #include <fcntl.h>
 #include <unistd.h>
+#include <thread>
 #include <utility>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -152,7 +153,7 @@ bool MythMediaDevice::performMountCmd(bool DoMount)
         int ret = myth_system(MountCommand, kMSDontBlockInputDevs);
         if (ret !=  GENERIC_EXIT_OK)
         {
-            usleep(300000);
+            std::this_thread::sleep_for(300ms);
             LOG(VB_MEDIA, LOG_INFO, QString("Retrying '%1'").arg(MountCommand));
             ret = myth_system(MountCommand, kMSDontBlockInputDevs);
         }
@@ -165,13 +166,13 @@ bool MythMediaDevice::performMountCmd(bool DoMount)
                 // In the case that m_devicePath is a symlink to a device
                 // in /etc/fstab then pmount delegates to mount which
                 // performs the mount asynchronously so we must wait a bit
-                usleep(1000000-1);
+                std::this_thread::sleep_for(1s);
                 for (int tries = 2; !findMountPath() && tries > 0; --tries)
                 {
                     LOG(VB_MEDIA, LOG_INFO,
                         QString("Repeating '%1'").arg(MountCommand));
                     myth_system(MountCommand, kMSDontBlockInputDevs);
-                    usleep(500000);
+                    std::this_thread::sleep_for(500ms);
                 }
                 if (!findMountPath())
                 {

--- a/mythtv/libs/libmythbase/mythmiscutil.cpp
+++ b/mythtv/libs/libmythbase/mythmiscutil.cpp
@@ -5,6 +5,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <iostream>
+#include <thread>
 
 // POSIX
 #include <unistd.h>
@@ -719,9 +720,9 @@ void myth_yield(void)
 {
 #ifdef _POSIX_PRIORITY_SCHEDULING
     if (sched_yield()<0)
-        usleep(5000);
+        std::this_thread::sleep_for(5ms);
 #else
-    usleep(5000);
+    std::this_thread::sleep_for(5ms);
 #endif
 }
 

--- a/mythtv/libs/libmythbase/mythsocket.cpp
+++ b/mythtv/libs/libmythbase/mythsocket.cpp
@@ -21,8 +21,8 @@
 #else
 #include <sys/socket.h>
 #endif
-#include <unistd.h> // for usleep
 #include <algorithm> // for max
+#include <thread>
 #include <vector> // for vector
 
 // MythTV
@@ -782,7 +782,7 @@ void MythSocket::WriteStringListReal(const QStringList *list, bool *ret)
                 *ret = false;
                 return;
             }
-            usleep(1000);
+            std::this_thread::sleep_for(1ms);
         }
     }
 

--- a/mythtv/libs/libmythbase/mythsystemunix.cpp
+++ b/mythtv/libs/libmythbase/mythsystemunix.cpp
@@ -228,7 +228,7 @@ void MythSystemLegacyIOHandler::Wait(int fd)
     while (m_pMap.contains(fd))
     {
         locker.unlock();
-        usleep(10ms);
+        std::this_thread::sleep_for(10ms);
         locker.relock();
     }
 }

--- a/mythtv/libs/libmythbase/mythsystemwindows.cpp
+++ b/mythtv/libs/libmythbase/mythsystemwindows.cpp
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <thread>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -98,7 +99,7 @@ void MythSystemLegacyIOHandler::run(void)
 
         while( run_system )
         {
-            usleep(10ms); // ~100x per second, for ~3MBps throughput
+            std::this_thread::sleep_for(10ms); // ~100x per second, for ~3MBps throughput
             m_pLock.lock();
             if( m_pMap.isEmpty() )
             {
@@ -203,7 +204,7 @@ void MythSystemLegacyIOHandler::Wait(HANDLE h)
     while (m_pMap.contains(h))
     {
         locker.unlock();
-        usleep(10ms);
+        std::this_thread::sleep_for(10ms);
         locker.relock();
     }
 }
@@ -251,7 +252,7 @@ void MythSystemLegacyManager::run(void)
         if( m_childCount == 0 )
         {
             m_mapLock.unlock();
-            usleep( 100ms );
+            std::this_thread::sleep_for(100ms);
             continue;
         }
 
@@ -457,7 +458,7 @@ void MythSystemLegacySignalManager::run(void)
     LOG(VB_GENERAL, LOG_INFO, "Starting process signal handler");
     while( run_system )
     {
-        usleep(50ms);
+        std::this_thread::sleep_for(50ms);
         while( run_system )
         {
             // handle cleanup and signalling for closed processes

--- a/mythtv/libs/libmythbase/signalhandling.cpp
+++ b/mythtv/libs/libmythbase/signalhandling.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib> // for free
 #include <iostream>
 #include <string>
+#include <thread>
 #include <sys/types.h>
 #include <unistd.h>
 #ifndef Q_OS_WINDOWS
@@ -256,7 +257,8 @@ void SignalHandler::signalHandler(int signum,
 
         // Wait for UI event loop to handle this, however we may be
         // blocking it if this signal occured in the UI thread.
-        // Note, can not use usleep() as it is not a signal safe function.
+        // Note, we cannot use std::this_thread::sleep_for()
+        // since it is not a signal safe function.
         sleep(1);
 
         if (!s_exit_program)
@@ -335,7 +337,7 @@ void SignalHandler::handleSignal(void)
     case SIGBUS:
     case SIGFPE:
     case SIGILL:
-        usleep(100000);
+        std::this_thread::sleep_for(100ms);
         s_exit_program = true;
         break;
     default:

--- a/mythtv/libs/libmythbase/test/test_mythsystem/test_mythsystem.h
+++ b/mythtv/libs/libmythbase/test/test_mythsystem/test_mythsystem.h
@@ -20,13 +20,12 @@
 #ifndef LIBMYTHBASE_TEST_MYTHSYSTEM_H
 #define LIBMYTHBASE_TEST_MYTHSYSTEM_H
 
-#include <unistd.h> // for usleep()
-
 #include <QTest>
 #include <QTemporaryFile>
 #include <QDateTime>
 
 #include <iostream>
+#include <thread>
 
 //#define NEW_LOGGING
 #ifdef NEW_LOGGING
@@ -273,7 +272,7 @@ class TestMythSystem: public QObject
     {
         QScopedPointer<MythSystem> cmd(
             MythSystem::Create("sleep 5", kMSRunShell));
-        usleep(50 * 1000);
+        std::this_thread::sleep_for(50ms);
         cmd->Signal(kSignalTerm);
         cmd->Wait();
         QCOMPARE(cmd->GetExitCode(), -1);

--- a/mythtv/libs/libmythbase/test/test_mythsystemlegacy/test_mythsystemlegacy.h
+++ b/mythtv/libs/libmythbase/test/test_mythsystemlegacy/test_mythsystemlegacy.h
@@ -20,8 +20,6 @@
 #ifndef LIBMYTHBASE_TEST_MYTHSYSTEMLEGACY_H
 #define LIBMYTHBASE_TEST_MYTHSYSTEMLEGACY_H
 
-#include <unistd.h> // for usleep()
-
 #include <QTest>
 #include <QTemporaryFile>
 #include <QDateTime>

--- a/mythtv/libs/libmythmetadata/imagescanner.cpp
+++ b/mythtv/libs/libmythmetadata/imagescanner.cpp
@@ -1,5 +1,7 @@
 #include "imagescanner.h"
 
+#include <thread>
+
 #include "libmythbase/mythcorecontext.h"  // for gCoreContext
 #include "libmythbase/mythlogging.h"
 
@@ -216,7 +218,7 @@ void ImageScanThread<DBFS>::run()
             // For initial scans pause briefly to give thumb generator a headstart
             // before being deluged by client requests
             if (firstScan)
-                usleep(1s);
+                std::this_thread::sleep_for(1s);
 
             // Notify clients of completion with removed & changed images
             m_dbfs.Notify("IMAGE_DB_CHANGED", mesg);

--- a/mythtv/libs/libmythmetadata/metadatafactory.cpp
+++ b/mythtv/libs/libmythmetadata/metadatafactory.cpp
@@ -3,7 +3,7 @@
 
 // C++
 #include <algorithm>
-#include <unistd.h> // for sleep()
+#include <thread>
 
 // QT
 #include <QApplication>
@@ -249,7 +249,7 @@ MetadataLookupList MetadataFactory::SynchronousLookup(MetadataLookup *lookup)
 
     while (m_returnList.isEmpty() && m_sync)
     {
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         QCoreApplication::processEvents();
     }
 

--- a/mythtv/libs/libmythmetadata/musicfilescanner.cpp
+++ b/mythtv/libs/libmythmetadata/musicfilescanner.cpp
@@ -1,6 +1,4 @@
-// POSIX headers
-#include <sys/stat.h>
-#include <unistd.h>
+#include <thread>
 
 // Qt headers
 #include <QDir>
@@ -681,7 +679,7 @@ void MusicFileScanner::SearchDirs(const QStringList &dirList)
                     gCoreContext->SendMessage(QString("MUSIC_SCANNER_ERROR %1 %2").arg(host, "Stalled"));
 
                     // give the user time to read the notification before restarting the scan
-                    sleep(5);
+                    std::this_thread::sleep_for(5s);
                 }
                 else
                 {

--- a/mythtv/libs/libmythmetadata/musicmetadata.cpp
+++ b/mythtv/libs/libmythmetadata/musicmetadata.cpp
@@ -1,13 +1,15 @@
 
 #include "musicmetadata.h"
 
+#include <thread>
+#include <utility>
+
 // qt
 #include <QApplication>
 #include <QDateTime>
 #include <QDir>
 #include <QDomDocument>
 #include <QScopedPointer>
-#include <utility>
 
 // mythtv
 #include "libmythbase/mythcorecontext.h"
@@ -1429,7 +1431,7 @@ void MetadataLoadingThread::run()
 {
     RunProlog();
     //if you want to simulate a big music collection load
-    //sleep(3);
+    //std::this_thread::sleep_for(3s);
     m_parent->resync();
     RunEpilog();
 }
@@ -2079,7 +2081,7 @@ void AlbumArtImages::scanForImages()
     while (scanThread->isRunning())
     {
         QCoreApplication::processEvents();
-        usleep(1000);
+        std::this_thread::sleep_for(1ms);
     }
 
     strList = scanThread->getResult();

--- a/mythtv/libs/libmythprotoserver/requesthandler/deletethread.cpp
+++ b/mythtv/libs/libmythprotoserver/requesthandler/deletethread.cpp
@@ -1,5 +1,7 @@
 #include <cstdlib>
 #include <iostream>
+#include <thread>
+
 #include <fcntl.h>
 
 #include <QList>
@@ -43,7 +45,7 @@ void DeleteThread::run(void)
         // loop through any stored files every half second 
         ProcessNew();
         ProcessOld();
-        usleep(0.5s);
+        std::this_thread::sleep_for(500ms);
     }
 
     if (!m_files.empty())

--- a/mythtv/libs/libmythtv/AirPlay/mythraopconnection.cpp
+++ b/mythtv/libs/libmythtv/AirPlay/mythraopconnection.cpp
@@ -1,7 +1,6 @@
-#include <unistd.h> // for usleep()
-
 #include <algorithm>
 #include <limits> // workaround QTBUG-90395
+#include <thread>
 #include <utility>
 
 #include <QTcpSocket>
@@ -1849,7 +1848,7 @@ std::chrono::milliseconds MythRAOPConnection::AudioCardLatency(void)
                      0ms,
                      frames);
     av_free(samples);
-    usleep(duration_cast<std::chrono::microseconds>(AUDIOCARD_BUFFER).count());
+    std::this_thread::sleep_for(AUDIOCARD_BUFFER);
     std::chrono::milliseconds audiots = m_audio->GetAudiotime();
     LOG(VB_PLAYBACK, LOG_DEBUG, LOC + QString("AudioCardLatency: ts=%1ms")
         .arg(audiots.count()));

--- a/mythtv/libs/libmythtv/HLS/httplivestream.cpp
+++ b/mythtv/libs/libmythtv/HLS/httplivestream.cpp
@@ -19,9 +19,6 @@
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-// POSIX headers
-#include <unistd.h> // for usleep
-
 // C headers
 #include <cstdio>
 

--- a/mythtv/libs/libmythtv/HLS/httplivestreambuffer.cpp
+++ b/mythtv/libs/libmythtv/HLS/httplivestreambuffer.cpp
@@ -37,6 +37,7 @@
 // C++
 #include <algorithm> // for min/max
 #include <array>
+#include <thread>
 
 // libmythbase
 #include "libmythbase/mthread.h"
@@ -1222,7 +1223,7 @@ protected:
                         QString("download failed, retry #%1").arg(retries));
                     if (retries == 1)   // first error
                         continue;       // will retry immediately
-                    usleep(500ms);      // cppcheck-suppress usleepCalled
+                    std::this_thread::sleep_for(500ms);
                     if (retries == 2)   // and retry once again
                         continue;
                     if (!m_parent->m_meta) // NOLINT(bugprone-branch-clone)

--- a/mythtv/libs/libmythtv/audio/audiooutputalsa.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputalsa.cpp
@@ -1,7 +1,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <sys/time.h>
+#include <thread>
 
 #include <QFile>
 #include "libmythbase/mythcorecontext.h"
@@ -608,7 +608,7 @@ void AudioOutputALSA::WriteAudio(uchar *aubuf, int size)
             case -ESTRPIPE:
                 LOG(VB_AUDIO, LOG_INFO, LOC + "WriteAudio: device is suspended");
                 while ((err = snd_pcm_resume(m_pcmHandle)) == -EAGAIN)
-                    usleep(200us);
+                    std::this_thread::sleep_for(200us);
 
                 if (err < 0)
                 {

--- a/mythtv/libs/libmythtv/audio/audiooutputbase.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputbase.cpp
@@ -3,10 +3,9 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <thread>
 
-// POSIX headers
-#include <unistd.h>
-#include <sys/time.h>
+#include <unistd.h> // getpid
 
 // SoundTouch
 #if __has_include(<soundtouch/SoundTouch.h>)
@@ -2034,7 +2033,7 @@ void AudioOutputBase::OutputAudioLoop(void)
                           .arg(ready).arg(m_fragmentSize));
             }
 
-            usleep(10ms);
+            std::this_thread::sleep_for(10ms);
             continue;
         }
 
@@ -2167,7 +2166,7 @@ int AudioOutputBase::GetAudioData(uchar *buffer, int size, bool full_buffer,
 void AudioOutputBase::Drain()
 {
     while (!m_pauseAudio && audioready() > m_fragmentSize)
-        usleep(1ms);
+        std::this_thread::sleep_for(1ms);
     if (m_pauseAudio)
     {
         // Audio is paused and can't be drained, clear ringbuffer

--- a/mythtv/libs/libmythtv/audio/audiooutputca.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputca.cpp
@@ -15,6 +15,7 @@
 #include <SoundTouch.h>
 
 #include <array>
+#include <thread>
 #include <vector>
 
 #include <CoreServices/CoreServices.h>
@@ -279,7 +280,7 @@ bool AudioOutputCA::OpenDevice()
             if (result < 0)
             {
                 d->CloseAnalog();
-                usleep(1s - 1us); // Argument to usleep must be less than 1 second
+                std::this_thread::sleep_for(1s);
             }
         }
         deviceOpened = (result > 0);
@@ -1740,7 +1741,7 @@ void CoreAudioData::ResetStream(AudioStreamID s)
                     continue;
                 }
                 
-                sleep(1);   // For the change to take effect
+                std::this_thread::sleep_for(1s);   // For the change to take effect
             }
         }
     }

--- a/mythtv/libs/libmythtv/audio/audiooutputdx.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputdx.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cmath>
+#include <thread>
 
 #include "libmythbase/mythlogging.h"
 #include "audiooutputdx.h"
@@ -321,7 +322,7 @@ void AudioOutputDXPrivate::FillBuffer(unsigned char *buffer, int size)
             (m_writeCursor >= play_pos &&
              m_writeCursor + size >= play_pos + m_parent->m_soundcardBufferSize))
         {
-            usleep(50000);
+            std::this_thread::sleep_for(50ms);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/audio/audiooutputopensles.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputopensles.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <thread>
 
 #include <dlfcn.h>
 
@@ -442,7 +443,7 @@ void AudioOutputOpenSLES::WriteAudio(unsigned char * buffer, int size)
         if (numBufferesQueued == OPENSLES_BUFFERS)
         {
             // wait for a buffer period, should be clear next time around
-            usleep(OPENSLES_BUFLEN);
+            std::this_thread::sleep_for(OPENSLES_BUFLEN);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/audio/audiooutputoss.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputoss.cpp
@@ -3,8 +3,10 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <fcntl.h>
 #include <iostream>
+#include <thread>
+
+#include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -134,7 +136,7 @@ bool AudioOutputOSS::OpenDevice()
             return false;
         }
         if (m_audioFd < 0)
-            usleep(50us);
+            std::this_thread::sleep_for(50us);
     }
 
     if (m_audioFd == -1)

--- a/mythtv/libs/libmythtv/audio/audiopulsehandler.cpp
+++ b/mythtv/libs/libmythtv/audio/audiopulsehandler.cpp
@@ -1,9 +1,9 @@
+#include <thread>
+
 #include <QMutexLocker>
 #include <QString>
 #include <QMutex>
 #include <QElapsedTimer>
-
-#include <unistd.h> // for usleep
 
 #include "libmythbase/mythmiscutil.h"
 #include "libmythbase/mythlogging.h"
@@ -273,7 +273,7 @@ bool PulseHandler::Init(void)
     while ((tries++ < 100) && !IS_READY(m_ctxState))
     {
         pa_mainloop_iterate(m_loop, 0, &ret);
-        usleep(10000);
+        std::this_thread::sleep_for(10ms);
     }
 
     if (PA_CONTEXT_READY != m_ctxState)
@@ -326,7 +326,7 @@ bool PulseHandler::SuspendInternal(bool suspend)
     while (m_pendingOperations && count++ < 100)
     {
         pa_mainloop_iterate(m_loop, 0, &ret);
-        usleep(10000);
+        std::this_thread::sleep_for(10ms);
     }
 
     // a failure isn't necessarily disastrous

--- a/mythtv/libs/libmythtv/audio/volumebase.cpp
+++ b/mythtv/libs/libmythtv/audio/volumebase.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 
 #include <algorithm>
+#include <thread>
 
 #include <QString>
 #include <QMutex>
@@ -73,7 +74,7 @@ class VolumeWriteBackThread : public MThread
 
             // Ignore further volume changes for the holdoff period
             setTerminationEnabled(true);
-            usleep(holdoff); // cppcheck-suppress usleepCalled
+            std::this_thread::sleep_for(holdoff);
             setTerminationEnabled(false);
 
             lock.relock();

--- a/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
+++ b/mythtv/libs/libmythtv/channelscan/channelscan_sm.cpp
@@ -27,11 +27,9 @@
  *
  */
 
-// C includes
-#include <unistd.h>
-
 // C++ includes
 #include <algorithm>
+#include <thread>
 #include <utility>
 
 // Qt includes
@@ -2019,7 +2017,7 @@ void ChannelScanSM::run(void)
         if (m_scanning)
             HandleActiveScan();
 
-        usleep(10 * 1000);
+        std::this_thread::sleep_for(10ms);
     }
 
     LOG(VB_CHANSCAN, LOG_INFO, LOC + "run -- end");

--- a/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
+++ b/mythtv/libs/libmythtv/decoders/avformatdecoder.cpp
@@ -1,7 +1,5 @@
 #include "avformatdecoder.h"
 
-#include <unistd.h>
-
 // C++ headers
 #include <algorithm>
 #include <array>
@@ -10,6 +8,7 @@
 #include <cstring>
 #include <iostream>
 #include <set>
+#include <thread>
 
 extern "C" {
 #include "libavutil/avutil.h"
@@ -991,7 +990,7 @@ int AvFormatDecoder::OpenFile(MythMediaBuffer *Buffer, bool novideo,
                 {
                     // wait a little to buffer more data
                     // 50*0.1 = 5 seconds max
-                    QThread::usleep(100000);
+                    std::this_thread::sleep_for(100ms);
                     // resets the read position
                     m_avfRingBuffer->SetInInit(false);
                     continue;
@@ -1052,7 +1051,7 @@ int AvFormatDecoder::OpenFile(MythMediaBuffer *Buffer, bool novideo,
                 {
                     CloseContext();
                     LOG(VB_PLAYBACK, LOG_INFO, LOC + "Stream scan incomplete - retrying");
-                    QThread::usleep(250000); // wait 250ms
+                    std::this_thread::sleep_for(250ms);
                 }
                 break;
             }

--- a/mythtv/libs/libmythtv/dummydecoder.h
+++ b/mythtv/libs/libmythtv/dummydecoder.h
@@ -1,6 +1,8 @@
 #ifndef DUMMYDECODER_H_
 #define DUMMYDECODER_H_
 
+#include <thread>
+
 #include "decoders/decoderbase.h"
 #include "mythframe.h"
 #include "programinfo.h"
@@ -16,7 +18,7 @@ class DummyDecoder : public DecoderBase
     int         OpenFile(MythMediaBuffer* /*Buffer*/, bool /*novideo*/, TestBufferVec & /*testbuf*/) override
                     { return 0; }
     bool        GetFrame(DecodeType /*Type*/, bool &/*Retry*/) override
-                    { usleep(10000); return false; }
+                    { std::this_thread::sleep_for(10ms); return false; }
     bool        IsLastFrameKey(void) const override       { return true; }
     QString     GetCodecDecoderName(void) const override  { return "dummy"; }
     MythCodecID GetVideoCodecID(void) const override      { return kCodec_NONE; }

--- a/mythtv/libs/libmythtv/io/mythfifowriter.cpp
+++ b/mythtv/libs/libmythtv/io/mythfifowriter.cpp
@@ -20,6 +20,7 @@
 #include <sys/stat.h>
 #include <cmath>
 #include <iostream>
+#include <thread>
 
 MythFIFOThread::MythFIFOThread()
   : MThread("FIFOThread")
@@ -150,7 +151,7 @@ bool MythFIFOWriter::FIFOInit(uint Id, const QString& Desc, const QString& Name,
     m_fifoThrds[Id].start();
 
     while (0 == m_killWr[Id] && !m_fifoThrds[Id].isRunning())
-        usleep(1000);
+        std::this_thread::sleep_for(1ms);
 
     return m_fifoThrds[Id].isRunning();
 }
@@ -271,6 +272,6 @@ void MythFIFOWriter::FIFODrain(void)
                 count++;
             }
         }
-        usleep(1000);
+        std::this_thread::sleep_for(1ms);
     }
 }

--- a/mythtv/libs/libmythtv/io/mythfilebuffer.cpp
+++ b/mythtv/libs/libmythtv/io/mythfilebuffer.cpp
@@ -1,3 +1,5 @@
+#include <thread>
+
 // QT
 #include <QFileInfo>
 #include <QDir>
@@ -223,7 +225,7 @@ bool MythFileBuffer::OpenFile(const QString &Filename, std::chrono::milliseconds
                 }
 
                 lasterror = 1;
-                usleep(10ms);
+                std::this_thread::sleep_for(10ms);
                 continue;
             }
 
@@ -241,7 +243,7 @@ bool MythFileBuffer::OpenFile(const QString &Filename, std::chrono::milliseconds
 
                 if (m_oldfile)
                     break; // if it's an old file it won't grow..
-                usleep(10ms);
+                std::this_thread::sleep_for(10ms);
                 continue;
             }
 
@@ -504,7 +506,7 @@ int MythFileBuffer::SafeRead(int /*fd*/, void *Buffer, uint Size)
 
             zerocnt++;
 
-            // 0.36 second timeout for livetvchain with usleep(60000),
+            // 0.36 second timeout for livetvchain,
             // or 2.4 seconds if it's a new file less than 30 minutes old.
             if (zerocnt >= (m_liveTVChain ? 6 : 40))
             {
@@ -514,7 +516,7 @@ int MythFileBuffer::SafeRead(int /*fd*/, void *Buffer, uint Size)
         if (m_stopReads)
             break;
         if (tot < Size)
-            usleep(60ms);
+            std::this_thread::sleep_for(60ms);
     }
     return static_cast<int>(tot);
 }

--- a/mythtv/libs/libmythtv/io/mythmediabuffer.cpp
+++ b/mythtv/libs/libmythtv/io/mythmediabuffer.cpp
@@ -1107,7 +1107,8 @@ void MythMediaBuffer::run(void)
         {
             // To give other threads a good chance to handle these
             // conditions, even if they are only requesting a read lock
-            // like us, yield (currently implemented with short usleep).
+            // like us, yield (currently implemented with short
+            // std::this_thread::sleep_for).
             m_generalWait.wakeAll();
             m_rwLock.unlock();
             std::this_thread::sleep_for(5ms);

--- a/mythtv/libs/libmythtv/jobqueue.cpp
+++ b/mythtv/libs/libmythtv/jobqueue.cpp
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <cstdlib>
+#include <thread>
 #include <fcntl.h>
 #include <pthread.h>
 
@@ -791,7 +792,7 @@ bool JobQueue::DeleteAllJobs(uint chanid, const QDateTime &recstartts)
     std::chrono::seconds maxSleep   = 90s;
     while (jobsAreRunning && totalSlept < maxSleep)
     {
-        usleep(1000);
+        std::this_thread::sleep_for(1ms);
         query.prepare("SELECT id FROM jobqueue "
                       "WHERE chanid = :CHANID and starttime = :STARTTIME "
                       "AND status NOT IN "
@@ -822,7 +823,7 @@ bool JobQueue::DeleteAllJobs(uint chanid, const QDateTime &recstartts)
             LOG(VB_JOBQUEUE, LOG_INFO, LOC + message);
         }
 
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         totalSlept++;
     }
 

--- a/mythtv/libs/libmythtv/mythplayeravsync.cpp
+++ b/mythtv/libs/libmythtv/mythplayeravsync.cpp
@@ -1,5 +1,4 @@
-// Qt
-#include <QThread>
+#include <thread>
 
 // MythTV
 #include "libmythbase/mythlogging.h"
@@ -30,7 +29,7 @@ void MythPlayerAVSync::WaitForFrame(std::chrono::microseconds FrameDue)
     auto unow = std::chrono::microseconds(m_avTimer.nsecsElapsed() / 1000);
     auto delay = FrameDue - unow;
     if (delay > 0us)
-        QThread::usleep(delay.count());
+        std::this_thread::sleep_for(delay);
 }
 
 void MythPlayerAVSync::ResetAVSyncForLiveTV(AudioPlayer* Audio)

--- a/mythtv/libs/libmythtv/mythpreviewplayer.cpp
+++ b/mythtv/libs/libmythtv/mythpreviewplayer.cpp
@@ -1,5 +1,4 @@
-// Qt
-#include <QThread>
+#include <thread>
 
 // MythTV
 #include "mythpreviewplayer.h"
@@ -115,7 +114,7 @@ uint8_t *MythPreviewPlayer::GetScreenGrabAtFrame(uint64_t FrameNum, bool Absolut
     {
         tries += 1;
         m_decodeOneFrame = true;
-        QThread::usleep(10000);
+        std::this_thread::sleep_for(10ms);
         if ((tries % 10) == 0)
             LOG(VB_PLAYBACK, LOG_INFO, LOC + "Waited 100ms for video frame");
     }

--- a/mythtv/libs/libmythtv/previewgenerator.cpp
+++ b/mythtv/libs/libmythtv/previewgenerator.cpp
@@ -1,5 +1,6 @@
 // C headers
 #include <cmath>
+#include <thread>
 #include <utility>
 
 // POSIX headers
@@ -538,7 +539,7 @@ bool PreviewGenerator::SaveOutFile(const QByteArray &data, const QDateTime &dt)
         if (written < 0)
         {
             failure_cnt++;
-            usleep(50ms);
+            std::this_thread::sleep_for(50ms);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/programinforemoteutil.cpp
+++ b/mythtv/libs/libmythtv/programinforemoteutil.cpp
@@ -1,6 +1,6 @@
 #include "programinforemoteutil.h"
 
-#include <unistd.h>
+#include <thread>
 
 #include <QFileInfo>
 #include <QFile>
@@ -237,7 +237,7 @@ QDateTime RemoteGetPreviewIfModified(
         if (written < 0)
         {
             failure_cnt++;
-            usleep(50000);
+            std::this_thread::sleep_for(50ms);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/programinfoupdater.cpp
+++ b/mythtv/libs/libmythtv/programinfoupdater.cpp
@@ -1,5 +1,4 @@
-// Posix headers
-#include <unistd.h> // for usleep()
+#include <thread>
 
 // MythTV headers
 #include "libmythbase/mthreadpool.h"
@@ -53,7 +52,7 @@ void ProgramInfoUpdater::run(void)
         // we don't need instant updates allow a few to queue up
         // if they come in quick succession, this allows multiple
         // updates to be consolidated into one update...
-        usleep(200 * 1000); // 200ms
+        std::this_thread::sleep_for(200ms);
 
         m_lock.lock();
 

--- a/mythtv/libs/libmythtv/recorders/DeviceReadBuffer.cpp
+++ b/mythtv/libs/libmythtv/recorders/DeviceReadBuffer.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
 #include <cerrno>
+#include <thread>
+
 #include <fcntl.h>
 #include <sys/types.h>
 
@@ -373,7 +375,7 @@ void DeviceReadBuffer::run(void)
 
         if (!IsOpen())
         {
-            usleep(5ms);
+            std::this_thread::sleep_for(5ms);
             continue;
         }
 
@@ -419,7 +421,7 @@ void DeviceReadBuffer::run(void)
 
         // Slow down reading if not under load
         if (errcnt == 0 && total < throttle)
-            usleep(1ms);
+            std::this_thread::sleep_for(1ms);
     }
 
     ClosePipes();
@@ -444,7 +446,7 @@ bool DeviceReadBuffer::HandlePausing(void)
         if (m_readerCB)
             m_readerCB->ReaderPaused(m_streamFd);
 
-        usleep(5ms);
+        std::this_thread::sleep_for(5ms);
         return false;
     }
     if (IsPaused())
@@ -536,7 +538,7 @@ bool DeviceReadBuffer::Poll(void) const
                 if ((EAGAIN == errno) || (EINTR  == errno))
                     continue; // errors that tell you to try again
 
-                usleep(2.5ms);
+                std::this_thread::sleep_for(2500us);
             }
             else //  ret == 0
             {
@@ -613,7 +615,7 @@ bool DeviceReadBuffer::CheckForErrors(
             return false;
         if (EAGAIN == errno)
         {
-            usleep(2.5ms);
+            std::this_thread::sleep_for(2500us);
             return false;
         }
         if (EOVERFLOW == errno)
@@ -633,7 +635,7 @@ bool DeviceReadBuffer::CheckForErrors(
             return false;
         }
 
-        usleep(500ms);
+        std::this_thread::sleep_for(500ms);
         return false;
     }
     if (len == 0)
@@ -649,7 +651,7 @@ bool DeviceReadBuffer::CheckForErrors(
 
             return false;
         }
-        usleep(500ms);
+        std::this_thread::sleep_for(500ms);
         return false;
     }
     return true;
@@ -715,7 +717,7 @@ uint DeviceReadBuffer::WaitForUnused(uint needed) const
             unused = GetUnused();
             if (IsPauseRequested() || !IsOpen() || !m_doRun)
                 return 0;
-            usleep(5ms);
+            std::this_thread::sleep_for(5ms);
         }
         if (IsPauseRequested() || !IsOpen() || !m_doRun)
             return 0;

--- a/mythtv/libs/libmythtv/recorders/ExternalRecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/ExternalRecorder.cpp
@@ -17,6 +17,7 @@
  *   along with this program; if not, write to the Free Software Foundation,
  *   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#include <thread>
 
 // Qt includes
 #include <QString>
@@ -96,7 +97,7 @@ void ExternalRecorder::run(void)
         {
             LOG(VB_GENERAL, LOG_WARNING, LOC +
                 "Recording will not commence until a PMT is set.");
-            usleep(5000);
+            std::this_thread::sleep_for(5ms);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/recorders/HLS/HLSReader.cpp
+++ b/mythtv/libs/libmythtv/recorders/HLS/HLSReader.cpp
@@ -1,8 +1,7 @@
 #include "HLSReader.h"
 
 #include <cstring>
-
-#include <unistd.h>
+#include <thread>
 
 #include <QtGlobal>
 #include <QRegularExpression>
@@ -970,7 +969,7 @@ bool HLSReader::LoadSegments(MythSingleDownload& downloader)
         }
         else
         {
-            usleep(5000);
+            std::this_thread::sleep_for(5ms);
         }
 
         if (m_prebufferCnt == 0)

--- a/mythtv/libs/libmythtv/recorders/asirecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/asirecorder.cpp
@@ -17,6 +17,7 @@
  *   along with this program; if not, write to the Free Software
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
+#include <thread>
 
 // Qt includes
 #include <QString>
@@ -145,7 +146,7 @@ void ASIRecorder::run(void)
         {
             LOG(VB_GENERAL, LOG_WARNING, LOC +
                 "Recording will not commence until a PMT is set.");
-            usleep(5000);
+            std::this_thread::sleep_for(5ms);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/recorders/cetonrecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/cetonrecorder.cpp
@@ -4,6 +4,7 @@
  *  Copyright (c) 2006-2009 by Silicondust Engineering Ltd.
  *  Distributed as part of MythTV under GPL v2 and later.
  */
+#include <thread>
 
 // MythTV includes
 #include "libmythbase/mythlogging.h"
@@ -96,7 +97,7 @@ void CetonRecorder::run(void)
         {
             LOG(VB_GENERAL, LOG_WARNING, LOC +
                     "Recording will not commence until a PMT is set.");
-            usleep(5000);
+            std::this_thread::sleep_for(5ms);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/recorders/cetonstreamhandler.cpp
+++ b/mythtv/libs/libmythtv/recorders/cetonstreamhandler.cpp
@@ -5,21 +5,9 @@
  *  Distributed as part of MythTV under GPL v2 and later.
  */
 
-#include <QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
-#include <QtSystemDetection>
-#endif
-
-// POSIX headers
-#include <fcntl.h>
-#include <unistd.h>
-#ifndef Q_OS_WINDOWS
-#include <sys/select.h>
-#include <sys/ioctl.h>
-#endif
+#include <thread>
 
 // Qt headers
-#include <QCoreApplication>
 #include <QRegularExpression>
 #include <QUrl>
 #include <QUrlQuery>
@@ -448,7 +436,7 @@ void CetonStreamHandler::ClearProgramNumber(void)
     {
         if (GetVar("mux", "ProgramNumber") == "0")
             return;
-        usleep(20ms);
+        std::this_thread::sleep_for(20ms);
     };
 
     LOG(VB_GENERAL, LOG_ERR, LOC + "Program number failed to clear");
@@ -467,7 +455,7 @@ uint CetonStreamHandler::GetProgramNumber(void) const
         if (prognum != 0)
             return prognum;
 
-        usleep(100ms);
+        std::this_thread::sleep_for(100ms);
     };
 
     LOG(VB_GENERAL, LOG_ERR, LOC +

--- a/mythtv/libs/libmythtv/recorders/darwinfirewiredevice.cpp
+++ b/mythtv/libs/libmythtv/recorders/darwinfirewiredevice.cpp
@@ -21,6 +21,7 @@
 
 // Std C++ headers
 #include <algorithm>
+#include <thread>
 #include <vector>
 
 // MythTV headers
@@ -189,7 +190,7 @@ void DarwinFirewireDevice::StartController(void)
     while (!m_priv->m_controller_thread_running)
     {
         m_lock.unlock();
-        usleep(5000);
+        std::this_thread::sleep_for(5ms);
         m_lock.lock();
     }
 }
@@ -222,7 +223,7 @@ void DarwinFirewireDevice::StopController(void)
     while (m_priv->m_controller_thread_running)
     {
         m_lock.unlock();
-        usleep(100 * 1000);
+        std::this_thread::sleep_for(100ms);
         m_lock.lock();
     }
 }

--- a/mythtv/libs/libmythtv/recorders/dvbrecorder.cpp
+++ b/mythtv/libs/libmythtv/recorders/dvbrecorder.cpp
@@ -20,6 +20,7 @@
  *   along with this program; if not, write to the Free Software
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
+#include <thread>
 
 // MythTV includes
 #include "libmythbase/mythlogging.h"
@@ -144,7 +145,7 @@ void DVBRecorder::run(void)
         {
             LOG(VB_GENERAL, LOG_WARNING, LOC +
                     "Recording will not commence until a PMT is set.");
-            usleep(5000);
+            std::this_thread::sleep_for(5ms);
             continue;
         }
 

--- a/mythtv/libs/libmythtv/recorders/dvbsignalmonitor.cpp
+++ b/mythtv/libs/libmythtv/recorders/dvbsignalmonitor.cpp
@@ -3,8 +3,7 @@
 #include <cerrno>
 #include <cmath>
 #include <cstring>
-
-#include <unistd.h>
+#include <thread>
 
 //Qt headers
 #include <QCoreApplication>
@@ -160,7 +159,7 @@ DVBSignalMonitor::DVBSignalMonitor(int db_cardnum, DVBChannel* _channel,
 
     m_minimumUpdateRate = _channel->GetMinSignalMonitorDelay();
     if (m_minimumUpdateRate > 30ms)
-        usleep(m_minimumUpdateRate);
+        std::this_thread::sleep_for(m_minimumUpdateRate);
 
     m_streamHandler = DVBStreamHandler::Get(_channel->GetCardNum(), m_inputid);
 }

--- a/mythtv/libs/libmythui/devices/jsmenu.cpp
+++ b/mythtv/libs/libmythui/devices/jsmenu.cpp
@@ -35,6 +35,8 @@
 // C/C++ headers
 #include <cstdio>
 #include <cerrno>
+#include <thread>
+
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -243,7 +245,7 @@ void JoystickMenuThread::run(void)
             /* Get the file descriptor (fd) for the monitor.
             This fd will get passed to select() */
             int fd = udev_monitor_get_fd(mon);
-            /* This section will run till no error, calling usleep() at
+            /* This section will run till no error, calling sleep_for() at
             the end of each pass. This is to use a udev_monitor in a
             non-blocking way. */
             /*===========================================================
@@ -274,7 +276,7 @@ void JoystickMenuThread::run(void)
                         udev_device_unref(dev);
                     }
                 }
-                usleep(250ms);
+                std::this_thread::sleep_for(250ms);
             }
             // unref the monitor
             udev_monitor_unref(mon); // Also closes fd.

--- a/mythtv/libs/libmythui/mediamonitor-darwin.cpp
+++ b/mythtv/libs/libmythui/mediamonitor-darwin.cpp
@@ -5,6 +5,8 @@
  * \author   Andrew Kimpton, Nigel Pearson
  */
 
+#include <thread>
+
 #include <QDir>
 #include <QMetaType>
 
@@ -451,9 +453,9 @@ void MonitorThreadDarwin::diskInsert(const char *devName,
     {
         LOG(VB_MEDIA, LOG_WARNING,
             (msg + "() - Waiting for mount '%1' to become stable.").arg(mnt));
-        usleep(std::chrono::microseconds(120000)); // cppcheck-suppress usleepCalled
+        std::this_thread::sleep_for(120ms);
         if ( ++attempts > 4 )
-            usleep(std::chrono::microseconds(200000)); // cppcheck-suppress usleepCalled
+            std::this_thread::sleep_for(200ms);
         if ( attempts > 8 )
         {
             delete media;

--- a/mythtv/libs/libmythui/mediamonitor-unix.cpp
+++ b/mythtv/libs/libmythui/mediamonitor-unix.cpp
@@ -5,6 +5,7 @@
 
 // Standard C headers
 #include <cstdio>
+#include <thread>
 
 // POSIX headers
 #include <dirent.h>
@@ -260,7 +261,7 @@ static bool DetectDevice(const QDBusObjectPath& entry, MythUdisksDevice& device,
 bool MediaMonitorUnix::CheckMountable(void)
 {
 #if CONFIG_QTDBUS
-    for (int i = 0; i < 10; ++i, usleep(500000))
+    for (int i = 0; i < 10; ++i, std::this_thread::sleep_for(500ms))
     {
         // Connect to UDisks2.  This can sometimes fail if mythfrontend
         // is started during system init

--- a/mythtv/libs/libmythupnp/taskqueue.cpp
+++ b/mythtv/libs/libmythupnp/taskqueue.cpp
@@ -11,6 +11,8 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "taskqueue.h"
 
+#include <thread>
+
 #include "libmythbase/mythlogging.h"
 
 /////////////////////////////////////////////////////////////////////////////
@@ -134,7 +136,7 @@ void TaskQueue::run( )
         }
         // Make sure to throttle our processing.
 
-        usleep( 100ms );
+        std::this_thread::sleep_for(100ms);
     }
 
     RunEpilog();

--- a/mythtv/programs/mythbackend/mythbackend.cpp
+++ b/mythtv/programs/mythbackend/mythbackend.cpp
@@ -5,6 +5,7 @@
 
 #include <csignal> // for signal
 #include <cstdlib>
+#include <thread>
 
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
@@ -194,7 +195,7 @@ int main(int argc, char **argv)
         newargv[newargc] = nullptr;
         LOG(VB_GENERAL, LOG_INFO,
             QString("Restarting mythbackend"));
-        usleep(50000);
+        std::this_thread::sleep_for(50ms);
         int rc = execvp(newargv[0], newargv);
         LOG(VB_GENERAL, LOG_ERR,
             QString("execvp failed prog %1 rc=%2 errno=%3").arg(argv[0]).arg(rc).arg(errno));

--- a/mythtv/programs/mythbackend/recordingextender.cpp
+++ b/mythtv/programs/mythbackend/recordingextender.cpp
@@ -20,6 +20,7 @@
  *   along with this program; if not, write to the Free Software
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
+#include <thread>
 
 // Qt
 #include <QFile>
@@ -1684,7 +1685,7 @@ void RecordingExtender::run()
 
     while (m_running)
     {
-        usleep(kExtensionTime); // cppcheck-suppress usleepCalled
+        std::this_thread::sleep_for(kExtensionTime);
 
         clearDownloadedInfo();
         processNewRecordings();

--- a/mythtv/programs/mythbackend/scheduler.cpp
+++ b/mythtv/programs/mythbackend/scheduler.cpp
@@ -2052,7 +2052,7 @@ void Scheduler::run(void)
     OldRecordedFixups();
 
     // wait for slaves to connect
-    usleep(3s);
+    std::this_thread::sleep_for(3s);
 
     QMutexLocker lockit(&m_schedLock);
 

--- a/mythtv/programs/mythbackend/servicesv2/v2music.cpp
+++ b/mythtv/programs/mythbackend/servicesv2/v2music.cpp
@@ -10,7 +10,7 @@
 
 // C/C++
 #include <cmath>
-#include <unistd.h>
+#include <thread>
 
 // MythTV
 #include "libmythbase/http/mythhttpmetaservice.h"
@@ -48,7 +48,7 @@ V2MusicMetadataInfoList* V2Music::GetTrackList(int nStartIndex,
     while (!all_music->doneLoading())
     {
         qApp->processEvents();
-        usleep(50000);
+        std::this_thread::sleep_for(50ms);
     }
 
     MetadataPtrList *musicList = all_music->getAllMetadata();
@@ -113,7 +113,7 @@ V2MusicMetadataInfo* V2Music::GetTrack(int Id)
     while (!all_music->doneLoading())
     {
         qApp->processEvents();
-        usleep(50000);
+        std::this_thread::sleep_for(50ms);
     }
 
     MusicMetadata *metadata = all_music->getMetadata(Id);

--- a/mythtv/programs/mythcommflag/mythcommflag.cpp
+++ b/mythtv/programs/mythcommflag/mythcommflag.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <thread>
 
 // Qt headers
 #include <QCoreApplication>
@@ -448,7 +449,7 @@ static int DoFlagCommercials(
 
     CommDetectorBase *tmp = commDetector;
     commDetector = nullptr;
-    sleep(1);
+    std::this_thread::sleep_for(1s);
     tmp->deleteLater();
 
     cer->deleteLater();

--- a/mythtv/programs/mythmetadatalookup/mythmetadatalookup.cpp
+++ b/mythtv/programs/mythmetadatalookup/mythmetadatalookup.cpp
@@ -1,9 +1,10 @@
 // C headers
-#include <unistd.h>
+#include <unistd.h> // close
 
 // C++ headers
 #include <iostream>
 #include <memory>
+#include <thread>
 
 // Qt headers
 #include <QtGlobal>
@@ -137,7 +138,7 @@ int main(int argc, char *argv[])
 
     while (lookup->StillWorking())
     {
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         qApp->processEvents();
     }
 

--- a/mythtv/programs/mythshutdown/mythshutdown.cpp
+++ b/mythtv/programs/mythshutdown/mythshutdown.cpp
@@ -2,7 +2,7 @@
 // C/C++
 #include <cstdlib>
 #include <iostream>
-#include <unistd.h>
+#include <thread>
 
 // Qt
 #include <QtGlobal>
@@ -92,7 +92,7 @@ static int lockShutdown()
     while (!query.exec("LOCK TABLE settings WRITE;") && tries < 5)
     {
         LOG(VB_GENERAL, LOG_INFO, "Waiting for lock on setting table");
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         tries++;
     }
 
@@ -146,7 +146,7 @@ static int unlockShutdown()
     while (!query.exec("LOCK TABLE settings WRITE;") && tries < 5)
     {
         LOG(VB_GENERAL, LOG_INFO, "Waiting for lock on setting table");
-        sleep(1);
+        std::this_thread::sleep_for(1s);
         tries++;
     }
 

--- a/mythtv/programs/mythtranscode/mythtranscode.cpp
+++ b/mythtv/programs/mythtranscode/mythtranscode.cpp
@@ -3,6 +3,7 @@
 #include <fcntl.h> // for open flags
 #include <fstream>
 #include <iostream>
+#include <thread>
 
 // Qt headers
 #include <QtGlobal>
@@ -840,11 +841,11 @@ static void WaitToDelete(ProgramInfo *pginfo)
 
         if (inUse)
         {
-            const unsigned kSecondsToWait = 10;
+            constexpr std::chrono::seconds kSecondsToWait = 10s;
             LOG(VB_GENERAL, LOG_NOTICE,
                 QString("Transcode: program in use, rechecking in %1 seconds.")
-                    .arg(kSecondsToWait));
-            sleep(kSecondsToWait);
+                    .arg(kSecondsToWait.count()));
+            std::this_thread::sleep_for(kSecondsToWait);
         }
     }
     LOG(VB_GENERAL, LOG_NOTICE, "Transcode: program is no longer in use.");

--- a/mythtv/programs/mythwelcome/welcomedialog.cpp
+++ b/mythtv/programs/mythwelcome/welcomedialog.cpp
@@ -4,6 +4,7 @@
 // C++
 #include <chrono>
 #include <cstdlib>
+#include <thread>
 
 // qt
 #include <QtGlobal>
@@ -636,7 +637,7 @@ void WelcomeDialog::unlockShutdown(void)
 void WelcomeDialog::runEPGGrabber(void)
 {
     runMythFillDatabase();
-    sleep(1);
+    std::this_thread::sleep_for(1s);
     updateStatusMessage();
     updateScreen();
 }


### PR DESCRIPTION
to make searching for them easier and use easier to read std::chrono_literals.

QWaitCondition and other wait or timer functions are still also used to sleep threads.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

