### PR TITLE
Fix Setup Video General menu header

### DIFF
--- a/mythtv/programs/mythfrontend/globalsettings.cpp
+++ b/mythtv/programs/mythfrontend/globalsettings.cpp
@@ -4611,7 +4611,7 @@ OSDSettings::OSDSettings()
 
 GeneralSettings::GeneralSettings()
 {
-    setLabel(tr("General (Basic)"));
+    setLabel(tr("General"));
     auto *general = new GroupSetting();
     general->setLabel(tr("General (Basic)"));
     general->addChild(ChannelOrdering());


### PR DESCRIPTION
This change removes "(Basic)" from the Setup -> Video -> General menu header.

Resolves #1164

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

