### PR TITLE
Remove raise of StopIteration in ttvdb4 generator

### DIFF
--- a/mythtv/bindings/python/ttvdbv4/myth4ttvdbv4.py
+++ b/mythtv/bindings/python/ttvdbv4/myth4ttvdbv4.py
@@ -556,26 +556,29 @@ class Myth4TTVDBv4(object):
 
         gen_episodes = ttvdb.getSeriesEpisodes(inetref, season_type='default', season=season,
                                                episodeNumber=episode, yielded=True)
-        ep = next(gen_episodes)
-        epi_x = ttvdb.getEpisodeExtended(ep.id)
-        for lang in self._select_preferred_langs(epi_x.nameTranslations):
-            translation = ttvdb.getEpisodeTranslation(epi_x.id, lang)
-            epi_x.fetched_translations.append(translation)
-        if self.debug:
-            print("%04d: buildSingle: Episode Information for %s : %s : %s"
-                  % (self._get_ellapsed_time(), inetref, season, episode))
-            _print_class_content(epi_x)
+        try:
+            ep = next(gen_episodes)
+            epi_x = ttvdb.getEpisodeExtended(ep.id)
+            for lang in self._select_preferred_langs(epi_x.nameTranslations):
+                translation = ttvdb.getEpisodeTranslation(epi_x.id, lang)
+                epi_x.fetched_translations.append(translation)
+            if self.debug:
+                print("%04d: buildSingle: Episode Information for %s : %s : %s"
+                      % (self._get_ellapsed_time(), inetref, season, episode))
+                _print_class_content(epi_x)
 
-        # get season information:
-        sea_x = None
-        for s in epi_x.seasons:
-            if s.type.id == ser_x.defaultSeasonType:
-                sea_x = ttvdb.getSeasonExtended(s.id)
-                if self.debug:
-                    print("%04d: buildSingle: Season Information for %s : %s"
-                          % (self._get_ellapsed_time(), inetref, season))
-                    _print_class_content(sea_x)
-                break
+            # get season information:
+            sea_x = None
+            for s in epi_x.seasons:
+                if s.type.id == ser_x.defaultSeasonType:
+                    sea_x = ttvdb.getSeasonExtended(s.id)
+                    if self.debug:
+                        print("%04d: buildSingle: Season Information for %s : %s"
+                              % (self._get_ellapsed_time(), inetref, season))
+                        _print_class_content(sea_x)
+                    break
+        except StopIteration:
+            sys.exit("No matching episode found")
 
         # no we have all extended records for series, season, episode, create xml for them
         self._format_xml(ser_x, sea_x, epi_x)
@@ -605,6 +608,8 @@ class Myth4TTVDBv4(object):
 
         # get data for passed inetref and preferred translations
         ser_x = ttvdb.getSeriesExtended(tvinetref)
+        if not ser_x:
+            sys.exit("No matching collection found")
 
         ser_x.fetched_translations = []
         for lang in self._select_preferred_langs(ser_x.nameTranslations):

--- a/mythtv/bindings/python/ttvdbv4/ttvdbv4_api.py
+++ b/mythtv/bindings/python/ttvdbv4/ttvdbv4_api.py
@@ -83,10 +83,9 @@ def _query_yielded(record, path, params, listname=None):
                 for item in datalist:
                     yield record(item)
             else:
-                raise StopIteration
+                return
         else:
-            #break
-            raise StopIteration
+            return
         curr_page += 1
         params['page'] = curr_page
 

--- a/mythtv/programs/scripts/metadata/Television/tvmaze.py
+++ b/mythtv/programs/scripts/metadata/Television/tvmaze.py
@@ -424,6 +424,8 @@ def buildSingleItem(inetref, season, episode_id):
 
     # get info for season episodes:
     ep_info = tvmaze.get_episode_information(episode_id)
+    if not ep_info:
+        sys.exit("No matching episode found")
     m = VideoMetadata()
     if show_info.genres is not None and len(show_info.genres) > 0:
         for g in show_info.genres:
@@ -534,6 +536,8 @@ def buildCollection(tvinetref, opts):
         print("Function 'buildCollection' called with argument '%s'" % tvinetref)
 
     show_info = tvmaze.get_show(tvinetref)
+    if not show_info:
+        sys.exit("No matching collection found")
     if opts.debug:
         for k, v in show_info.__dict__.items():
             print(k, " : ", v)


### PR DESCRIPTION
Tom Peterson's suggested change to replace the "**raise StopIteration**" lines with "**return**" inside the generator routine has been implemented in _ttvdbv4_api.py_. This is the PEP 479-compliant way to end a generator.

In _myth4ttvdbv4.py_, the **buildSingle()** routine has been updated to accommodate a possible **StopIteration** exception when the generator is called. If that exception happens, we will exit with a "_No matching episode found_" error message. Similarly, **buildCollection()** has been updated to exit with a "_No matching collection found_" error message when the provided reference identifier does not correspond to a known TV series.

The **tvmaze** metadata grabber had similar vague failures.

For a non-existent episode:
```
tvmaze.py -l en -a US -D 32938 2 35
ERROR: <class 'AttributeError'> : 'NoneType' object has no attribute 'name'

```
For a non-existent series:
```
tvmaze.py -l en -a US -C 99999
ERROR: <class 'AttributeError'> : 'NoneType' object has no attribute 'name'
```
The **tvmaze.py** script has been updated to switch these to:

```
tvmaze.py -l en -a US -D 32938 2 35
ERROR: <class 'SystemExit'> : No matching episode found

tvmaze.py -l en -a US -C 99999
ERROR: <class 'SystemExit'> : No matching collection found
```
This provides consistent behavior between **ttvdb4.py** and **tvmaze.py** grabbers for these types of failures.

Resolves #1433

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

