### PR TITLE
Prevent segmentation fault when exiting GUIStartup

### DIFF
--- a/mythtv/libs/libmyth/mythcontext.cpp
+++ b/mythtv/libs/libmyth/mythcontext.cpp
@@ -982,8 +982,12 @@ QString MythContext::Impl::TestDBconnection(bool prompt)
             }
             if (m_guiStartup)
             {
-                if (m_guiStartup->m_Exit
-                  || m_guiStartup->m_Setup
+                if (m_guiStartup->m_Exit)
+                {
+                    keep_trying = false;
+                    break;
+                }
+                if (m_guiStartup->m_Setup
                   || m_guiStartup->m_Search
                   || m_guiStartup->m_Retry)
                     break;


### PR DESCRIPTION
Without this, the outer while loop will continue infinitely and cause a segmentation fault at the next checkPort() call in the call to QObject::connect, suggesting the GUIStartup instance pointed to by MythContext::Impl::m_guiStartup has been deleted, probably via the call to MythScreenType::Close() in GUIStartup::OnClosePromptReturn().  This might still be a race condition dependent use after free, however.

---

To trigger this start mythfrontend without a backend to connect to and immediately exit the GUIStartup screen once it is shown.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organized and have [good commit messages](https://chris.beams.io/posts/git-commit)

