### PR TITLE
Close memory leak in SubtitleFormat::Load()

### DIFF
--- a/mythtv/libs/libmythtv/captions/subtitlescreen.cpp
+++ b/mythtv/libs/libmythtv/captions/subtitlescreen.cpp
@@ -183,6 +183,9 @@ private:
                               MythUIShape *bg2);
 
     QHash<QString, MythFontProperties *> m_fontMap;
+    // Set true if corresponding entry in m_fontMap
+    // is dynamically allocated memory
+    QHash<QString, bool> m_fontMapAllocated;
     QHash<QString, MythUIShape *>       m_shapeMap;
     QHash<QString, QSet<QString> >     m_changeMap;
     // The following m_*Map fields are the original values from the
@@ -375,6 +378,16 @@ SubtitleFormat::~SubtitleFormat(void)
         m_cleanup[i]->deleteLater();
         m_cleanup[i] = nullptr; // just to be safe
     }
+    for (auto it = m_fontMap.cbegin(); it != m_fontMap.cend(); ++it)
+    {
+        if (m_fontMapAllocated[it.key()])
+        {
+            // Release dynamically allocated memory
+            delete m_fontMap[it.key()];
+        }
+    }
+    m_fontMap.clear();
+    m_fontMapAllocated.clear();
 }
 
 QString SubtitleFormat::MakePrefix(const QString &family,
@@ -481,6 +494,8 @@ void SubtitleFormat::Complement(MythFontProperties *font, MythUIShape *bg)
 void SubtitleFormat::Load(const QString &family,
                           const CC708CharacterAttribute &attr)
 {
+    bool resultFontAllocated {false};
+
     // Widgets for the actual values
     auto *baseParent = new MythUIType(nullptr, "base");
     m_cleanup += baseParent;
@@ -507,8 +522,19 @@ void SubtitleFormat::Load(const QString &family,
             QString("Couldn't load theme file %1").arg(kSubFileName));
     QString prefix = MakePrefix(family, attr);
     MythFontProperties *resultFont = baseParent->GetFont(prefix);
+    LOG(VB_VBI, LOG_DEBUG,
+        QString("providerBaseFont = %1").arg(fontToString(providerBaseFont)));
     if (!resultFont)
+    {
         resultFont = providerBaseFont;
+        // Remember resultFont points to dynamically allocated memory
+        resultFontAllocated = true;
+    }
+    else
+    {
+        // Release dynamically allocated memory
+        delete providerBaseFont;
+    }
     auto *resultBG = dynamic_cast<MythUIShape *>(baseParent->GetChild(prefix));
 
     // The providerBaseShape object is not leaked here.  It is added
@@ -525,10 +551,14 @@ void SubtitleFormat::Load(const QString &family,
     if (family == kSubFamily708 &&
         (attr.m_fontTag & 0x7) == k708AttrFontSmallCaps)
         resultFont->GetFace()->setCapitalization(QFont::SmallCaps);
+    if (m_fontMap[prefix] && m_fontMapAllocated[prefix])
+    {
+        // Release dynamically allocated memory
+        delete m_fontMap[prefix];
+    }
     m_fontMap[prefix] = resultFont;
+    m_fontMapAllocated[prefix] = resultFontAllocated;
     m_shapeMap[prefix] = resultBG;
-    LOG(VB_VBI, LOG_DEBUG,
-        QString("providerBaseFont = %1").arg(fontToString(providerBaseFont)));
     LOG(VB_VBI, LOG_DEBUG,
         QString("negFont = %1").arg(fontToString(negFont)));
     LOG(VB_VBI, LOG_DEBUG,


### PR DESCRIPTION
The first call to **CreateProviderDefault()** causes dynamic memory allocation into _providerBaseFont_. This was never getting deleted. Fixing this was tricky because only sometimes it gets stored into _resultFont_ which gets written into the _QHash m_fontMap_ member of the **SubtitleFormat** class.

Since _m_fontMap_ doesn't always hold allocated memory, a new QHash called _m_fontMapAllocated_ has been added. It holds a boolean which will be set true if the corresponding entry in _m_fontMap_ is allocated memory. When the class is destructed, or when an entry in _m_fontMap_ is replaced, the value in _m_fontMapAllocated_ is used to determine if the memory should be deleted.

These changes eliminate the memory leak.

Resolves #1481

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

