### PR TITLE
Cmake support for Valgrind and Sanitizer builds

### DIFF
--- a/README.CMake.md
+++ b/README.CMake.md
@@ -383,6 +383,28 @@
   command are booleans, and should be set to "ON" or "OFF".  The rest
   of the entries are strings.
 
+  To build applications which will be easier to debug using Valgrind,
+  turn on the ENABLE_VALGRIND option.
+
+```
+$ cmake --preset <qt5|qt6> -DENABLE_VALGRIND=ON -DCMAKE_INSTALL_PREFIX=<install_location>
+$ cmake --build build-<qt5|qt6>
+```
+
+  To build applications with Address Sanitizer, turn on the ENABLE_ASAN option.
+
+```
+$ cmake --preset <qt5|qt6> -DENABLE_ASAN=ON -DCMAKE_INSTALL_PREFIX=<install_location>
+$ cmake --build build-<qt5|qt6>
+```
+
+  To build applications with Thread Sanitizer, turn on the ENABLE_TSAN option.
+
+```
+$ cmake --preset <qt5|qt6> -DENABLE_TSAN=ON -DCMAKE_INSTALL_PREFIX=<install_location>
+$ cmake --build build-<qt5|qt6>
+```
+
   The build also loads two per-user options files (by default named
   `.config/MythTV/BuildOverridesPre.cmake` and
   `.config/MythTV/BuildOverridesPost.cmake`) so that you can

--- a/cmake/MythOptions.cmake
+++ b/cmake/MythOptions.cmake
@@ -169,6 +169,8 @@ option(ENABLE_SYSTEMD_JOURNAL "Enable systemd journal support." ON)
 option(ENABLE_SYSTEMD_NOTIFY "Enable systemd notify support." ON)
 option(ENABLE_QTWEBENGINE "Enable webengine support." ON)
 option(ENABLE_VALGRIND "Enable valgrind support." OFF)
+option(ENABLE_ASAN "Enable AddressSanitizer." OFF)
+option(ENABLE_TSAN "Enable ThreadSanitizer." OFF)
 option(
   ENABLE_EXIV2_DOWNLOAD
   "Build latest exiv2 instead of embedded copy.  This only afects native builds. Android/Windows builds will always downloded exiv2."

--- a/cmake/SetCompilerOptions.cmake
+++ b/cmake/SetCompilerOptions.cmake
@@ -217,6 +217,45 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
 endif()
 
+# Setting ENABLE_VALGRIND=ON does NOT mean that we're going to pull Valgrind
+# into MythTv. It means that we're going to make a few small changes to
+# MythTv apps which will make them easier to test with a tool like Valgrind.
+# Even with these changes, apps run 10 - 50 times slower under Valgrind.
+if(ENABLE_VALGRIND)
+    add_compile_definitions(CONFIG_VALGRIND=1)
+    # Disabling frame pointer omission makes it
+    # easier to understand reported call stacks.
+    if(MSVC)
+        add_compile_options(/Oy-)
+    else()
+        add_compile_options(-fno-omit-frame-pointer)
+    endif()
+endif()
+
+# Set ENABLE_ASAN=ON to build the apps with Address Sanitizer. Upon exit,
+# they will report memory corruption issues by printing to stdout. The
+# added memory tracking will cause the apps to run 1.5 - 2 times slower.
+if(ENABLE_ASAN)
+    if(MSVC)
+        add_compile_options(/fsanitize=address /Oy-)
+    else()
+        add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=address)
+    endif()
+endif()
+
+# Set ENABLE_TSAN=ON to build the apps with Thread Sanitizer. Upon exit,
+# they will report data race issues by printing to stdout. The added
+# memory tracking will cause the apps to run 5 - 10 times slower.
+if(ENABLE_TSAN)
+    if(MSVC)
+        add_compile_options(/fsanitize=thread /Oy-)
+    else()
+        add_compile_options(-fsanitize=thread -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=thread)
+    endif()
+endif()
+
 #
 # Check for Interprocedural Optimization, aka Link Time Optimization.
 #


### PR DESCRIPTION
When **ENABLE_VALGRIND=ON**, define of **CONFIG_VALGRIND=1** is set to build applications which will be easier to debug using **Valgrind**. Compiler options are set to make it easier to understand reported call stacks. Usage example:

```
cmake --preset qt5 -DENABLE_VALGRIND=ON -DCMAKE_INSTALL_PREFIX=./install
cmake --build build-qt5
```

Adding option to set **ENABLE_ASAN=ON** or **ENABLE_TSAN=ON** to allow user to build with **Address Sanitizer** or **Thread Sanitizer**. Updating compiler and linker options for those types of builds. Usage examples:

```
cmake --preset qt5 -DENABLE_ASAN=ON -DCMAKE_INSTALL_PREFIX=./install
cmake --build build-qt5
```

```
cmake --preset qt5 -DENABLE_TSAN=ON -DCMAKE_INSTALL_PREFIX=./install
cmake --build build-qt5
```


Resolves: #1442

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

