### PR TITLE
Remove AudioOutputALSA::GetDevices memory leaks

### DIFF
--- a/mythtv/libs/libmythtv/audio/audiooutputalsa.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputalsa.cpp
@@ -1015,10 +1015,16 @@ QMap<QString, QString> *AudioOutputALSA::GetDevices(const char *type)
 
     while (*n != nullptr)
     {
-          QString name = snd_device_name_get_hint(*n, "NAME");
-          QString desc = snd_device_name_get_hint(*n, "DESC");
-          if (!name.isEmpty() && !desc.isEmpty() && (name != "null"))
-              alsadevs->insert(name, desc);
+          char *name = snd_device_name_get_hint(*n, "NAME");
+          char *desc = snd_device_name_get_hint(*n, "DESC");
+          QString nameStr(name);
+          QString descStr(desc);
+          // To avoid a memory leak, the return value from snd_device_name_get_hint()
+          // should be freed when no longer needed.
+          free(name);   // NOLINT(cppcoreguidelines-no-malloc)
+          free(desc);   // NOLINT(cppcoreguidelines-no-malloc)
+          if (!nameStr.isEmpty() && !descStr.isEmpty() && (nameStr != "null"))
+              alsadevs->insert(nameStr, descStr);
           n++;
     }
     snd_device_name_free_hint(hints);

--- a/mythtv/libs/libmythtv/audio/audiooutputalsa.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutputalsa.cpp
@@ -1017,14 +1017,12 @@ QMap<QString, QString> *AudioOutputALSA::GetDevices(const char *type)
     {
           char *name = snd_device_name_get_hint(*n, "NAME");
           char *desc = snd_device_name_get_hint(*n, "DESC");
-          QString nameStr(name);
-          QString descStr(desc);
+          if (name && desc && (strcmp(name, "null") != 0))
+              alsadevs->insert(name, desc);
           // To avoid a memory leak, the return value from snd_device_name_get_hint()
           // should be freed when no longer needed.
           free(name);   // NOLINT(cppcoreguidelines-no-malloc)
           free(desc);   // NOLINT(cppcoreguidelines-no-malloc)
-          if (!nameStr.isEmpty() && !descStr.isEmpty() && (nameStr != "null"))
-              alsadevs->insert(nameStr, descStr);
           n++;
     }
     snd_device_name_free_hint(hints);


### PR DESCRIPTION
The ALSA documentation for **snd_device_name_get_hint()** tells us that it returns `an allocated ASCII string if success, otherwise NULL`. It also instructs that `the return value should be freed when no longer needed`.

These free() calls were missing in **AudioOutputALSA::GetDevices()**
after calling **snd_device_name_get_hint()**. Code has been updated to store the pointer returned by each call to the routine, and to free those pointers once they are no longer needed.

This removes the memory leaks.

Resolves: #1460

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

