### PR TITLE
Remove VB_STDIO and VB_FLUSH

### DIFF
--- a/mythtv/libs/libmythbase/logging.cpp
+++ b/mythtv/libs/libmythbase/logging.cpp
@@ -536,7 +536,6 @@ void LogPrintLine( uint64_t mask, LogLevel_t level, const char *file, int line,
                    const char *function, QString message)
 {
     int type = kMessage;
-    type |= (mask & VB_FLUSH) ? kFlush : 0;
     LoggingItem *item = LoggingItem::create(file, function, line, level,
                                             (LoggingType)type);
     if (!item)
@@ -558,10 +557,6 @@ void LogPrintLine( uint64_t mask, LogLevel_t level, const char *file, int line,
             item->DecrRef();
             qLock.relock();
         }
-    }
-    else if (logThread && !logThreadFinished && (type & kFlush))
-    {
-        logThread->flush();
     }
 }
 

--- a/mythtv/libs/libmythbase/logging.cpp
+++ b/mythtv/libs/libmythbase/logging.cpp
@@ -409,17 +409,17 @@ bool LoggerThread::logConsole(LoggingItem *item) const
     std::string line;
 
 #if !defined(NDEBUG) || CONFIG_FORCE_LOGLONG
-        if (true) // NOLINT(readability-simplify-boolean-expr)
+    if (true) // NOLINT(readability-simplify-boolean-expr)
 #else
-        if (m_loglong)
+    if (m_loglong)
 #endif
-        {
-            line = item->toString();
-        }
-        else
-        {
-            line = item->toStringShort();
-        }
+    {
+        line = item->toString();
+    }
+    else
+    {
+        line = item->toStringShort();
+    }
 
     std::cout << line << std::flush;
 

--- a/mythtv/libs/libmythbase/logging.cpp
+++ b/mythtv/libs/libmythbase/logging.cpp
@@ -408,12 +408,6 @@ bool LoggerThread::logConsole(LoggingItem *item) const
 #ifndef Q_OS_ANDROID
     std::string line;
 
-    if (item->m_type & kStandardIO)
-    {
-        line = qPrintable(item->m_message);
-    }
-    else
-    {
 #if !defined(NDEBUG) || CONFIG_FORCE_LOGLONG
         if (true) // NOLINT(readability-simplify-boolean-expr)
 #else
@@ -426,7 +420,6 @@ bool LoggerThread::logConsole(LoggingItem *item) const
         {
             line = item->toStringShort();
         }
-    }
 
     std::cout << line << std::flush;
 
@@ -544,7 +537,6 @@ void LogPrintLine( uint64_t mask, LogLevel_t level, const char *file, int line,
 {
     int type = kMessage;
     type |= (mask & VB_FLUSH) ? kFlush : 0;
-    type |= (mask & VB_STDIO) ? kStandardIO : 0;
     LoggingItem *item = LoggingItem::create(file, function, line, level,
                                             (LoggingType)type);
     if (!item)

--- a/mythtv/libs/libmythbase/logging.h
+++ b/mythtv/libs/libmythbase/logging.h
@@ -39,7 +39,6 @@ enum LoggingType : std::uint8_t {
     kRegistering   = 0x02,
     kDeregistering = 0x04,
     kFlush         = 0x08,
-    kStandardIO    = 0x10,
     kInitializing  = 0x20,
 };
 

--- a/mythtv/libs/libmythbase/logging.h
+++ b/mythtv/libs/libmythbase/logging.h
@@ -38,7 +38,6 @@ enum LoggingType : std::uint8_t {
     kMessage       = 0x01,
     kRegistering   = 0x02,
     kDeregistering = 0x04,
-    kFlush         = 0x08,
     kInitializing  = 0x20,
 };
 

--- a/mythtv/libs/libmythbase/mythcommandlineparser.cpp
+++ b/mythtv/libs/libmythbase/mythcommandlineparser.cpp
@@ -2907,12 +2907,10 @@ int MythCommandLineParser::ConfigureLogging(const QString& mask, bool progress)
         verboseMask = static_cast<uint64_t>(toLongLong("verboseint"));
     }
 
-    verboseMask |= VB_FLUSH;
-
     int quiet = toInt("quiet");
     if (std::max(quiet, static_cast<int>(progress)) > 1)
     {
-        verboseMask = VB_NONE|VB_FLUSH;
+        verboseMask = VB_NONE;
         verboseArgParse("none");
     }
 

--- a/mythtv/libs/libmythbase/mythcommandlineparser.cpp
+++ b/mythtv/libs/libmythbase/mythcommandlineparser.cpp
@@ -2907,7 +2907,7 @@ int MythCommandLineParser::ConfigureLogging(const QString& mask, bool progress)
         verboseMask = static_cast<uint64_t>(toLongLong("verboseint"));
     }
 
-    verboseMask |= VB_STDIO|VB_FLUSH;
+    verboseMask |= VB_FLUSH;
 
     int quiet = toInt("quiet");
     if (std::max(quiet, static_cast<int>(progress)) > 1)

--- a/mythtv/libs/libmythbase/mythdbcon.cpp
+++ b/mythtv/libs/libmythbase/mythdbcon.cpp
@@ -87,10 +87,11 @@ MSqlDatabase::MSqlDatabase(QString name, QString driver)
 {
     if (!QSqlDatabase::isDriverAvailable(m_driver))
     {
-        LOG(VB_FLUSH, LOG_CRIT,
+        LOG(VB_GENERAL, LOG_CRIT,
             QString("FATAL: Unable to load the QT %1 driver, is it installed?")
             .arg(m_driver));
-        exit(GENERIC_EXIT_DB_ERROR); // Exits before we can process the log queue
+        logStop(); // flush log before exit
+        exit(GENERIC_EXIT_DB_ERROR);
         //return;
     }
 
@@ -99,9 +100,10 @@ MSqlDatabase::MSqlDatabase(QString name, QString driver)
 
     if (!m_db.isValid() || m_db.isOpenError())
     {
-        LOG(VB_FLUSH, LOG_CRIT, MythDB::DBErrorMessage(m_db.lastError()));
-        LOG(VB_FLUSH, LOG_CRIT, QString("FATAL: Unable to create database object (%1), the installed QT driver may be invalid.").arg(m_name));
-        exit(GENERIC_EXIT_DB_ERROR); // Exits before we can process the log queue
+        LOG(VB_GENERAL, LOG_CRIT, MythDB::DBErrorMessage(m_db.lastError()));
+        LOG(VB_GENERAL, LOG_CRIT, QString("FATAL: Unable to create database object (%1), the installed QT driver may be invalid.").arg(m_name));
+        logStop(); // flush log before exit
+        exit(GENERIC_EXIT_DB_ERROR);
         //return;
     }
     m_lastDBKick = MythDate::current().addSecs(-60);

--- a/mythtv/libs/libmythbase/verbosedefs.h
+++ b/mythtv/libs/libmythbase/verbosedefs.h
@@ -158,13 +158,6 @@ VERBOSE_MAP(VB_FLUSH,     0x1000000000ULL, true,
    flush output to the standard output from console
    programs that have debugging enabled.
  */
-VERBOSE_MAP(VB_STDIO,     0x2000000000ULL, true,
-            "")
-/* Please do not add a description for VB_STDIO, it
-   should not be passed in via "-v". It is used to
-   send output to the standard output from console
-   programs that have debugging enabled.
- */
 VERBOSE_MAP(VB_GPU,       0x4000000000ULL, true,
             "GPU OpenGL driver messages")
 VERBOSE_MAP(VB_GPUAUDIO,  0x8000000000ULL, true,

--- a/mythtv/libs/libmythbase/verbosedefs.h
+++ b/mythtv/libs/libmythbase/verbosedefs.h
@@ -151,13 +151,6 @@ VERBOSE_MAP(VB_RPLXQUEUE, 0x400000000ULL, true,
             "MPEG2Fix Replex Queue messages")
 VERBOSE_MAP(VB_DECODE,    0x800000000ULL, true,
             "MPEG2Fix Decode messages")
-VERBOSE_MAP(VB_FLUSH,     0x1000000000ULL, true,
-            "")
-/* Please do not add a description for VB_FLUSH, it
-   should not be passed in via "-v". It is used to
-   flush output to the standard output from console
-   programs that have debugging enabled.
- */
 VERBOSE_MAP(VB_GPU,       0x4000000000ULL, true,
             "GPU OpenGL driver messages")
 VERBOSE_MAP(VB_GPUAUDIO,  0x8000000000ULL, true,

--- a/mythtv/programs/mythshutdown/mythshutdown.cpp
+++ b/mythtv/programs/mythshutdown/mythshutdown.cpp
@@ -29,6 +29,14 @@
 // MythShutdown
 #include "mythshutdown_commandlineparser.h"
 
+inline static void LOG_STDIO(QString message)
+{
+    if (logLevel >= LOG_ERR)
+    {
+        std::cout << message.toStdString() << std::endl;
+    }
+}
+
 static void setGlobalSetting(const QString &key, const QString &v)
 {
     QString value = (v.isNull()) ? QString("") : v;
@@ -52,9 +60,8 @@ static void setGlobalSetting(const QString &key, const QString &v)
     }
     else
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Error: Database not open while trying "
-                    "to save setting: %1\n").arg(key));
+        LOG_STDIO(QString("Error: Database not open while trying to save setting: %1")
+            .arg(key));
     }
 }
 
@@ -73,9 +80,8 @@ static QString getGlobalSetting(const QString &key, const QString &defaultval)
     }
     else
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Error: Database not open while trying to "
-                        "load setting: %1", "mythshutdown").arg(key) + "\n");
+        LOG_STDIO(QObject::tr("Error: Database not open while trying to load setting: %1",
+                              "mythshutdown").arg(key));
     }
 
     return value;
@@ -98,9 +104,8 @@ static int lockShutdown()
 
     if (tries >= 5)
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Error: Waited too long to obtain "
-                        "lock on setting table", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Error: Waited too long to obtain lock on setting table",
+                              "mythshutdown"));
         return 1;
     }
 
@@ -152,9 +157,8 @@ static int unlockShutdown()
 
     if (tries >= 5)
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Error: Waited too long to obtain "
-                        "lock on setting table", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Error: Waited too long to obtain lock on setting table",
+                              "mythshutdown"));
         return 1;
     }
 
@@ -232,9 +236,8 @@ static bool isRecording()
                 "isRecording: Attempting to connect to master server...");
         if (!gCoreContext->ConnectToMasterServer(false))
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Error: Could not connect to master server",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("Error: Could not connect to master server",
+                                  "mythshutdown"));
             return false;
         }
     }
@@ -250,45 +253,37 @@ static int getStatus(bool bWantRecStatus)
 
     if (isRunning("mythtranscode"))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Transcoding in progress...", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Transcoding in progress...", "mythshutdown"));
         res |= 1;
     }
 
     if (isRunning("mythcommflag"))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Commercial Detection in progress...",
-                        "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Commercial Detection in progress...", "mythshutdown"));
         res |= 2;
     }
 
     if (isRunning("mythfilldatabase"))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Grabbing EPG data in progress...", "mythshutdown") +
-            "\n");
+        LOG_STDIO(QObject::tr("Grabbing EPG data in progress...", "mythshutdown"));
         res |= 4;
     }
 
     if (bWantRecStatus && isRecording())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Recording in progress...", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Recording in progress...", "mythshutdown"));
         res |= 8;
     }
 
     if (getGlobalSetting("MythShutdownLock", "0") != "0")
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Shutdown is locked", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Shutdown is locked", "mythshutdown"));
         res |= 16;
     }
 
     if (JobQueue::HasRunningOrPendingJobs(15min))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Has queued or pending jobs", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Has queued or pending jobs", "mythshutdown"));
         res |= 32;
     }
 
@@ -320,9 +315,7 @@ static int getStatus(bool bWantRecStatus)
     {
         if (dtCurrent >= dtPeriod1Start && dtCurrent <= dtPeriod1End)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("In a daily wakeup period (1).", "mythshutdown") +
-                "\n");
+            LOG_STDIO(QObject::tr("In a daily wakeup period (1).", "mythshutdown"));
             res |= 64;
         }
     }
@@ -331,9 +324,7 @@ static int getStatus(bool bWantRecStatus)
     {
         if (dtCurrent >= dtPeriod2Start && dtCurrent <= dtPeriod2End)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("In a daily wakeup period (2).", "mythshutdown") +
-                "\n");
+            LOG_STDIO(QObject::tr("In a daily wakeup period (2).", "mythshutdown"));
             res |= 64;
         }
     }
@@ -345,9 +336,7 @@ static int getStatus(bool bWantRecStatus)
         auto delta = std::chrono::seconds(dtCurrent.secsTo(dtPeriod1Start));
         if (delta >= 0s && delta <= 15min)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("About to start daily wakeup period (1)",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("About to start daily wakeup period (1)", "mythshutdown"));
             res |= 128;
         }
     }
@@ -357,17 +346,14 @@ static int getStatus(bool bWantRecStatus)
         auto delta = std::chrono::seconds(dtCurrent.secsTo(dtPeriod2Start));
         if (delta >= 0s && delta <= 15min)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("About to start daily wakeup period (2)",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("About to start daily wakeup period (2)", "mythshutdown"));
             res |= 128;
         }
     }
 
     if (isRunning("mythtv-setup"))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Setup is running...", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Setup is running...", "mythshutdown"));
         res = 255;
     }
 
@@ -389,14 +375,12 @@ static int checkOKShutdown(bool bWantRecStatus)
 
     if (res > 0)
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Not OK to shutdown", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Not OK to shutdown", "mythshutdown"));
         res = 1;
     }
     else
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("OK to shutdown", "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("OK to shutdown", "mythshutdown"));
         res = 0;
     }
 
@@ -410,9 +394,8 @@ static void setWakeupTime(const QDateTime &wakeupTime)
 {
     LOG(VB_GENERAL, LOG_INFO, "Mythshutdown: --setwakeup");
 
-    LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-        QObject::tr("Wakeup time given is: %1 (local time)", "mythshutdown")
-        .arg(MythDate::toString(wakeupTime, MythDate::kDateTimeShort)) + "\n");
+    LOG_STDIO(QObject::tr("Wakeup time given is: %1 (local time)", "mythshutdown")
+        .arg(MythDate::toString(wakeupTime, MythDate::kDateTimeShort)));
 
     setGlobalSetting("MythShutdownNextScheduled",
                      MythDate::toString(wakeupTime, MythDate::kDatabase));
@@ -422,16 +405,12 @@ static int setScheduledWakeupTime()
 {
     if (!gCoreContext->IsConnectedToMaster())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Setting scheduled wakeup time: "
-                        "Attempting to connect to master server...",
-                        "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Setting scheduled wakeup time: Attempting to connect to master server...",
+                              "mythshutdown"));
         if (!gCoreContext->ConnectToMasterServer(false))
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Setting scheduled wakeup time: "
-                            "Could not connect to master server!",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("Setting scheduled wakeup time: Could not connect to master server!",
+                                  "mythshutdown"));
             return 1;
         }
     }
@@ -504,10 +483,8 @@ static int shutdown()
     {
         if (dtCurrent < dtPeriod1Start)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Daily wakeup today at %1", "mythshutdown")
-                .arg(MythDate::toString(dtPeriod1Start, MythDate::kTime)) +
-                "\n");
+            LOG_STDIO(QObject::tr("Daily wakeup today at %1", "mythshutdown")
+                .arg(MythDate::toString(dtPeriod1Start, MythDate::kTime)));
             dtNextDailyWakeup = dtPeriod1Start;
         }
     }
@@ -517,10 +494,8 @@ static int shutdown()
     {
         if (dtCurrent < dtPeriod2Start)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Daily wakeup today at %1", "mythshutdown")
-                .arg(MythDate::toString(dtPeriod2Start, MythDate::kTime)) +
-                "\n");
+            LOG_STDIO(QObject::tr("Daily wakeup today at %1", "mythshutdown")
+                .arg(MythDate::toString(dtPeriod2Start, MythDate::kTime)));
             dtNextDailyWakeup = dtPeriod2Start;
         }
     }
@@ -539,20 +514,15 @@ static int shutdown()
         {
             dtNextDailyWakeup = dtNextDailyWakeup.addDays(1);
 
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Next daily wakeup is tomorrow at %1",
-                            "mythshutdown")
-                .arg(MythDate::toString(dtNextDailyWakeup, MythDate::kTime)) +
-                "\n");
+            LOG_STDIO(QObject::tr("Next daily wakeup is tomorrow at %1", "mythshutdown")
+                .arg(MythDate::toString(dtNextDailyWakeup, MythDate::kTime)));
         }
     }
 
     // if dtNextDailyWakeup is still not valid then no daily wakeups are set
     if (!dtNextDailyWakeup.isValid())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Error: no daily wakeup times are set",
-                        "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Error: no daily wakeup times are set","mythshutdown"));
     }
 
     // get next scheduled wake up for a recording if any
@@ -563,16 +533,12 @@ static int shutdown()
 
     if (!dtNextRecordingStart.isValid())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Error: no recording time is set", "mythshutdown") +
-            "\n");
+        LOG_STDIO(QObject::tr("Error: no recording time is set", "mythshutdown"));
     }
     else
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Recording scheduled at: %1", "mythshutdown")
-            .arg(MythDate::toString(dtNextRecordingStart, MythDate::kTime)) +
-            "\n");
+        LOG_STDIO(QObject::tr("Recording scheduled at: %1", "mythshutdown")
+            .arg(MythDate::toString(dtNextRecordingStart, MythDate::kTime)));
     }
 
     // check if scheduled recording time has already passed
@@ -582,9 +548,8 @@ static int shutdown()
 
         if (delta < 0)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Scheduled recording time has already passed. "
-                            "Schedule deleted", "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("Scheduled recording time has already passed. Schedule deleted",
+                                  "mythshutdown"));
 
             dtNextRecordingStart = QDateTime();
             setGlobalSetting("MythShutdownNextScheduled", "");
@@ -600,9 +565,8 @@ static int shutdown()
     if (!dtNextRecordingStart.isValid() && !dtNextDailyWakeup.isValid())
     {
         dtWakeupTime = QDateTime();
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Error: no wake up time set and no scheduled program",
-                        "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Error: no wake up time set and no scheduled program",
+                              "mythshutdown"));
     }
 
     // no daily wakeup set
@@ -610,9 +574,7 @@ static int shutdown()
     if (dtNextRecordingStart.isValid() && !dtNextDailyWakeup.isValid())
     {
         dtWakeupTime = dtNextRecordingStart;
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Will wake up at next scheduled program",
-                        "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Will wake up at next scheduled program", "mythshutdown"));
     }
 
     // daily wakeup is set
@@ -620,9 +582,7 @@ static int shutdown()
     if (!dtNextRecordingStart.isValid() && dtNextDailyWakeup.isValid())
     {
         dtWakeupTime = dtNextDailyWakeup;
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QObject::tr("Will wake up at next daily wakeup",
-                        "mythshutdown") + "\n");
+        LOG_STDIO(QObject::tr("Will wake up at next daily wakeup", "mythshutdown"));
     }
 
     // daily wakeup is set
@@ -632,18 +592,14 @@ static int shutdown()
     {
         if (dtNextDailyWakeup < dtNextRecordingStart)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Program is scheduled but will "
-                            "wake up at next daily wakeup",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("Program is scheduled but will wake up at next daily wakeup",
+                                  "mythshutdown"));
             dtWakeupTime = dtNextDailyWakeup;
         }
         else
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Daily wakeup is set but will wake up "
-                            "at next scheduled program",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("Daily wakeup is set but will wake up at next scheduled program",
+                                  "mythshutdown"));
             dtWakeupTime = dtNextRecordingStart;
         }
     }
@@ -688,22 +644,18 @@ static int shutdown()
                     .toString(wakeup_timeformat));
             }
 
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Sending command to set time in BIOS %1",
-                            "mythshutdown")
-                .arg(nvramCommand) + "\n");
+            LOG_STDIO(QObject::tr("Sending command to set time in BIOS %1", "mythshutdown")
+                .arg(nvramCommand));
 
             shutdownmode = myth_system(nvramCommand);
 
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Program %1 exited with code %2", "mythshutdown")
-                .arg(nvramCommand).arg(shutdownmode) + "\n");
+            LOG_STDIO(QObject::tr("Program %1 exited with code %2", "mythshutdown")
+                .arg(nvramCommand).arg(shutdownmode));
 
             if (shutdownmode == 2)
             {
-                LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                    QObject::tr("Error: nvram-wakeup failed to "
-                                "set time in BIOS", "mythshutdown") + "\n");
+                LOG_STDIO(QObject::tr("Error: nvram-wakeup failed to set time in BIOS",
+                                      "mythshutdown"));
                 return 1;
             }
 
@@ -716,10 +668,8 @@ static int shutdown()
         }
         else
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("The next wakeup time is less than "
-                            "15 mins away, not shutting down.",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("The next wakeup time is less than 15 mins away, not shutting down.",
+                                  "mythshutdown"));
             return 0;
         }
     }
@@ -730,14 +680,10 @@ static int shutdown()
     {
         case 0:
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("everything looks fine, shutting down ...",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("everything looks fine, shutting down ...", "mythshutdown"));
             QString poweroffCmd = gCoreContext->GetSetting(
                 "MythShutdownPoweroff", "/sbin/poweroff");
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                "..\n.\n" + QObject::tr("shutting down", "mythshutdown") +
-                " ...\n");
+            LOG_STDIO("..\n.\n" + QObject::tr("shutting down", "mythshutdown") + " ...");
 
             myth_system(poweroffCmd);
             res = 0;
@@ -745,19 +691,13 @@ static int shutdown()
         }
         case 1:
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Everything looks fine, but reboot is needed",
-                            "mythshutdown") + "\n");
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Sending command to bootloader", "mythshutdown") +
-                " ...\n");
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR, nvramRestartCmd);
+            LOG_STDIO(QObject::tr("Everything looks fine, but reboot is needed", "mythshutdown"));
+            LOG_STDIO(QObject::tr("Sending command to bootloader", "mythshutdown") + " ...");
+            LOG_STDIO(nvramRestartCmd);
 
             myth_system(nvramRestartCmd);
 
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                "..\n.\n" + QObject::tr("rebooting", "mythshutdown") +
-                " ...\n");
+            LOG_STDIO("..\n.\n" + QObject::tr("rebooting", "mythshutdown") +" ...");
 
             QString rebootCmd =
                 gCoreContext->GetSetting("MythShutdownReboot", "/sbin/reboot");
@@ -766,9 +706,7 @@ static int shutdown()
             break;
         }
         default:
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Error: Invalid shutdown mode, doing nothing.",
-                            "mythshutdown") + "\n");
+            LOG_STDIO(QObject::tr("Error: Invalid shutdown mode, doing nothing.", "mythshutdown"));
             res = 1;
             break;
     }
@@ -853,8 +791,7 @@ int main(int argc, char **argv)
     MythContext context {MYTH_BINARY_VERSION};
     if (!context.Init(false))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Error: "
-            "Could not initialize MythContext. Exiting.\n");
+        LOG_STDIO("Error: Could not initialize MythContext. Exiting.");
         return GENERIC_EXIT_NO_MYTHCONTEXT;
     }
 
@@ -886,11 +823,8 @@ int main(int argc, char **argv)
 
         if (!wakeuptime.isValid())
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                QObject::tr("Error: "
-                            "--setwakeup invalid date format (%1)\n\t\t\t"
-                            "must be yyyy-MM-ddThh:mm:ss", "mythshutdown")
-                .arg(tmp) + "\n");
+            LOG_STDIO(QObject::tr("Error: --setwakeup invalid date format (%1)\n\t\t\t"
+                                  "must be yyyy-MM-ddThh:mm:ss", "mythshutdown").arg(tmp));
             res = 1;
         }
         else

--- a/mythtv/programs/mythutil/markuputils.cpp
+++ b/mythtv/programs/mythutil/markuputils.cpp
@@ -15,6 +15,14 @@
 // Local includes
 #include "markuputils.h"
 
+inline static void LOG_STDIO(QString message)
+{
+    if (logLevel >= LOG_ERR)
+    {
+        std::cout << message.toStdString() << std::endl;
+    }
+}
+
 static int GetMarkupList(const MythUtilCommandLineParser &cmdline,
                          const QString &type)
 {
@@ -227,7 +235,7 @@ static int GetMarkup(const MythUtilCommandLineParser &cmdline)
     QString filename = cmdline.toString("getmarkup");
     if (filename.isEmpty())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Missing --getmarkup filename\n");
+        LOG_STDIO("Missing --getmarkup filename\n");
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QVector<ProgramInfo::MarkupEntry> mapMark;
@@ -236,8 +244,7 @@ static int GetMarkup(const MythUtilCommandLineParser &cmdline)
     QFile outfile(filename);
     if (!outfile.open(QIODevice::WriteOnly))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Couldn't open output file %1\n").arg(filename));
+        LOG_STDIO(QString("Couldn't open output file %1\n").arg(filename));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QTextStream stream(&outfile);
@@ -285,7 +292,7 @@ static int SetMarkup(const MythUtilCommandLineParser &cmdline)
     QString filename = cmdline.toString("setmarkup");
     if (filename.isEmpty())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Missing --setmarkup filename\n");
+        LOG_STDIO("Missing --setmarkup filename");
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QVector<ProgramInfo::MarkupEntry> mapMark;
@@ -293,39 +300,33 @@ static int SetMarkup(const MythUtilCommandLineParser &cmdline)
     QFile infile(filename);
     if (!infile.open(QIODevice::ReadOnly))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Couldn't open input file %1\n").arg(filename));
+        LOG_STDIO(QString("Couldn't open input file %1").arg(filename));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QDomDocument xml;
     if (!xml.setContent(&infile))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Failed to read valid XML from file %1\n").arg(filename));
+        LOG_STDIO(QString("Failed to read valid XML from file %1").arg(filename));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QDomElement metadata = xml.documentElement();
     if (metadata.tagName() != "metadata")
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Expected top-level 'metadata' element "
-                    "in file %1\n").arg(filename));
+        LOG_STDIO(QString("Expected top-level 'metadata' element in file %1").arg(filename));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QDomNode item = metadata.firstChild();
     if (!item.isElement() || item.toElement().tagName() != "item")
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Expected 'item' element within 'metadata' element "
-                    "in file %1\n").arg(filename));
+        LOG_STDIO(QString("Expected 'item' element within 'metadata' element in file %1")
+            .arg(filename));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QDomNode markup = item.firstChild();
     if (!markup.isElement() || markup.toElement().tagName() != "markup")
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Expected 'markup' element within 'item' element "
-                    "in file %1\n").arg(filename));
+        LOG_STDIO(QString("Expected 'markup' element within 'item' element in file %1")
+            .arg(filename));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     for (QDomNode n = markup.firstChild(); !n.isNull(); n = n.nextSibling())
@@ -345,9 +346,7 @@ static int SetMarkup(const MythUtilCommandLineParser &cmdline)
             }
             else
             {
-                LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                    QString("Weird tag '%1', expected 'mark' or 'seek'\n")
-                    .arg(tagName));
+                LOG_STDIO(QString("Weird tag '%1', expected 'mark' or 'seek'").arg(tagName));
                 continue;
             }
             int type = e.attribute("type").toInt();

--- a/mythtv/programs/mythutil/mpegutils.cpp
+++ b/mythtv/programs/mythutil/mpegutils.cpp
@@ -19,6 +19,7 @@
  *   along with this program; if not, write to the Free Software
  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
+#include <iostream>
 
 // MythTV headers
 #include "libmythbase/exitcodes.h"
@@ -152,12 +153,12 @@ static int pid_counter(const MythUtilCommandLineParser &cmdline)
         {
             offset = 0;
         }
-        LOG(VB_STDIO|VB_FLUSH, logLevel,
+        std::cout <<
             QString("\r                                            \r"
                     "Processed %1 packets")
-            .arg(total_count));
+            .arg(total_count).toStdString() << std::flush;
     }
-    LOG(VB_STDIO|VB_FLUSH, logLevel, "\n");
+    std::cout << std::endl;
 
     delete[] buffer;
     delete srcbuffer;
@@ -268,19 +269,19 @@ static int pid_filter(const MythUtilCommandLineParser &cmdline)
         {
             offset = 0;
         }
-        LOG(VB_STDIO|VB_FLUSH, logLevel,
+        std::cout <<
             QString("\r                                            \r"
                     "Processed %1 packets")
-            .arg(total_count));
+            .arg(total_count).toStdString() << std::flush;
     }
-    LOG(VB_STDIO|VB_FLUSH, logLevel, "\n");
+    std::cout << std::endl;
 
     delete[] buffer;
     delete srcbuffer;
     delete destRB;
 
-    LOG(VB_STDIO|VB_FLUSH, logLevel, QString("Wrote %1 of %2 packets\n")
-        .arg(write_count).arg(total_count));
+    std::cout << QString("Wrote %1 of %2 packets")
+        .arg(write_count).arg(total_count).toStdString() << std::endl;
 
     return GENERIC_EXIT_OK;
 }
@@ -416,7 +417,7 @@ class PrintOutput
         }
         else
         {
-            LOG(VB_STDIO|VB_FLUSH, logLevel, msg);
+            std::cout << msg.toStdString() << std::flush;
         }
     }
 
@@ -804,10 +805,10 @@ static int pid_printer(const MythUtilCommandLineParser &cmdline)
         offset = sd->ProcessData((const unsigned char*)buffer, len);
 
         totalBytes += len - offset;
-        LOG(VB_STDIO|VB_FLUSH, logLevel,
+        std::cout <<
             QString("\r                                            \r"
                     "Processed %1 bytes")
-            .arg(totalBytes));
+            .arg(totalBytes).toStdString() << std::flush;
     }
 
     if (use_xml) {
@@ -815,17 +816,18 @@ static int pid_printer(const MythUtilCommandLineParser &cmdline)
         pmsl->Output(QString("</MPEGSections>"));
     }
 
-    LOG(VB_STDIO|VB_FLUSH, logLevel, "\n");
+    std::cout << std::endl;
 
     if (ptsl->GetFirstPTS() >= 0)
     {
         QTime ot = QTime(0,0,0,0).addMSecs(ptsl->GetElapsedPTS()/90);
 
-        LOG(VB_STDIO|VB_FLUSH, logLevel,
-            QString("First PTS %1, Last PTS %2, elapsed %3 %4\n")
+        std::cout <<
+            QString("First PTS %1, Last PTS %2, elapsed %3 %4")
             .arg(ptsl->GetFirstPTS()).arg(ptsl->GetLastPTS())
             .arg(ptsl->GetElapsedPTS())
-            .arg(ot.toString("hh:mm:ss.zzz")));
+            .arg(ot.toString("hh:mm:ss.zzz"))
+            .toStdString() << std::endl;
     }
 
     delete sd;

--- a/mythtv/programs/mythutil/mpegutils.cpp
+++ b/mythtv/programs/mythutil/mpegutils.cpp
@@ -37,13 +37,21 @@
 // Application local headers
 #include "mpegutils.h"
 
+inline static void LOG_STDIO(QString message, LogLevel_t level = LOG_ERR)
+{
+    if (logLevel >= level)
+    {
+        std::cout << message.toStdString() << std::endl;
+    }
+}
+
 static QHash<uint,bool> extract_pids(const QString &pidsStr, bool required)
 {
     QHash<uint,bool> use_pid;
     if (pidsStr.isEmpty())
     {
         if (required)
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Missing --pids option\n");
+            LOG_STDIO("Missing --pids option");
     }
     else
     {
@@ -57,8 +65,7 @@ static QHash<uint,bool> extract_pids(const QString &pidsStr, bool required)
         }
         if (required && use_pid.empty())
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-                "At least one pid must be specified\n");
+            LOG_STDIO("At least one pid must be specified");
         }
     }
     return use_pid;
@@ -88,7 +95,7 @@ static int pid_counter(const MythUtilCommandLineParser &cmdline)
 {
     if (cmdline.toString("infile").isEmpty())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Missing --infile option\n");
+        LOG_STDIO("Missing --infile option");
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QString src = cmdline.toString("infile");
@@ -96,7 +103,7 @@ static int pid_counter(const MythUtilCommandLineParser &cmdline)
     MythMediaBuffer *srcbuffer = MythMediaBuffer::Create(src, false);
     if (!srcbuffer)
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Couldn't open input URL\n");
+        LOG_STDIO("Couldn't open input URL");
         return GENERIC_EXIT_NOT_OK;
     }
 
@@ -109,8 +116,7 @@ static int pid_counter(const MythUtilCommandLineParser &cmdline)
              packet_size != (188+16) &&
              packet_size != (188+20))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Invalid packet size %1, must be 188, 204, or 208\n")
+        LOG_STDIO(QString("Invalid packet size %1, must be 188, 204, or 208")
             .arg(packet_size));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
@@ -167,10 +173,9 @@ static int pid_counter(const MythUtilCommandLineParser &cmdline)
     {
         if (pid_count[i])
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_CRIT,
-                QString("PID 0x%1 -- %2\n")
+            LOG_STDIO(QString("PID 0x%1 -- %2")
                 .arg(i,4,16,QChar('0'))
-                .arg(pid_count[i],11));
+                .arg(pid_count[i],11), LOG_CRIT);
         }
     }
 
@@ -181,14 +186,14 @@ static int pid_filter(const MythUtilCommandLineParser &cmdline)
 {
     if (cmdline.toString("infile").isEmpty())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Missing --infile option\n");
+        LOG_STDIO("Missing --infile option");
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QString src = cmdline.toString("infile");
 
     if (cmdline.toString("outfile").isEmpty())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Missing --outfile option\n");
+        LOG_STDIO("Missing --outfile option");
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QString dest = cmdline.toString("outfile");
@@ -202,8 +207,7 @@ static int pid_filter(const MythUtilCommandLineParser &cmdline)
              packet_size != (188+16) &&
              packet_size != (188+20))
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR,
-            QString("Invalid packet size %1, must be 188, 204, or 208\n")
+        LOG_STDIO(QString("Invalid packet size %1, must be 188, 204, or 208")
             .arg(packet_size));
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
@@ -215,14 +219,14 @@ static int pid_filter(const MythUtilCommandLineParser &cmdline)
     MythMediaBuffer *srcbuffer = MythMediaBuffer::Create(src, false);
     if (!srcbuffer)
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Couldn't open input URL\n");
+        LOG_STDIO("Couldn't open input URL");
         return GENERIC_EXIT_NOT_OK;
     }
 
     MythMediaBuffer *destRB = MythMediaBuffer::Create(dest, true);
     if (!destRB)
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Couldn't open output URL\n");
+        LOG_STDIO("Couldn't open output URL");
         delete srcbuffer;
         return GENERIC_EXIT_NOT_OK;
     }
@@ -488,8 +492,7 @@ class PrintMPEGStreamListener : public MPEGStreamListener, public PrintOutput
             }
             else
             {
-                LOG(VB_STDIO|VB_FLUSH, LOG_WARNING,
-                    "Couldn't find PTS stream\n");
+                LOG_STDIO("Couldn't find PTS stream", LOG_WARNING);
             }
         }
     }
@@ -714,7 +717,7 @@ static int pid_printer(const MythUtilCommandLineParser &cmdline)
 {
     if (cmdline.toString("infile").isEmpty())
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Missing --infile option\n");
+        LOG_STDIO("Missing --infile option");
         return GENERIC_EXIT_INVALID_CMDLINE;
     }
     QString src = cmdline.toString("infile");
@@ -722,7 +725,7 @@ static int pid_printer(const MythUtilCommandLineParser &cmdline)
     MythMediaBuffer *srcRB = MythMediaBuffer::Create(src, false);
     if (!srcRB)
     {
-        LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Couldn't open input URL\n");
+        LOG_STDIO("Couldn't open input URL");
         return GENERIC_EXIT_NOT_OK;
     }
 
@@ -740,7 +743,7 @@ static int pid_printer(const MythUtilCommandLineParser &cmdline)
         out = MythMediaBuffer::Create(dest, true);
         if (!out)
         {
-            LOG(VB_STDIO|VB_FLUSH, LOG_ERR, "Couldn't open output URL\n");
+            LOG_STDIO("Couldn't open output URL");
             delete srcRB;
             return GENERIC_EXIT_NOT_OK;
         }


### PR DESCRIPTION
This removes VB_STDIO and VB_FLUSH so all of the remaining verbose masks are simply masks, whereas VB_STDIO was used to treat the message differently for output to `std::cout` and VB_FLUSH flushed the log queue in addition to printing a message.

By bypassing LOG() for the VB_STDIO cases most of the uses of VB_FLUSH were also removed.  The remaining uses could be replaced by a call to `logStop()`, which will also flush the log queue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

