### PR TITLE
macOS: address issue where maridb server requires ssl connection

### DIFF
--- a/platform/darwin/startup_script.zsh.in
+++ b/platform/darwin/startup_script.zsh.in
@@ -32,5 +32,8 @@ export PYTHONPATH=$PYTHON_BASE_PATH:$PYTHON_BASE_PATH/site-packages:$PYTHON_BASE
 # set the mythtv share dir
 export MYTHTVDIR="$RSRC_DIR"
 
+# Automatically trust the mariadb server ssl certificate
+export MARIADB_TLS_DISABLE_PEER_VERIFICATION=1
+
 cd $BASE_DIR
 ./@APP_EXE_NAME@ $@


### PR DESCRIPTION
  resolves an issue reported in the forums where frontend will not
  connect to a mariadb backend using ssl without a cert copied locally.
  https://forum.mythtv.org/viewtopic.php?t=6196

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

