### PR TITLE
Properly set initial playback volume for PCM Mixer

### DIFF
--- a/mythtv/libs/libmythtv/audio/audiooutputpulse.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputpulse.cpp
@@ -610,7 +610,15 @@ bool AudioOutputPulseAudio::ConnectPlaybackStream(void)
                                      (char*)"under");
     if (m_setInitialVol)
     {
-        int volume = gCoreContext->GetNumSetting("MasterMixerVolume", 80);
+        int volume;
+        if (gCoreContext->GetSetting("MixerControl", "PCM") == "PCM")
+        {
+            volume = gCoreContext->GetNumSetting("PCMMixerVolume", 80);
+        }
+        else
+        {
+            volume = gCoreContext->GetNumSetting("MasterMixerVolume", 80);
+        }
         pa_cvolume_set(&m_volumeControl, m_channels,
                        (float)volume * (float)PA_VOLUME_NORM / 100.0F);
     }


### PR DESCRIPTION
For PulseAudio, set the initial playback volume
to _PCMMixerVolume_ when _MixerControl_ is set to **PCM**.

Resolves #1297

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

