### PR TITLE
Restrict No window! error log message to mythfrontend

### DIFF
--- a/mythtv/libs/libmythtv/mythvideoprofile.cpp
+++ b/mythtv/libs/libmythtv/mythvideoprofile.cpp
@@ -1333,7 +1333,10 @@ void MythVideoProfile::InitStatics(bool Reinit /*= false*/)
 
     if (!HasMythMainWindow())
     {
-        LOG(VB_GENERAL, LOG_ERR, LOC + "No window!");
+        if (gCoreContext->IsFrontend())
+        {
+            LOG(VB_GENERAL, LOG_ERR, LOC + "No window!");
+        }
         return;
     }
 


### PR DESCRIPTION
**MythVideoProfile::InitStatics()** gets called for several applications, including **_mythfrontend_**, **_mythtranscode_**, **_mythcommflag_**, and **_mythpreviewgen_**. An error log gets generated when the application does not have control of the MythTv main window. However, this only makes sense for **_mythfrontend_**.

This code change will only allow generation of the error log message for the **_mythfrontend_** application. We still **return** out of the function for non-frontend applications because failing to do so will lead to errors. The code which follows tries to create a _QWidget_ which cannot be done without a _QApplication_ which cannot be created without a MythTv main window to run it in.

Resolves: #1018

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

