### PR TITLE
Always use <QtEnvironmentVariables> to ensure thread safety

### DIFF
--- a/mythtv/libs/libmyth/mythcontext.cpp
+++ b/mythtv/libs/libmyth/mythcontext.cpp
@@ -10,6 +10,7 @@
 
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtSystemDetection>
 #endif
 #include <QCoreApplication>
@@ -32,10 +33,6 @@
 #endif
 #endif
 
-#ifdef Q_OS_WINDOWS
-#include <cstdlib> // getenv, _putenv
-#include "libmythbase/compat.h"
-#endif
 #include "libmythbase/configuration.h"
 #include "libmythbase/dbutil.h"
 #include "libmythbase/exitcodes.h"
@@ -148,7 +145,7 @@ class MythContext::Impl : public QObject
     void ShowConnectionFailurePopup(bool persistent);
     void HideConnectionFailurePopup();
 
-    void ShowVersionMismatchPopup(uint remote_version);
+    void ShowVersionMismatchPopup(unsigned remote_version);
 
   public slots:
     void OnCloseDialog() const;
@@ -1455,7 +1452,7 @@ void MythContext::Impl::HideConnectionFailurePopup()
     m_lastCheck = QDateTime();
 }
 
-void MythContext::Impl::ShowVersionMismatchPopup(uint remote_version)
+void MythContext::Impl::ShowVersionMismatchPopup(unsigned remote_version)
 {
     if (m_mbeVersionPopup)
         return;
@@ -1647,16 +1644,16 @@ bool MythContext::Init(const bool gui,
 #ifdef Q_OS_WINDOWS
     // HOME environment variable might not be defined
     // some libraries will fail without it
-    QString home = getenv("HOME");
+    QString home = qEnvironmentVariable("HOME");
     if (home.isEmpty())
     {
-        home = getenv("LOCALAPPDATA");      // Vista
+        home = qEnvironmentVariable("LOCALAPPDATA");      // Vista
         if (home.isEmpty())
-            home = getenv("APPDATA");       // XP
+            home = qEnvironmentVariable("APPDATA");       // XP
         if (home.isEmpty())
-            home = QString(".");  // getenv("TEMP")?
+            home = QString(".");  // qEnvironmentVariable("TEMP")?
 
-        _putenv(QString("HOME=%1").arg(home).toLocal8Bit().constData());
+        qputenv("HOME", home.toLocal8Bit().constData());
     }
 #endif
 

--- a/mythtv/libs/libmythbase/bonjourregister.cpp
+++ b/mythtv/libs/libmythbase/bonjourregister.cpp
@@ -3,6 +3,10 @@
 #include <cstdlib>
 #include <limits> // workaround QTBUG-90395
 
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
 #include <QSocketNotifier>
 #include <QtEndian>
 
@@ -16,7 +20,7 @@ QMutex BonjourRegister::g_lock;
 BonjourRegister::BonjourRegister(QObject *parent)
     : QObject(parent)
 {
-    setenv("AVAHI_COMPAT_NOWARN", "1", 1);
+    qputenv("AVAHI_COMPAT_NOWARN", "1");
 }
 
 BonjourRegister::~BonjourRegister()

--- a/mythtv/libs/libmythbase/compat.h
+++ b/mythtv/libs/libmythbase/compat.h
@@ -59,9 +59,6 @@
 
             using uint = unsigned int;
 
-#   define setenv(x, y, z) ::SetEnvironmentVariableA(x, y)
-#   define unsetenv(x) 0
-
 #define lstat stat
 #define nice(x) ((int)!::SetPriorityClass(\
                     ::GetCurrentProcess(), ((x) < -10) ? \

--- a/mythtv/libs/libmythbase/mythcommandlineparser.cpp
+++ b/mythtv/libs/libmythbase/mythcommandlineparser.cpp
@@ -22,6 +22,7 @@
 
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtSystemDetection>
 #endif
 
@@ -3022,7 +3023,7 @@ static bool setUser(const QString &username)
     }
     else if (!user_id && user_info)
     {
-        if (setenv("HOME", user_info->pw_dir,1) == -1)
+        if (!qputenv("HOME", user_info->pw_dir))
         {
             std::cerr << "Error setting home directory.\n";
             return false;

--- a/mythtv/libs/libmythbase/mythdirs.cpp
+++ b/mythtv/libs/libmythbase/mythdirs.cpp
@@ -3,6 +3,7 @@
 
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtSystemDetection>
 #endif
 #include <QDir>
@@ -33,8 +34,8 @@ static QString thumbnaildir;
 
 void InitializeMythDirs(void)
 {
-    installprefix = qgetenv( "MYTHTVDIR"   );
-    confdir       = qgetenv( "MYTHCONFDIR" );
+    installprefix = qEnvironmentVariable( "MYTHTVDIR"   );
+    confdir       = qEnvironmentVariable( "MYTHCONFDIR" );
 
     if (!confdir.isEmpty())
     {
@@ -52,7 +53,7 @@ void InitializeMythDirs(void)
 
     // Turn into Canonical Path for consistent compares
 
-    QDir sDir(qgetenv("ProgramData") + "/mythtv/");
+    QDir sDir(qEnvironmentVariable("ProgramData") + "/mythtv/");
     if (sDir.exists())
         sharedir = sDir.canonicalPath() + "/";
 
@@ -62,7 +63,7 @@ void InitializeMythDirs(void)
     }
     if (confdir.isEmpty())
     {
-        confdir  = qgetenv( "LOCALAPPDATA" ) + "/mythtv";
+        confdir  = qEnvironmentVariable( "LOCALAPPDATA" ) + "/mythtv";
         confdir = QDir(confdir).canonicalPath() + "/";
     }
 

--- a/mythtv/libs/libmythbase/mythmiscutil.cpp
+++ b/mythtv/libs/libmythbase/mythmiscutil.cpp
@@ -17,6 +17,7 @@
 #include "compat.h"
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtProcessorDetection>
 #include <QtSystemDetection>
 #endif
@@ -949,8 +950,11 @@ void setHttpProxy(void)
         }
 
         url = url.arg(p.hostName()).arg(p.port());
-        setenv("HTTP_PROXY", url.toLatin1().constData(), 1);
-        setenv("http_proxy", url.toLatin1().constData(), 0);
+        qputenv("HTTP_PROXY", url.toLocal8Bit().constData());
+        if (!qEnvironmentVariableIsSet("http_proxy"))
+        {
+            qputenv("http_proxy", url.toLocal8Bit().constData());
+        }
 
         return;
     }

--- a/mythtv/libs/libmythtv/opengl/mythvaapiinterop.cpp
+++ b/mythtv/libs/libmythtv/opengl/mythvaapiinterop.cpp
@@ -1,5 +1,10 @@
 ﻿#include "mythvaapiinterop.h"
 
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
+
 // MythTV
 #include "libmythbase/mythconfig.h"
 #include "libmythbase/mythlogging.h"

--- a/mythtv/libs/libmythtv/videoout_d3d.cpp
+++ b/mythtv/libs/libmythtv/videoout_d3d.cpp
@@ -7,6 +7,11 @@
 #include <iostream>
 #include <algorithm>
 
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
+
 #include "libmythbase/mythconfig.h"
 #include "libmythbase/mythlogging.h"
 #include "libmythui/mythmainwindow.h"
@@ -435,7 +440,7 @@ QStringList VideoOutputD3D::GetAllowedRenderers(
 {
     QStringList list;
     if (codec_is_std(myth_codec_id) || (codec_is_dxva2_hw(myth_codec_id) &&
-        !getenv("NO_DXVA2")))
+        !qEnvironmentVariableIsSet("NO_DXVA2")))
     {
         list += "direct3d";
     }
@@ -449,7 +454,7 @@ MythCodecID VideoOutputD3D::GetSupportedCodec(
 #if CONFIG_DXVA2
     MythCodecID test_cid = (MythCodecID)(kCodec_MPEG1_DXVA2 + (stream_type - 1));
     bool use_cpu = !codec_is_dxva2_hw(test_cid);
-    if ((decoder == "dxva2") && !getenv("NO_DXVA2") && !use_cpu)
+    if ((decoder == "dxva2") && !qEnvironmentVariableIsSet("NO_DXVA2") && !use_cpu)
         return test_cid;
 #endif
     return (MythCodecID)(kCodec_MPEG1 + (stream_type - 1));

--- a/mythtv/libs/libmythui/devices/lirc_client.cpp
+++ b/mythtv/libs/libmythui/devices/lirc_client.cpp
@@ -33,6 +33,13 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
+#include <QByteArray>
+
 #include "lirc_client.h"
 
 // clazy:excludeall=raw-environment-function
@@ -555,16 +562,16 @@ static std::string lirc_getfilename(const struct lirc_state *state,
 				    const std::string& current_file)
 {
 	std::string filename;
+	std::string home {"/"};
 
 	if(file.empty())
 	{
-		const char *home=getenv("HOME");
-		if(home==nullptr)
+		if (qEnvironmentVariableIsSet("HOME"))
 		{
-			home="/";
+			home = qgetenv("HOME").toStdString();
 		}
 		filename = home;
-		if(strlen(home)>0 && filename.back()!='/')
+		if(!home.empty() && filename.back()!='/')
 		{
 			filename += "/";
 		}
@@ -572,10 +579,9 @@ static std::string lirc_getfilename(const struct lirc_state *state,
 	}
 	else if(file.starts_with("~/"))
 	{
-		const char *home=getenv("HOME");
-		if(home==nullptr)
+		if (qEnvironmentVariableIsSet("HOME"))
 		{
-			home="/";
+			home = qgetenv("HOME").toStdString();
 		}
 		filename = home;
 		filename += file.substr(1);

--- a/mythtv/libs/libmythui/mythdisplay.cpp
+++ b/mythtv/libs/libmythui/mythdisplay.cpp
@@ -5,6 +5,7 @@
 //Qt
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtSystemDetection>
 #endif
 #include <QTimer>
@@ -1259,7 +1260,10 @@ void MythDisplay::ConfigureQtGUI(int SwapInterval, const MythCommandLineParser& 
         else if (!vendor.isEmpty() || force)
         {
             LOG(VB_GENERAL, LOG_INFO, LOC + QString("Requesting EGL for vendor '%1'").arg(vendor));
-            setenv("QT_XCB_GL_INTEGRATION", "xcb_egl", 0);
+            if (!qEnvironmentVariableIsSet("QT_XCB_GL_INTEGRATION"))
+            {
+                qputenv("QT_XCB_GL_INTEGRATION", "xcb_egl");
+            }
         }
     }
 #endif

--- a/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
+++ b/mythtv/libs/libmythui/opengl/mythrenderopengl.cpp
@@ -3,6 +3,10 @@
 #include <cmath>
 
 // Qt
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
 #include <QLibrary>
 #include <QPainter>
 #include <QWindow>

--- a/mythtv/libs/libmythui/platforms/mythdrmdevice.cpp
+++ b/mythtv/libs/libmythui/platforms/mythdrmdevice.cpp
@@ -3,6 +3,7 @@
 // Qt
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtSystemDetection>
 #endif
 #include <QDir>
@@ -177,11 +178,17 @@ void MythDRMDevice::SetupDRM(const MythCommandLineParser& CmdLine)
 
     // If we are using eglfs_kms we want atomic operations. No effect on other plugins.
     LOG(VB_GENERAL, LOG_INFO, QString("Exporting '%1=1'").arg(s_kmsAtomic));
-    setenv(s_kmsAtomic, "1", 0);
+    if (!qEnvironmentVariableIsSet(s_kmsAtomic))
+    {
+        qputenv(s_kmsAtomic, "1");
+    }
 
     // Seems to fix occasional issues. Again no impact on other plugins.
     LOG(VB_GENERAL, LOG_INFO, QString("Exporting '%1=1'").arg(s_kmsSetMode));
-    setenv(s_kmsSetMode, "1", 0);
+    if (!qEnvironmentVariableIsSet(s_kmsSetMode))
+    {
+        qputenv(s_kmsSetMode, "1");
+    }
 
     bool plane  = qEnvironmentVariableIsSet(s_kmsPlaneIndex) ||
                   qEnvironmentVariableIsSet(s_kmsPlaneCRTCS);
@@ -289,7 +296,7 @@ void MythDRMDevice::SetupDRM(const MythCommandLineParser& CmdLine)
     {
         LOG(VB_GENERAL, LOG_INFO, QString("Wrote %1:\r\n%2").arg(filename, wrote));
         LOG(VB_GENERAL, LOG_INFO, QString("Exporting '%1=%2'").arg(s_kmsConfigFile, filename));
-        setenv(s_kmsConfigFile, qPrintable(filename), 1);
+        qputenv(s_kmsConfigFile, qPrintable(filename));
     }
     file.close();
 
@@ -297,8 +304,8 @@ void MythDRMDevice::SetupDRM(const MythCommandLineParser& CmdLine)
     auto crtcplane  = QString("%1,%2").arg(device->m_crtc->m_id).arg(guiplane->m_id);
     LOG(VB_GENERAL, LOG_INFO, QString("Exporting '%1=%2'").arg(s_kmsPlaneIndex, planeindex));
     LOG(VB_GENERAL, LOG_INFO, QString("Exporting '%1=%2'").arg(s_kmsPlaneCRTCS, crtcplane));
-    setenv(s_kmsPlaneIndex, qPrintable(planeindex), 1);
-    setenv(s_kmsPlaneCRTCS, qPrintable(crtcplane), 1);
+    qputenv(s_kmsPlaneIndex, qPrintable(planeindex));
+    qputenv(s_kmsPlaneCRTCS, qPrintable(crtcplane));
 
     // Set the zpos if supported
     if (auto zposp = MythDRMProperty::GetProperty("zpos", guiplane->m_properties); zposp.get())
@@ -307,7 +314,7 @@ void MythDRMDevice::SetupDRM(const MythCommandLineParser& CmdLine)
         {
             auto val = QString::number(std::min(range->m_min + 1, range->m_max));
             LOG(VB_GENERAL, LOG_INFO, QString("Exporting '%1=%2'").arg(s_kmsPlaneZpos, val));
-            setenv(s_kmsPlaneZpos, qPrintable(val), 1);
+            qputenv(s_kmsPlaneZpos, qPrintable(val));
         }
     }
 

--- a/mythtv/libs/libmythui/test/test_lirc/test_lirc.cpp
+++ b/mythtv/libs/libmythui/test/test_lirc/test_lirc.cpp
@@ -3,6 +3,10 @@
 #include <fcntl.h>
 #include <iostream>
 
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
 #include <QTest>
 
 #include "lirc_client.cpp" // NOLINT(bugprone-suspicious-include)
@@ -388,9 +392,9 @@ void TestLirc::test_getfilename(void)
     QFETCH(const QString, qs_expected);
 
     if (qs_home.isEmpty())
-        unsetenv("HOME");
+        qunsetenv("HOME");
     else
-        setenv("HOME", qs_home.toUtf8().data(), 1);
+        qputenv("HOME", qs_home.toUtf8().data());
 
     m_state = lirc_init("/etc/lircrc", qs_user_file.toUtf8().data(),
                         "test_lirc", nullptr, 0);

--- a/mythtv/programs/mythavtest/mythavtest.cpp
+++ b/mythtv/programs/mythavtest/mythavtest.cpp
@@ -3,6 +3,9 @@
 #include <utility>
 
 #include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
 #include <QApplication>
 #include <QDir>
 #include <QString>

--- a/mythtv/programs/mythbackend/mythbackend.cpp
+++ b/mythtv/programs/mythbackend/mythbackend.cpp
@@ -9,6 +9,7 @@
 
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtSystemDetection>
 #endif
 #ifndef Q_OS_WINDOWS
@@ -108,12 +109,12 @@ int main(int argc, char **argv)
 
 #ifdef Q_OS_DARWIN
     QString path = QCoreApplication::applicationDirPath();
-    setenv("PYTHONPATH",
+    qputenv("PYTHONPATH",
            QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
            .arg(path)
            .arg(QFileInfo(PYTHON_EXE).fileName())
            .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))
-           .toUtf8().constData(), 1);
+           .toUtf8().constData());
 #endif
 
     int retval = cmdline.Daemonize();

--- a/mythtv/programs/mythfrontend/mythfrontend.cpp
+++ b/mythtv/programs/mythfrontend/mythfrontend.cpp
@@ -12,6 +12,7 @@
 // Qt
 #include <QtGlobal>
 #if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
 #include <QtSystemDetection>
 #endif
 #ifdef Q_OS_ANDROID
@@ -2037,12 +2038,12 @@ Q_DECL_EXPORT int main(int argc, char **argv)
 
 #ifdef Q_OS_DARWIN
     QString path = QCoreApplication::applicationDirPath();
-    setenv("PYTHONPATH",
+    qputenv("PYTHONPATH",
            QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
            .arg(path)
            .arg(QFileInfo(PYTHON_EXE).fileName())
            .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))
-           .toUtf8().constData(), 1);
+           .toUtf8().constData());
 #endif
 
 #ifdef Q_OS_ANDROID

--- a/mythtv/programs/mythmetadatalookup/mythmetadatalookup.cpp
+++ b/mythtv/programs/mythmetadatalookup/mythmetadatalookup.cpp
@@ -8,6 +8,9 @@
 
 // Qt headers
 #include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
 #include <QCoreApplication>
 #include <QEventLoop>
 #ifdef Q_OS_DARWIN
@@ -56,12 +59,12 @@ int main(int argc, char *argv[])
 
 #ifdef Q_OS_DARWIN
     QString path = QCoreApplication::applicationDirPath();
-    setenv("PYTHONPATH",
+    qputenv("PYTHONPATH",
            QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
            .arg(path)
            .arg(QFileInfo(PYTHON_EXE).fileName())
            .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))
-           .toUtf8().constData(), 1);
+           .toUtf8().constData());
 #endif
 
     int retval = cmdline.ConfigureLogging();

--- a/mythtv/programs/mythutil/musicmetautils.cpp
+++ b/mythtv/programs/mythutil/musicmetautils.cpp
@@ -1,4 +1,8 @@
 // qt
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+#include <QtEnvironmentVariables>
+#endif
 #include <QDir>
 #include <QDomDocument>
 #include <QProcess>
@@ -363,12 +367,12 @@ static int FindLyrics(const MythUtilCommandLineParser &cmdline)
 
 #ifdef Q_OS_DARWIN
     QString path = QCoreApplication::applicationDirPath();
-    setenv("PYTHONPATH",
+    qputenv("PYTHONPATH",
            QString("%1/../Resources/lib/%2:%1/../Resources/lib/%2/site-packages:%1/../Resources/lib/%2/lib-dynload:%3")
            .arg(path)
            .arg(QFileInfo(PYTHON_EXE).fileName())
            .arg(QProcessEnvironment::systemEnvironment().value("PYTHONPATH"))
-           .toUtf8().constData(), 1);
+           .toUtf8().constData());
     QString PYTHON_LOCAL_EXE = path + QFileInfo(PYTHON_EXE).fileName();
 #else
     QString PYTHON_LOCAL_EXE = QString(PYTHON_EXE);


### PR DESCRIPTION
Always use `<QtEnvironmentVariables>` to ensure thread safety.  This also replaces the last use of `compat.h` in `mythcontext.cpp`, i.e. `uint` with `unsigned`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

