### PR TITLE
Fix mythpreviewgen memory alloc/dealloc mismatch

### DIFF
--- a/mythtv/libs/libmythtv/previewgenerator.cpp
+++ b/mythtv/libs/libmythtv/previewgenerator.cpp
@@ -714,7 +714,7 @@ bool PreviewGenerator::LocalPreviewRun(void)
         utime(outname.toLocal8Bit().constData(), &times);
     }
 
-    delete[] data;
+    free(data);
 
     m_programInfo.MarkAsInUse(false, kPreviewGeneratorInUseID);
 


### PR DESCRIPTION
The doubly improper 'delete' and 'array' delete **delete[]** has been replaced with **free()**. This makes the memory allocation and deallocation methods consistent.

Resolves: #1485

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] contribution does not duplicate one of our [existing pull requests](https://github.com/MythTV/mythtv/pulls)
- [x] contribution is in a branch rebased against [master](https://github.com/MythTV/mythtv)
- [x] code compiles successfully without errors
- [x] code follows the [MythTV Coding Standards](https://www.mythtv.org/wiki/Coding_Standards)
- [x] documentation added/updated/removed where necessary
- [x] commits are logically organised and have [good commit messages](https://chris.beams.io/posts/git-commit)

