### PR TITLE
Remove unnecessary Valgrind libs from cmake build

### DIFF
--- a/mythtv/programs/mythbackend/CMakeLists.txt
+++ b/mythtv/programs/mythbackend/CMakeLists.txt
@@ -157,7 +157,6 @@ target_link_libraries(
          mythmetadata
          mythprotoserver
          mythupnp
-         $<TARGET_NAME_IF_EXISTS:PkgConfig::VALGRIND>
          $<TARGET_NAME_IF_EXISTS:Qt${QT_VERSION_MAJOR}::DBus>)
 
 install(TARGETS mythbackend RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/mythtv/programs/mythpreviewgen/CMakeLists.txt
+++ b/mythtv/programs/mythpreviewgen/CMakeLists.txt
@@ -4,7 +4,6 @@ add_executable(
 
 target_include_directories(mythpreviewgen PRIVATE .)
 
-target_link_libraries(mythpreviewgen PUBLIC myth mythtv mythbase
-         $<TARGET_NAME_IF_EXISTS:PkgConfig::VALGRIND>)
+target_link_libraries(mythpreviewgen PUBLIC myth mythtv mythbase)
 
 install(TARGETS mythpreviewgen RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Eliminate unnecessary Valgrind libraries from link operations for **mythbackend** and **mythpreviewgen**.

Resolves: #1440

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

