### PR TITLE
Qt6: Fix segmentation fault on Linux with Xwayland

### DIFF
--- a/mythtv/libs/libmythui/mythdisplay.cpp
+++ b/mythtv/libs/libmythui/mythdisplay.cpp
@@ -1242,7 +1242,8 @@ void MythDisplay::ConfigureQtGUI(int SwapInterval, const MythCommandLineParser& 
     // NOTE disable using EGL by setting MYTHTV_NO_EGL
     // NOTE We have no Qt platform information, window/surface or logging when this is called.
     QString soft = qgetenv("LIBGL_ALWAYS_SOFTWARE");
-    bool ignore = soft == "1" || soft.compare("true", Qt::CaseInsensitive) == 0;
+    bool ignore = soft == "1" || soft.compare("true", Qt::CaseInsensitive) == 0
+        || qEnvironmentVariableIsSet("WAYLAND_DISPLAY");
     bool allow = qEnvironmentVariableIsEmpty("MYTHTV_NO_EGL") && !ignore;
     bool force = !qEnvironmentVariableIsEmpty("MYTHTV_FORCE_EGL");
     if ((force || allow) && MythDisplayX11::IsAvailable())


### PR DESCRIPTION
Forcing the xcb QPA with the environment variable QT_QPA_PLATFORM=xcb or the `--platform xcb` command-line flag causes `QEGLPlatformContext: eglMakeCurrent failed: 300d` (EGL_BAD_SURFACE) and a subsequent segmentation fault when using Qt6.

Disabling this code when Wayland is detected, allows mythfrontend to work on Linux with Qt 6 using Xwayland.

References:
https://github.com/MythTV/mythtv/issues/754
https://github.com/MythTV/mythtv/issues/1334

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

