### PR TITLE
Restore accidentally removed css files

### DIFF
--- a/mythtv/html/html.pro
+++ b/mythtv/html/html.pro
@@ -4,8 +4,8 @@ TEMPLATE = aux
 
 html.path = $${PREFIX}/share/mythtv/html/
 html.files = robots.txt favicon.ico
-# mythfrontend.html is just a copy of frontend_index.qsp
 html.files += mythbackend.html mythfrontend.html
+html.files += css
 html.files += images
 html.files += 3rdParty xslt apps assets
 


### PR DESCRIPTION
Removed in 5f37f574db7f50aba382a616dc9422232124bd70 with the WebFrontend, but these files are still used.

---

@bennettpeter This should resolve the issue accidentally created in https://github.com/MythTV/mythtv/pull/1256.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

