### PR TITLE
Close memory leak in CC708Window::GetStrings()

### DIFF
--- a/mythtv/libs/libmythtv/captions/cc708window.cpp
+++ b/mythtv/libs/libmythtv/captions/cc708window.cpp
@@ -380,7 +380,13 @@ std::vector<CC708String*> CC708Window::GetStrings(void) const
         }
     }
     if (!createdNonblankStrings)
+    {
+        for (auto ptr : list)
+        {
+            delete ptr;
+        }
         list.clear();
+    }
     return list;
 }
 


### PR DESCRIPTION
The **GetStrings()** routine has been updated to delete allocated memory pointers in the list before clearing that list. This removes the memory leak.

Resolves #1474

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

