### PR TITLE
Python: Fix call to `BEConnection.reconnect`

### DIFF
--- a/mythtv/bindings/python/MythTV/connections.py
+++ b/mythtv/bindings/python/MythTV/connections.py
@@ -395,7 +395,7 @@ class BEEventConnection( BEConnection ):
         except MythError as e:
             if e.sockcode == 54:
                 # remote has closed connection, attempt reconnect
-                self.reconnect(True, True)
+                self.reconnect(True)
                 return self.backendCommand(event, self.socket.getdeadline())
             else:
                 raise


### PR DESCRIPTION
The prototype changed in cd23715783f3 ("Add IPv6 support to the Python Bindings."). Another callsite was similarly corrected in 40f72efe1ddd ("Fix incorrect backend connection reconnect call.")

---

If we could have this in fixes/36 in due course that would be great.

Not sure how much use these bindings get given the bug was introduced in 2011. I'd love to have a modern services equivalent of the events from https://wiki.mythtv.org/wiki/SYSTEM_EVENT_(Myth_Protocol) esp the "playback started/stopped/paused" ones for a frontend, would be useful in https://github.com/ijc/uc-integration-mythtv.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)
