### PR TITLE
Eliminate empty backup file

### DIFF
--- a/mythtv/programs/scripts/database/mythconverg_backup.pl
+++ b/mythtv/programs/scripts/database/mythconverg_backup.pl
@@ -1267,6 +1267,21 @@ EOF
                 '', "$mysqldump exited with status: $exit");
         verbose($verbose_level_debug,
                 "$mysqldump output:", $result) if ($exit);
+
+        # In very rare conditions a backup of size 0 could be
+        # generated. This is not useful, and we don't want it
+        # to waste one of our limited number of backup slots.
+        if (-e $output_file && -z _)
+        {
+            verbose($verbose_level_debug, '',
+                ${safe_mysqldump}.' generated an empty backup');
+            unlink $output_file;
+            if (!$exit)
+            {
+                $exit = 61; # ENODATA
+            }
+        }
+
         reset_environment;
         return $exit;
     }


### PR DESCRIPTION
In very rare conditions a backup of size 0 could be generated. This is not useful, and we don't want it to waste one of our limited number of backup slots.

This new block of code checks whether the generated backup file is empty. If so, we'll remove it and exit with an ENODATA indication. The compression and rotation steps will be skipped.

This was tested by temporarily adding debug code to generate an empty backup file right after the sql backup command runs.

        unlink $output_file;
        open(my $fh, '>', $output_file);
        close($fh);

Resolves #1185

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

