### PR TITLE
Fix track progress in mythmusic

### DIFF
--- a/mythtv/libs/libmythtv/audio/audiooutput.cpp
+++ b/mythtv/libs/libmythtv/audio/audiooutput.cpp
@@ -57,6 +57,13 @@ extern "C" {
 
 #define LOC QString("AO: ")
 
+const QEvent::Type AudioOutput::Event::kPlaying{static_cast<QEvent::Type>(QEvent::registerEventType())};
+const QEvent::Type AudioOutput::Event::kBuffering{static_cast<QEvent::Type>(QEvent::registerEventType())};
+const QEvent::Type AudioOutput::Event::kInfo{static_cast<QEvent::Type>(QEvent::registerEventType())};
+const QEvent::Type AudioOutput::Event::kPaused{static_cast<QEvent::Type>(QEvent::registerEventType())};
+const QEvent::Type AudioOutput::Event::kStopped{static_cast<QEvent::Type>(QEvent::registerEventType())};
+const QEvent::Type AudioOutput::Event::kError{static_cast<QEvent::Type>(QEvent::registerEventType())};
+
 void AudioOutput::Cleanup(void)
 {
 #if CONFIG_AUDIO_PULSE

--- a/mythtv/libs/libmythtv/audio/audiooutput.h
+++ b/mythtv/libs/libmythtv/audio/audiooutput.h
@@ -256,12 +256,12 @@ class MTV_PUBLIC AudioOutput::Event : public MythEvent
     MythEvent *clone(void) const override // MythEvent
         { return new Event(*this); }
 
-    static const inline QEvent::Type kPlaying    {static_cast<QEvent::Type>(QEvent::registerEventType())};
-    static const inline QEvent::Type kBuffering  {static_cast<QEvent::Type>(QEvent::registerEventType())};
-    static const inline QEvent::Type kInfo       {static_cast<QEvent::Type>(QEvent::registerEventType())};
-    static const inline QEvent::Type kPaused     {static_cast<QEvent::Type>(QEvent::registerEventType())};
-    static const inline QEvent::Type kStopped    {static_cast<QEvent::Type>(QEvent::registerEventType())};
-    static const inline QEvent::Type kError      {static_cast<QEvent::Type>(QEvent::registerEventType())};
+    static const QEvent::Type kPlaying;
+    static const QEvent::Type kBuffering;
+    static const QEvent::Type kInfo;
+    static const QEvent::Type kPaused;
+    static const QEvent::Type kStopped;
+    static const QEvent::Type kError;
 
   private:
     Event(const Event &o) = default;


### PR DESCRIPTION
The event IDs in AudioOutput were declared as static inline, causing copies of them in diffrerent tranlation modules. As the values came from calling QEvent::registerEventType, each of these copies ended up with different values.
Thus comparing the event type as received in mythmusic (initialized in libmythtv) with the event IDs as initialized in mythmusic would not work. Making them non-inline static member variables makes sure the event IDs are only initialized once and thus consistent between all translation units.

Thank you for contributing to MythTV!

Please review the checklist below to ensure that your contribution
to MythTV is ready for review by our developers.

It is helpful to regularly rebase your pull request to ensure changes
apply cleanly to the current MythTV development branch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

