### PR TITLE
Qt6: Revise the fix for OpenGL on Wayland and xcb EGL integration

### DIFF
--- a/mythtv/libs/libmythui/opengl/mythpainterwindowopengl.cpp
+++ b/mythtv/libs/libmythui/opengl/mythpainterwindowopengl.cpp
@@ -1,7 +1,10 @@
-// MythTV
+#include "mythpainterwindowopengl.h"
+
+#include <QGuiApplication>
+#include <QWindow>
+
 #include "libmythbase/mythlogging.h"
 #include "mythmainwindow.h"
-#include "opengl/mythpainterwindowopengl.h"
 
 #define LOC QString("GLPaintWin: ")
 
@@ -12,6 +15,13 @@ MythPainterWindowOpenGL::MythPainterWindowOpenGL(MythMainWindow *MainWin)
     setAttribute(Qt::WA_NoSystemBackground);
     setAttribute(Qt::WA_NativeWindow);
     setAttribute(Qt::WA_DontCreateNativeAncestors);
+    // The eglfs QPA platform works without setting the surface type and
+    // can only have one OpenGLSurface, which must be the top level widget
+    // (which for us is currently the MythMainWindow).
+    if (QGuiApplication::platformName() != "eglfs" && windowHandle() != nullptr)
+    {
+        windowHandle()->setSurfaceType(QWindow::OpenGLSurface);
+    }
     winId();
 #ifdef Q_OS_MACOS
      // must be visible before OpenGL initialisation on OSX

--- a/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
+++ b/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
@@ -24,11 +24,6 @@
 
 #define LOC QString("OpenGL: ")
 
-#ifdef Q_OS_ANDROID
-#include <android/log.h>
-#include <QWindow>
-#endif
-
 static constexpr GLuint VERTEX_INDEX  { 0 };
 static constexpr GLuint COLOR_INDEX   { 1 };
 static constexpr GLuint TEXTURE_INDEX { 2 };
@@ -96,7 +91,6 @@ MythRenderOpenGL* MythRenderOpenGL::Create(QWidget *Widget)
     bool opengles = !qEnvironmentVariableIsEmpty("MYTHTV_OPENGL_ES");
     bool core     = !qEnvironmentVariableIsEmpty("MYTHTV_OPENGL_CORE");
     QSurfaceFormat format = QSurfaceFormat::defaultFormat();
-    format.setRenderableType(QSurfaceFormat::OpenGL);
     if (core)
     {
         format.setProfile(QSurfaceFormat::CoreProfile);
@@ -118,7 +112,6 @@ MythRenderOpenGL* MythRenderOpenGL::Create(QWidget *Widget)
     if (VERBOSE_LEVEL_CHECK(VB_GPU, LOG_INFO))
         format.setOption(QSurfaceFormat::DebugContext);
 
-    QSurfaceFormat::setDefaultFormat(format);
     return new MythRenderOpenGL(format, Widget);
 }
 
@@ -543,19 +536,6 @@ void MythRenderOpenGL::SetWidget(QWidget *Widget)
         LOG(VB_GENERAL, LOG_CRIT, LOC + "No window surface!");
         return;
     }
-
-#if defined(Q_OS_ANDROID) || (QT_VERSION > QT_VERSION_CHECK(6,3,0))
-    // Ensure surface type is always OpenGL
-    m_window->setSurfaceType(QWindow::OpenGLSurface);
-    m_window->destroy();
-    m_window->create();
-    if (native && native->windowHandle() != m_window)
-    {
-        native->windowHandle()->setSurfaceType(QWindow::OpenGLSurface);
-        native->windowHandle()->destroy();
-        native->windowHandle()->create();
-    }
-#endif
 
 #ifdef CONFIG_QTWEBENGINE
     auto * globalcontext = QOpenGLContext::globalShareContext();


### PR DESCRIPTION
The original fix, 373bce861d0b00ee972f3882e8386664b37fd93b, broke the GUI for the eglfs QPA platform.

Setting the surface type in the MythPainterWindowOpenGL constructor before creating the QWindow, which both winId() and setVisible(true) would do, is simpler and avoids the delay caused by destroying and creating a new surface.

References:
https://github.com/MythTV/mythtv/issues/754
https://github.com/MythTV/mythtv/issues/1099
https://github.com/MythTV/mythtv/issues/1334
https://github.com/MythTV/mythtv/pull/1341

---

Unless @warpme says the check for eglfs is unnecessary, this should be the final version.  If so, 373bce861d0b00ee972f3882e8386664b37fd93b and this should also be applied to fixes/36.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organized and have [good commit messages](https://chris.beams.io/posts/git-commit)

