### PR TITLE
Add support for ECDSA (and other) TLS certificates

### DIFF
--- a/mythtv/libs/libmythbase/http/mythhttps.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttps.cpp
@@ -88,7 +88,7 @@ bool MythHTTPS::InitSSLServer(QSslConfiguration& Config)
     }
 
     auto rawHostKey = hostKeyFile.readAll();
-    auto hostKey = QSslKey(rawHostKey, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey);
+    auto hostKey = QSslKey(rawHostKey, hostCert.publicKey().algorithm(), QSsl::Pem, QSsl::PrivateKey);
     if (hostKey.isNull())
     {
         LOG(VB_GENERAL, LOG_ERR, LOC + QString("Unable to load host key from file (%1)").arg(hostKeyPath));

--- a/mythtv/libs/libmythbase/http/mythhttps.cpp
+++ b/mythtv/libs/libmythbase/http/mythhttps.cpp
@@ -46,28 +46,6 @@ bool MythHTTPS::InitSSLServer(QSslConfiguration& Config)
         configdir.chop(1);
     configdir.append(QStringLiteral("/certificates/"));
 
-    auto hostKeyPath = gCoreContext->GetSetting("hostSSLKey", "");
-    if (hostKeyPath.isEmpty())
-        hostKeyPath = configdir + "key.pem";
-    LOG(VB_HTTP, LOG_DEBUG, LOC + "key " + hostKeyPath);
-
-    QFile hostKeyFile(hostKeyPath);
-    if (!hostKeyFile.exists() || !hostKeyFile.open(QIODevice::ReadOnly))
-    {
-        LOG(VB_GENERAL, LOG_WARNING, LOC +
-            QString("SSL Host key file (%1) does not exist or is not readable").arg(hostKeyPath));
-        return false;
-    }
-
-    auto rawHostKey = hostKeyFile.readAll();
-    auto hostKey = QSslKey(rawHostKey, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey);
-    if (hostKey.isNull())
-    {
-        LOG(VB_GENERAL, LOG_ERR, LOC + QString("Unable to load host key from file (%1)").arg(hostKeyPath));
-        return false;
-    }
-    Config.setPrivateKey(hostKey);
-
     auto hostCertPath = gCoreContext->GetSetting("hostSSLCertificate", "");
     if (hostCertPath.isEmpty())
         hostCertPath = configdir + "cert.pem";
@@ -95,6 +73,28 @@ bool MythHTTPS::InitSSLServer(QSslConfiguration& Config)
     }
 
     Config.setLocalCertificate(hostCert);
+
+    auto hostKeyPath = gCoreContext->GetSetting("hostSSLKey", "");
+    if (hostKeyPath.isEmpty())
+        hostKeyPath = configdir + "key.pem";
+    LOG(VB_HTTP, LOG_DEBUG, LOC + "key " + hostKeyPath);
+
+    QFile hostKeyFile(hostKeyPath);
+    if (!hostKeyFile.exists() || !hostKeyFile.open(QIODevice::ReadOnly))
+    {
+        LOG(VB_GENERAL, LOG_WARNING, LOC +
+            QString("SSL Host key file (%1) does not exist or is not readable").arg(hostKeyPath));
+        return false;
+    }
+
+    auto rawHostKey = hostKeyFile.readAll();
+    auto hostKey = QSslKey(rawHostKey, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey);
+    if (hostKey.isNull())
+    {
+        LOG(VB_GENERAL, LOG_ERR, LOC + QString("Unable to load host key from file (%1)").arg(hostKeyPath));
+        return false;
+    }
+    Config.setPrivateKey(hostKey);
 
     auto caCertPath = gCoreContext->GetSetting("caSSLCertificate", "");
     bool caCertPathDefault {false};

--- a/mythtv/libs/libmythtv/mheg/netstream.cpp
+++ b/mythtv/libs/libmythtv/mheg/netstream.cpp
@@ -222,10 +222,11 @@ bool NetStream::Request(const QUrl& url)
         QString fname = gCoreContext->GetSetting("MhegClientCert", "");
         if (!fname.isEmpty())
         {
+            QSslCertificate cert;
             QFile f1(QFile::exists(fname) ? fname : GetShareDir() + fname);
             if (f1.open(QIODevice::ReadOnly))
             {
-                QSslCertificate cert(&f1, QSsl::Pem);
+                cert = QSslCertificate(&f1, QSsl::Pem);
                 if (!cert.isNull())
                     ssl.setLocalCertificate(cert);
                 else
@@ -246,7 +247,8 @@ bool NetStream::Request(const QUrl& url)
                 QFile f2(QFile::exists(fname) ? fname : GetShareDir() + fname);
                 if (f2.open(QIODevice::ReadOnly))
                 {
-                    QSslKey key(&f2, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey,
+                    auto keyAlgo = cert.isNull() ? QSsl::Rsa : cert.publicKey().algorithm();
+                    QSslKey key(&f2, keyAlgo, QSsl::Pem, QSsl::PrivateKey,
                         gCoreContext->GetSetting("MhegClientKeyPass", "").toLatin1());
                     if (!key.isNull())
                         ssl.setPrivateKey(key);

--- a/mythtv/libs/libmythupnp/httpserver.cpp
+++ b/mythtv/libs/libmythupnp/httpserver.cpp
@@ -200,7 +200,6 @@ void HttpServer::LoadSSLConfig()
         secureCiphers.append(*it);
     }
     m_sslConfig.setCiphers(secureCiphers);
-#endif
 
     QString hostKeyPath = gCoreContext->GetSetting("hostSSLKey", "");
 
@@ -214,7 +213,6 @@ void HttpServer::LoadSSLConfig()
         return;
     }
 
-#ifndef QT_NO_OPENSSL
     QByteArray rawHostKey = hostKeyFile.readAll();
     QSslKey hostKey = QSslKey(rawHostKey, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey);
     if (!hostKey.isNull())

--- a/mythtv/libs/libmythupnp/httpserver.cpp
+++ b/mythtv/libs/libmythupnp/httpserver.cpp
@@ -242,7 +242,7 @@ void HttpServer::LoadSSLConfig()
     }
 
     QByteArray rawHostKey = hostKeyFile.readAll();
-    QSslKey hostKey = QSslKey(rawHostKey, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey);
+    QSslKey hostKey = QSslKey(rawHostKey, hostCert.publicKey().algorithm(), QSsl::Pem, QSsl::PrivateKey);
     if (!hostKey.isNull())
         m_sslConfig.setPrivateKey(hostKey);
     else

--- a/mythtv/libs/libmythupnp/httpserver.cpp
+++ b/mythtv/libs/libmythupnp/httpserver.cpp
@@ -206,23 +206,6 @@ void HttpServer::LoadSSLConfig()
     if (hostKeyPath.isEmpty()) // No key, assume no SSL
         return;
 
-    QFile hostKeyFile(hostKeyPath);
-    if (!hostKeyFile.exists() || !hostKeyFile.open(QIODevice::ReadOnly))
-    {
-        LOG(VB_GENERAL, LOG_ERR, QString("HttpServer: SSL Host key file (%1) does not exist or is not readable").arg(hostKeyPath));
-        return;
-    }
-
-    QByteArray rawHostKey = hostKeyFile.readAll();
-    QSslKey hostKey = QSslKey(rawHostKey, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey);
-    if (!hostKey.isNull())
-        m_sslConfig.setPrivateKey(hostKey);
-    else
-    {
-        LOG(VB_GENERAL, LOG_ERR, QString("HttpServer: Unable to load host key from file (%1)").arg(hostKeyPath));
-        return;
-    }
-
     QString hostCertPath = gCoreContext->GetSetting("hostSSLCertificate", "");
     QSslCertificate hostCert;
     QList<QSslCertificate> certList = QSslCertificate::fromPath(hostCertPath);
@@ -248,6 +231,23 @@ void HttpServer::LoadSSLConfig()
     else
     {
         LOG(VB_GENERAL, LOG_ERR, QString("HttpServer: Unable to load host cert from file (%1)").arg(hostCertPath));
+        return;
+    }
+
+    QFile hostKeyFile(hostKeyPath);
+    if (!hostKeyFile.exists() || !hostKeyFile.open(QIODevice::ReadOnly))
+    {
+        LOG(VB_GENERAL, LOG_ERR, QString("HttpServer: SSL Host key file (%1) does not exist or is not readable").arg(hostKeyPath));
+        return;
+    }
+
+    QByteArray rawHostKey = hostKeyFile.readAll();
+    QSslKey hostKey = QSslKey(rawHostKey, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey);
+    if (!hostKey.isNull())
+        m_sslConfig.setPrivateKey(hostKey);
+    else
+    {
+        LOG(VB_GENERAL, LOG_ERR, QString("HttpServer: Unable to load host key from file (%1)").arg(hostKeyPath));
         return;
     }
 


### PR DESCRIPTION
Wherever a QSslKey is created, use the key algorithm from the certificate instead of hard-coding one. This enables using any type of certificate that Qt supports.

I've tested the MythHTTPS and uPNP HttpServer changes with a local build of fixes/36 on Debian 13, using ECDSA certs from Let's Encrypt. I'm not sure how to test the MHEG change, but it compiles with no issues.

I put the code moves and actual code changes into separate commits to hopefully make things clear, since the changes are so small compared to the moves, but I'm happy to do some squashing if that would be preferable.

##### Checklist
- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)
