### PR TITLE
Simplify mythdirs.cpp and remove RUNPREFIX

### DIFF
--- a/cmake/MythOptions.cmake
+++ b/cmake/MythOptions.cmake
@@ -24,7 +24,7 @@ set(MYTH_DEFAULT_LIBS_PREFIX
 set(MYTH_RUN_PREFIX
     ""
     CACHE PATH
-          "The prefix where MythTV is expected to be at runtime.  This may differ from MYTH_DEFAULT_PREFIX or CMAKE_INSTALL_PREFIX for packagers."
+          "The prefix where MythTV is expected to be at runtime, used by the Python bindings.  This may differ from MYTH_DEFAULT_PREFIX or CMAKE_INSTALL_PREFIX for packagers."
 )
 
 # Location for downloaded tarballs.

--- a/mythtv/.cppcheck-suppress
+++ b/mythtv/.cppcheck-suppress
@@ -10,6 +10,4 @@
 *:*/libs/libmythfreemheg/*
 *:*/libs/libmythmpeg2/*
 *:*/libs/libmythtv/visualisations/goom/*
-*:*/programs/mythbackend/serviceHosts/*
-*:*/programs/mythbackend/services/*
 *:*/test/*

--- a/mythtv/.cppcheck-suppress
+++ b/mythtv/.cppcheck-suppress
@@ -6,7 +6,6 @@
 
 // Ignore all warnings in these files (MythTV code)
 *:*/docs/doxygen-architecture-document.cpp
-*:*/filters/*
 *:*/html/*
 *:*/libs/libmythfreemheg/*
 *:*/libs/libmythmpeg2/*

--- a/mythtv/configure
+++ b/mythtv/configure
@@ -82,7 +82,7 @@ Standard options:
   --compile-type=CTYPE     one of release, profile, debug [$compile_type]
                            NOTE: profile is for sampling profilers
   --prefix=PREFIX          install in PREFIX [$prefix]
-  --runprefix=PREFIX       prefix to be used at runtime (e.g. .. or /myth/latest)
+  --runprefix=PREFIX       prefix to be used at runtime by the Python bindings
   --libdir-name=LIBNAME    search/install libraries in PREFIX/LIBNAME [$libdir_name]
   --disable-ccache         disable compiler cache (ccache)
   --disable-distcc         disable distributed compilation (distcc)
@@ -6239,7 +6239,6 @@ get_version(){
 
 map 'get_version $v' $LIBRARY_LIST
 
-echo "RUNPREFIX=$runprefix" >> $TMPMAK
 echo "SYSROOT=$sysroot" >> $TMPMAK
 
 enabled audio_alsa        && append CCONFIG "using_alsa"
@@ -6475,7 +6474,7 @@ cp_if_changed $TMPPRO bindings/python/setup.cfg
 
 echo "Creating bindings/python/MythTV/_versions.py"
 sed -e "s/@MYTHTV_PYTHON_OWN_VERSION@/${MYTHTV_PYTHON_OWN_VERSION}/g" \
-    -e "s!@MYTHTV_INSTALL_PREFIX@!${prefix}!g" \
+    -e "s!@MYTHTV_INSTALL_PREFIX@!${runprefix}!g" \
     bindings/python/MythTV/_versions.py.in > $TMPPRO
 cp_if_changed $TMPPRO bindings/python/MythTV/_versions.py
 

--- a/mythtv/docs/doxygen-architecture-document.cpp
+++ b/mythtv/docs/doxygen-architecture-document.cpp
@@ -531,8 +531,8 @@ locations. The following methods in MythContext allow programs and plugins
 to access these assets:
 <ol>
   <li>GetInstallPrefix() returns either the runtime env. var. $MYTHTVDIR
-      or the compile-time var. RUNPREFIX. If these are relative paths,
-      it is initialised relative to the application's location.
+      or uses QCoreApplication::applicationDirPath() to determine the install
+      location if $MYTHTVDIR is a relative path or empty.
       The value is used thus:
   <ul>
     <li>GetInstallPrefix() + /share/mythtv/ = GetShareDir(), GetFontsDir()</li>

--- a/mythtv/docs/doxygen-architecture-document.cpp
+++ b/mythtv/docs/doxygen-architecture-document.cpp
@@ -551,7 +551,6 @@ to access these assets:
     <li>GetInstallPrefix() + /bin/mtd</li>
     <li>GetInstallPrefix() + LIBDIRNAME + /mythtv/ = GetLibraryDir()</li>
     <li>GetLibraryDir() + /plugins/ = GetPluginsDir()</li>
-    <li>GetLibraryDir() + /filters/ = GetFiltersDir()</li>
   </ul></li>
 
   <li>GetConfDir() returns the value of the runtime env. var. $MYTHCONFDIR,

--- a/mythtv/libs/libmythbase/CMakeLists.txt
+++ b/mythtv/libs/libmythbase/CMakeLists.txt
@@ -240,7 +240,7 @@ set_source_files_properties(
   mythdirs.cpp
   PROPERTIES
     COMPILE_DEFINITIONS
-    "RUNPREFIX=\"${MYTH_RUN_PREFIX}\";LIBDIRNAME=\"${CMAKE_INSTALL_LIBDIR}\"")
+    "LIBDIRNAME=\"${CMAKE_INSTALL_LIBDIR}\"")
 target_include_directories(
   mythbase
   PRIVATE .

--- a/mythtv/libs/libmythbase/libmythbase.pro
+++ b/mythtv/libs/libmythbase/libmythbase.pro
@@ -201,7 +201,6 @@ INSTALLS += inc inc2
 INCLUDEPATH += ..
 DEPENDPATH  +=  ../../external/libudfread
 
-DEFINES += RUNPREFIX=\\\"$${RUNPREFIX}\\\"
 DEFINES += LIBDIRNAME=\\\"$${LIBDIRNAME}\\\"
 DEFINES += MBASE_API
 

--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -26,7 +26,6 @@ static QString confdir;
 static QString themedir;
 static QString pluginsdir;
 static QString translationsdir;
-static QString filtersdir;
 static QString cachedir;
 static QString remotecachedir;
 static QString themebasecachedir;
@@ -252,12 +251,10 @@ void InitializeMythDirs(void)
     themedir        = sharedir + "themes/";
     pluginsdir      = libdir;
     translationsdir = sharedir + "i18n/";
-    filtersdir      = libdir;
 #else
     themedir        = sharedir + "themes/";
     pluginsdir      = libdir   + "plugins/";
     translationsdir = sharedir + "i18n/";
-    filtersdir      = libdir   + "filters/";
 #endif
 
     LOG(VB_GENERAL, LOG_NOTICE, "Using runtime prefix = " + installprefix);
@@ -270,7 +267,6 @@ void InitializeMythDirs(void)
     LOG(VB_GENERAL, LOG_DEBUG, "themedir          = "+ themedir         );
     LOG(VB_GENERAL, LOG_DEBUG, "pluginsdir        = "+ pluginsdir       );
     LOG(VB_GENERAL, LOG_DEBUG, "translationsdir   = "+ translationsdir  );
-    LOG(VB_GENERAL, LOG_DEBUG, "filtersdir        = "+ filtersdir       );
     LOG(VB_GENERAL, LOG_DEBUG, "confdir           = "+ confdir          );
     LOG(VB_GENERAL, LOG_DEBUG, "cachedir          = "+ cachedir         );
     LOG(VB_GENERAL, LOG_DEBUG, "remotecachedir    = "+ remotecachedir   );
@@ -286,7 +282,6 @@ QString GetConfDir(void) { return confdir; }
 QString GetThemesParentDir(void) { return themedir; }
 QString GetPluginsDir(void) { return pluginsdir; }
 QString GetTranslationsDir(void) { return translationsdir; }
-QString GetFiltersDir(void) { return filtersdir; }
 
 /**
  * Returns the base directory for all cached files.  On linux this
@@ -322,29 +317,16 @@ QString GetThemeBaseCacheDir(void) { return themebasecachedir; }
 #ifdef Q_OS_DARWIN
 static const QString kPluginLibPrefix = "lib";
 static const QString kPluginLibSuffix = ".dylib";
-static const QString kFilterLibPrefix = "lib";
-static const QString kFilterLibSuffix = ".dylib";
 #elif defined(Q_OS_WINDOWS)
 static const QString kPluginLibPrefix = "lib";
 static const QString kPluginLibSuffix = ".dll";
-static const QString kFilterLibPrefix = "lib";
-static const QString kFilterLibSuffix = ".dll";
 #elif defined(Q_OS_ANDROID)
 static const QString kPluginLibPrefix = "libmythplugin";
 static const QString kPluginLibSuffix = ".so";
-static const QString kFilterLibPrefix = "libmythfilter";
-static const QString kFilterLibSuffix = ".so";
 #else
 static const QString kPluginLibPrefix = "lib";
 static const QString kPluginLibSuffix = ".so";
-static const QString kFilterLibPrefix = "lib";
-static const QString kFilterLibSuffix = ".so";
 #endif
-
-QString GetFiltersNameFilter(void)
-{
-    return kFilterLibPrefix + '*' + kFilterLibSuffix;
-}
 
 QString GetPluginsNameFilter(void)
 {

--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -214,14 +214,12 @@ void InitializeMythDirs(void)
             installprefix = QString("../Resources");
     #endif
 
-    QDir prefixDir = qApp->applicationDirPath();
-
     if (QDir(installprefix).isRelative())
     {
         // If the PREFIX is relative, evaluate it relative to our
         // executable directory. This can be fragile on Unix, so
         // use relative PREFIX values with care.
-
+        QDir prefixDir = qApp->applicationDirPath();
         LOG(VB_GENERAL, LOG_DEBUG, QString("Relative PREFIX! (%1), appDir=%2")
             .arg(installprefix, prefixDir.canonicalPath()));
 

--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -246,15 +246,13 @@ void InitializeMythDirs(void)
     remotecachedir = cachedir + "/remotecache";
     themebasecachedir = cachedir + "/themecache";
     thumbnaildir = cachedir + "/thumbnails";
+    themedir        = sharedir + "themes/";
+    translationsdir = sharedir + "i18n/";
 
 #ifdef Q_OS_ANDROID
-    themedir        = sharedir + "themes/";
     pluginsdir      = libdir;
-    translationsdir = sharedir + "i18n/";
 #else
-    themedir        = sharedir + "themes/";
     pluginsdir      = libdir   + "plugins/";
-    translationsdir = sharedir + "i18n/";
 #endif
 
     LOG(VB_GENERAL, LOG_NOTICE, "Using runtime prefix = " + installprefix);

--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -45,8 +45,7 @@ void InitializeMythDirs(void)
 #ifdef Q_OS_WINDOWS
 
     if (installprefix.isEmpty())
-        installprefix = QDir( qApp->applicationDirPath() )
-                            .absolutePath();
+        installprefix = QDir{QCoreApplication::applicationDirPath()}.absolutePath();
 
     appbindir = installprefix + "/";
     libdir    = appbindir;
@@ -129,8 +128,7 @@ void InitializeMythDirs(void)
 
 #elif defined(Q_OS_ANDROID)
     if (installprefix.isEmpty())
-        installprefix = QDir( qApp->applicationDirPath() )
-                            .absolutePath();
+        installprefix = QDir{QCoreApplication::applicationDirPath()}.absolutePath();
     QString extdir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/Mythtv";
     if (!QDir(extdir).exists())
         QDir(extdir).mkdir(".");
@@ -223,7 +221,7 @@ void InitializeMythDirs(void)
         // If the PREFIX is relative, evaluate it relative to our
         // executable directory. This can be fragile on Unix, so
         // use relative PREFIX values with care.
-        QDir prefixDir = qApp->applicationDirPath();
+        QDir prefixDir {QCoreApplication::applicationDirPath()};
         LOG(VB_GENERAL, LOG_DEBUG, QString("Relative PREFIX! (%1), appDir=%2")
             .arg(installprefix, prefixDir.canonicalPath()));
 

--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -242,10 +242,12 @@ void InitializeMythDirs(void)
 
     if (confdir.isEmpty())
         confdir = QDir::homePath() + "/.mythtv";
+
     cachedir = confdir + "/cache";
-    remotecachedir = cachedir + "/remotecache";
+    remotecachedir    = cachedir + "/remotecache";
     themebasecachedir = cachedir + "/themecache";
-    thumbnaildir = cachedir + "/thumbnails";
+    thumbnaildir      = cachedir + "/thumbnails";
+
     themedir        = sharedir + "themes/";
     translationsdir = sharedir + "i18n/";
 

--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -204,11 +204,15 @@ void InitializeMythDirs(void)
 #else
 
     if (installprefix.isEmpty())
-            installprefix = QString(RUNPREFIX);
+    {
+        QDir installdir {QCoreApplication::applicationDirPath()};
+        installdir.cdUp();
+        installprefix = installdir.absolutePath();
+    }
 
     #ifdef Q_OS_DARWIN
-        // Check to see if the RUNPREFIX exists, if it does not, this is
-        // likely an APP bundle and so RUNPREFIX needs to be pointed
+        // Check to see if the installprefix directory exists, if it does not,
+        // this is likely an APP bundle and so needs to be pointed
         // internally to the APP Bundle.
         if (! QDir(installprefix).exists())
             installprefix = QString("../Resources");

--- a/mythtv/libs/libmythbase/mythdirs.h
+++ b/mythtv/libs/libmythbase/mythdirs.h
@@ -14,13 +14,11 @@
  MBASE_PUBLIC  QString GetThemesParentDir(void);
  MBASE_PUBLIC  QString GetPluginsDir(void);
  MBASE_PUBLIC  QString GetTranslationsDir(void);
- MBASE_PUBLIC  QString GetFiltersDir(void);
  MBASE_PUBLIC  QString GetCacheDir(void);
  MBASE_PUBLIC  QString GetRemoteCacheDir(void);
  MBASE_PUBLIC  QString GetThemeBaseCacheDir(void);
  MBASE_PUBLIC  QString GetThumbnailDir(void);
 
- MBASE_PUBLIC  QString GetFiltersNameFilter(void);
  MBASE_PUBLIC  QString GetPluginsNameFilter(void);
  MBASE_PUBLIC  QString FindPluginName(const QString &plugname);
  MBASE_PUBLIC  QString GetTranslationsNameFilter(void);

--- a/mythtv/programs/mythbackend/mythbackend.cpp
+++ b/mythtv/programs/mythbackend/mythbackend.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
 #ifdef Q_OS_DARWIN
     QString path = QCoreApplication::applicationDirPath();
     setenv("PYTHONPATH",
-           QString("%1/../Resources/lib/%2:/../Resources/lib/%2/site-packages:/../Resources/lib/%2/lib-dynload:%3")
+           QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
            .arg(path)
            .arg(QFileInfo(PYTHON_EXE).fileName())
            .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))

--- a/mythtv/programs/mythfrontend/mythfrontend.cpp
+++ b/mythtv/programs/mythfrontend/mythfrontend.cpp
@@ -2038,7 +2038,7 @@ Q_DECL_EXPORT int main(int argc, char **argv)
 #ifdef Q_OS_DARWIN
     QString path = QCoreApplication::applicationDirPath();
     setenv("PYTHONPATH",
-           QString("%1/../Resources/lib/%2:/../Resources/lib/%2/site-packages:/../Resources/lib/%2/lib-dynload:%3")
+           QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
            .arg(path)
            .arg(QFileInfo(PYTHON_EXE).fileName())
            .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))

--- a/mythtv/programs/mythmetadatalookup/mythmetadatalookup.cpp
+++ b/mythtv/programs/mythmetadatalookup/mythmetadatalookup.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_DARWIN
     QString path = QCoreApplication::applicationDirPath();
     setenv("PYTHONPATH",
-           QString("%1/../Resources/lib/%2:/../Resources/lib/%2/site-packages:/../Resources/lib/%2/lib-dynload:%3")
+           QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
            .arg(path)
            .arg(QFileInfo(PYTHON_EXE).fileName())
            .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))

--- a/mythtv/programs/mythutil/musicmetautils.cpp
+++ b/mythtv/programs/mythutil/musicmetautils.cpp
@@ -361,17 +361,18 @@ public:
 static int FindLyrics(const MythUtilCommandLineParser &cmdline)
 {
 
-    #ifdef Q_OS_DARWIN
-        QString path = QCoreApplication::applicationDirPath();
-        setenv("PYTHONPATH",
-               QString("%1/../Resources/lib/python3:%1/../Resources/lib/python3/site-packages:%1/../Resources/lib/python3/lib-dynload:%2")
-               .arg(path)
-               .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))
-               .toUtf8().constData(), 1);
-            QString PYTHON_LOCAL_EXE = path + "python3";
-    #else
-        QString PYTHON_LOCAL_EXE = QString(PYTHON_EXE);
-    #endif
+#ifdef Q_OS_DARWIN
+    QString path = QCoreApplication::applicationDirPath();
+    setenv("PYTHONPATH",
+           QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
+           .arg(path)
+           .arg(QFileInfo(PYTHON_EXE).fileName())
+           .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))
+           .toUtf8().constData(), 1);
+    QString PYTHON_LOCAL_EXE = path + QFileInfo(PYTHON_EXE).fileName();
+#else
+    QString PYTHON_LOCAL_EXE = QString(PYTHON_EXE);
+#endif
 
     // make sure our lyrics cache directory exists
     QString lyricsDir = GetConfDir() + "/MythMusic/Lyrics/";

--- a/mythtv/settings.pro
+++ b/mythtv/settings.pro
@@ -39,11 +39,6 @@ isEmpty( PREFIX ) {
     PREFIX = /usr/local
 }
 
-# Where the binaries actually locate the assets/filters/plugins at runtime
-isEmpty( RUNPREFIX ) {
-    RUNPREFIX = $$PREFIX
-}
-
 # Alternate library dir for OSes and packagers (e.g. lib64)
 
 isEmpty( LIBDIRNAME ) {
@@ -52,7 +47,7 @@ isEmpty( LIBDIRNAME ) {
 
 # Where libraries, plugins and filters are installed
 isEmpty( LIBDIR ) {
-    LIBDIR = $${RUNPREFIX}/$${LIBDIRNAME}
+    LIBDIR = $${PREFIX}/$${LIBDIRNAME}
 }
 
 # Die on the (common) case where OS X users inadvertently use Fink's


### PR DESCRIPTION
@jhoyt4 I think this will break for the application bundle on macOS, so if there is some way to determine the program is in an application bundle, a suggested change would be welcome.

@rcrdnalor I don't think the python bindings will work fully if moved after install.  Could the uses of `INSTALL_PREFIX` be replaced with some code using relative paths from the python file?

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

