### PR TITLE
Switch to floor division in pager.py

### DIFF
--- a/mythtv/bindings/python/tmdb3/tmdb3/pager.py
+++ b/mythtv/bindings/python/tmdb3/tmdb3/pager.py
@@ -67,7 +67,7 @@ class PagedList(Sequence):
             raise IndexError("list index outside range")
         if (index >= len(self._data)) \
                 or isinstance(self._data[index], UnpagedData):
-            self._populatepage(index/self._pagesize + 1)
+            self._populatepage(index//self._pagesize + 1)
         return self._data[index]
 
     def __setitem__(self, index, value):


### PR DESCRIPTION
Implementing Tom Peterson's suggested fix for a crash caused by the default division behavior of Python 3. With a single slash '/', Python 3 gives a floating point result. Python 2 used to provide an integer result. In pager.py, division is used to calculate a page offset, which needs to be an integer value. To enforce this under Python 3, the code has been updated to use "floor division" by using two slashes '//'. This provides an integer result which will prevent a crash.

Resolves #1426

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

